### PR TITLE
refactor: split client context into base + secure shape

### DIFF
--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -13,7 +13,11 @@ class SyncClientContext:
     environment: Environment
     gamma: SyncTransport
     data: SyncTransport
-    signer: LocalAccount | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SyncSecureClientContext(SyncClientContext):
+    signer: LocalAccount
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,7 +25,16 @@ class AsyncClientContext:
     environment: Environment
     gamma: AsyncTransport
     data: AsyncTransport
-    signer: LocalAccount | None = None
 
 
-__all__ = ["AsyncClientContext", "SyncClientContext"]
+@dataclass(frozen=True, slots=True)
+class AsyncSecureClientContext(AsyncClientContext):
+    signer: LocalAccount
+
+
+__all__ = [
+    "AsyncClientContext",
+    "AsyncSecureClientContext",
+    "SyncClientContext",
+    "SyncSecureClientContext",
+]

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -26,7 +26,7 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
-from polymarket._internal.context import AsyncClientContext
+from polymarket._internal.context import AsyncSecureClientContext
 from polymarket._internal.dispatch import (
     async_dispatch,
     async_paginate_keyset,
@@ -93,13 +93,12 @@ class AsyncSecureClient:
         except (ValueError, TypeError) as error:
             raise UserInputError(f"Invalid private_key: {error}") from error
 
-        self._ctx = AsyncClientContext(
+        self._ctx = AsyncSecureClientContext(
             environment=environment,
             gamma=AsyncTransport(base_url=environment.gamma_url, logger=logger),
             data=AsyncTransport(base_url=environment.data_url, logger=logger),
             signer=signer,
         )
-        self._signer = signer
 
     @classmethod
     async def create(
@@ -130,7 +129,7 @@ class AsyncSecureClient:
 
     @property
     def wallet(self) -> str:
-        return self._signer.address
+        return self._ctx.signer.address
 
     async def __aenter__(self) -> Self:
         return self
@@ -150,7 +149,7 @@ class AsyncSecureClient:
             await self._ctx.data.close()
 
     def _user_or_signer(self, user: str | None) -> str:
-        return self._signer.address if user is None else user
+        return self._ctx.signer.address if user is None else user
 
     async def get_market(
         self,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -26,7 +26,7 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
-from polymarket._internal.context import SyncClientContext
+from polymarket._internal.context import SyncSecureClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
     sync_paginate_keyset,
@@ -93,13 +93,12 @@ class SecureClient:
         except (ValueError, TypeError) as error:
             raise UserInputError(f"Invalid private_key: {error}") from error
 
-        self._ctx = SyncClientContext(
+        self._ctx = SyncSecureClientContext(
             environment=environment,
             gamma=SyncTransport(base_url=environment.gamma_url, logger=logger),
             data=SyncTransport(base_url=environment.data_url, logger=logger),
             signer=signer,
         )
-        self._signer = signer
 
     @classmethod
     def create(
@@ -130,7 +129,7 @@ class SecureClient:
 
     @property
     def wallet(self) -> str:
-        return self._signer.address
+        return self._ctx.signer.address
 
     def __enter__(self) -> Self:
         return self
@@ -151,7 +150,7 @@ class SecureClient:
             self._ctx.data.close()
 
     def _user_or_signer(self, user: str | None) -> str:
-        return self._signer.address if user is None else user
+        return self._ctx.signer.address if user is None else user
 
     def get_market(
         self,

--- a/tests/unit/test_client_request_params.py
+++ b/tests/unit/test_client_request_params.py
@@ -1,13 +1,14 @@
 # pyright: reportPrivateUsage=false
 import asyncio
 import dataclasses
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 
 from polymarket import AsyncPublicClient, AsyncSecureClient, PublicClient, SecureClient
+from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -22,22 +23,32 @@ def _capture(captured: list[httpx.Request], payload: Any = ()) -> httpx.MockTran
     return httpx.MockTransport(handler)
 
 
-def _install_sync(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
-    transport = SyncTransport(
+def _sync_data_transport(handler: httpx.MockTransport) -> SyncTransport:
+    return SyncTransport(
         base_url="https://example.test",
         client=httpx.Client(base_url="https://example.test", transport=handler),
     )
-    client._ctx = dataclasses.replace(client._ctx, data=transport)
+
+
+def _async_data_transport(handler: httpx.MockTransport) -> AsyncTransport:
+    return AsyncTransport(
+        base_url="https://example.test",
+        client=httpx.AsyncClient(base_url="https://example.test", transport=handler),
+    )
+
+
+def _install_sync(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
+    transport = _sync_data_transport(handler)
+    # pyright loses narrowing through the union; cast to the secure shape — both
+    # clients accept it via subtype substitution.
+    client._ctx = cast(SyncSecureClientContext, dataclasses.replace(client._ctx, data=transport))
 
 
 def _install_async(
     client: AsyncPublicClient | AsyncSecureClient, handler: httpx.MockTransport
 ) -> None:
-    transport = AsyncTransport(
-        base_url="https://example.test",
-        client=httpx.AsyncClient(base_url="https://example.test", transport=handler),
-    )
-    client._ctx = dataclasses.replace(client._ctx, data=transport)
+    transport = _async_data_transport(handler)
+    client._ctx = cast(AsyncSecureClientContext, dataclasses.replace(client._ctx, data=transport))
 
 
 def _qs(request: httpx.Request) -> dict[str, list[str]]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a type-level refactor that changes how secure clients store/access the signer; low functional risk, but could surface typing/casting issues where tests or internal code replace `_ctx`.
> 
> **Overview**
> **Splits client context into public vs secure shapes.** `SyncClientContext`/`AsyncClientContext` no longer carry an optional `signer`; new `SyncSecureClientContext`/`AsyncSecureClientContext` subclasses require a `signer` and are exported.
> 
> **Updates secure clients to rely on the secure context.** `SecureClient`/`AsyncSecureClient` now instantiate the secure context type and read signer-derived values (e.g., `wallet`, default `user`) via `self._ctx.signer` rather than maintaining a separate `_signer`.
> 
> **Adjusts unit tests that patch transports.** Test helpers now build data transports separately and cast the replaced `_ctx` to the secure context shape to satisfy typing when working with `PublicClient | SecureClient` unions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff79c182990b9fa1dd6643e06737333f6bfc44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->