### PR TITLE
feat: add clob foundation

### DIFF
--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from polymarket._internal.validation import require_nonempty
+from polymarket.models.base import BaseModel
+
+
+class _MidpointResponse(BaseModel):
+    mid: Decimal
+
+
+def build_midpoint_request(*, token_id: str) -> tuple[str, dict[str, str]]:
+    require_nonempty("token_id", token_id)
+    return "/midpoint", {"token_id": token_id}
+
+
+def parse_midpoint(data: object) -> Decimal:
+    return _MidpointResponse.parse_response(data).mid
+
+
+__all__ = ["build_midpoint_request", "parse_midpoint"]

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -13,6 +13,7 @@ class SyncClientContext:
     environment: Environment
     gamma: SyncTransport
     data: SyncTransport
+    clob: SyncTransport
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +26,7 @@ class AsyncClientContext:
     environment: Environment
     gamma: AsyncTransport
     data: AsyncTransport
+    clob: AsyncTransport
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -2,9 +2,11 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
 from polymarket._internal.actions.data import (
@@ -85,6 +87,7 @@ class AsyncPublicClient:
             environment=environment,
             gamma=AsyncTransport(base_url=environment.gamma_url, logger=logger),
             data=AsyncTransport(base_url=environment.data_url, logger=logger),
+            clob=AsyncTransport(base_url=environment.clob_url, logger=logger),
         )
 
     @property
@@ -107,7 +110,10 @@ class AsyncPublicClient:
         try:
             await self._ctx.gamma.close()
         finally:
-            await self._ctx.data.close()
+            try:
+                await self._ctx.data.close()
+            finally:
+                await self._ctx.clob.close()
 
     async def get_market(
         self,
@@ -723,3 +729,7 @@ class AsyncPublicClient:
             sort=sort,
         )
         return async_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    async def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(await self._ctx.clob.get_json(path, params=params))

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -2,12 +2,14 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
 from polymarket._internal.actions.data import (
@@ -97,6 +99,7 @@ class AsyncSecureClient:
             environment=environment,
             gamma=AsyncTransport(base_url=environment.gamma_url, logger=logger),
             data=AsyncTransport(base_url=environment.data_url, logger=logger),
+            clob=AsyncTransport(base_url=environment.clob_url, logger=logger),
             signer=signer,
         )
 
@@ -146,7 +149,10 @@ class AsyncSecureClient:
         try:
             await self._ctx.gamma.close()
         finally:
-            await self._ctx.data.close()
+            try:
+                await self._ctx.data.close()
+            finally:
+                await self._ctx.clob.close()
 
     def _user_or_signer(self, user: str | None) -> str:
         return self._ctx.signer.address if user is None else user
@@ -772,3 +778,7 @@ class AsyncSecureClient:
             sort=sort,
         )
         return async_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    async def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(await self._ctx.clob.get_json(path, params=params))

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -85,6 +85,7 @@ class PublicClient:
             environment=environment,
             gamma=SyncTransport(base_url=environment.gamma_url, logger=logger),
             data=SyncTransport(base_url=environment.data_url, logger=logger),
+            clob=SyncTransport(base_url=environment.clob_url, logger=logger),
         )
 
     @property
@@ -107,7 +108,10 @@ class PublicClient:
         try:
             self._ctx.gamma.close()
         finally:
-            self._ctx.data.close()
+            try:
+                self._ctx.data.close()
+            finally:
+                self._ctx.clob.close()
 
     def get_market(
         self,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -97,6 +97,7 @@ class SecureClient:
             environment=environment,
             gamma=SyncTransport(base_url=environment.gamma_url, logger=logger),
             data=SyncTransport(base_url=environment.data_url, logger=logger),
+            clob=SyncTransport(base_url=environment.clob_url, logger=logger),
             signer=signer,
         )
 
@@ -147,7 +148,10 @@ class SecureClient:
         try:
             self._ctx.gamma.close()
         finally:
-            self._ctx.data.close()
+            try:
+                self._ctx.data.close()
+            finally:
+                self._ctx.clob.close()
 
     def _user_or_signer(self, user: str | None) -> str:
         return self._ctx.signer.address if user is None else user

--- a/tests/integration/test_clob.py
+++ b/tests/integration/test_clob.py
@@ -1,0 +1,60 @@
+import asyncio
+from decimal import Decimal
+
+import pytest
+
+from polymarket import AsyncPublicClient, AsyncSecureClient
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+_PAGES_TO_SCAN = 5
+
+
+async def _find_active_clob_token() -> str:
+    async with AsyncPublicClient() as client:
+        paginator = client.list_markets(closed=False, page_size=20)
+        pages_seen = 0
+        async for page in paginator:
+            pages_seen += 1
+            for market in page.items:
+                if not market.state.enable_order_book:
+                    continue
+                if not market.state.accepting_orders:
+                    continue
+                token_id = market.outcomes.yes.token_id
+                if token_id is None:
+                    continue
+                return token_id
+            if pages_seen >= _PAGES_TO_SCAN:
+                break
+
+    pytest.skip("no CLOB-active market with a Yes-outcome token id found")
+
+
+@pytest.mark.integration
+def test_async_public_get_midpoint_returns_decimal_in_unit_range() -> None:
+    async def run() -> Decimal:
+        token_id = await _find_active_clob_token()
+        async with AsyncPublicClient() as client:
+            return await client.get_midpoint(token_id=token_id)
+
+    midpoint = asyncio.run(run())
+
+    assert isinstance(midpoint, Decimal)
+    assert Decimal("0") <= midpoint <= Decimal("1")
+
+
+@pytest.mark.integration
+def test_async_secure_get_midpoint_returns_decimal_in_unit_range() -> None:
+    async def run() -> Decimal:
+        token_id = await _find_active_clob_token()
+        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        try:
+            return await client.get_midpoint(token_id=token_id)
+        finally:
+            await client.close()
+
+    midpoint = asyncio.run(run())
+
+    assert isinstance(midpoint, Decimal)
+    assert Decimal("0") <= midpoint <= Decimal("1")

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -1,0 +1,42 @@
+from decimal import Decimal
+
+import pytest
+
+from polymarket._internal.actions.clob import build_midpoint_request, parse_midpoint
+from polymarket.errors import UnexpectedResponseError, UserInputError
+
+
+def test_build_midpoint_request_targets_midpoint_path_with_token_id() -> None:
+    path, params = build_midpoint_request(token_id="123")
+
+    assert path == "/midpoint"
+    assert params == {"token_id": "123"}
+
+
+def test_build_midpoint_request_rejects_empty_token_id() -> None:
+    with pytest.raises(UserInputError, match="token_id"):
+        build_midpoint_request(token_id="")
+
+
+def test_parse_midpoint_returns_decimal_for_decimal_string() -> None:
+    assert parse_midpoint({"mid": "0.53"}) == Decimal("0.53")
+
+
+def test_parse_midpoint_handles_integer_decimal_response() -> None:
+    assert parse_midpoint({"mid": "1"}) == Decimal("1")
+    assert parse_midpoint({"mid": "0"}) == Decimal("0")
+
+
+def test_parse_midpoint_rejects_non_dict_response() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_midpoint([])
+
+
+def test_parse_midpoint_rejects_missing_mid_field() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_midpoint({})
+
+
+def test_parse_midpoint_rejects_non_decimal_mid_value() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_midpoint({"mid": "not-a-decimal"})

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -1,0 +1,78 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import dataclasses
+from decimal import Decimal
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from polymarket import AsyncPublicClient, AsyncSecureClient
+from polymarket._internal.context import AsyncSecureClientContext
+from polymarket.clients._transport import AsyncTransport
+from polymarket.errors import UnexpectedResponseError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+def _clob_handler(captured: list[httpx.Request], payload: object) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_async_clob(
+    client: AsyncPublicClient | AsyncSecureClient, handler: httpx.MockTransport
+) -> None:
+    transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = cast(AsyncSecureClientContext, dataclasses.replace(client._ctx, clob=transport))
+
+
+def test_async_public_get_midpoint_hits_clob_midpoint_with_token_id() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> Decimal:
+        async with AsyncPublicClient() as client:
+            _install_async_clob(client, _clob_handler(captured, {"mid": "0.5125"}))
+            return await client.get_midpoint(token_id="8501497")
+
+    result = asyncio.run(run())
+
+    assert result == Decimal("0.5125")
+    assert len(captured) == 1
+    parsed = urlparse(str(captured[0].url))
+    assert parsed.path == "/midpoint"
+    assert parse_qs(parsed.query) == {"token_id": ["8501497"]}
+
+
+def test_async_secure_get_midpoint_uses_same_clob_endpoint() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> Decimal:
+        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        try:
+            _install_async_clob(client, _clob_handler(captured, {"mid": "0.42"}))
+            return await client.get_midpoint(token_id="99")
+        finally:
+            await client.close()
+
+    assert asyncio.run(run()) == Decimal("0.42")
+    parsed = urlparse(str(captured[0].url))
+    assert parsed.path == "/midpoint"
+    assert parse_qs(parsed.query) == {"token_id": ["99"]}
+
+
+def test_async_get_midpoint_propagates_malformed_response_error() -> None:
+    async def run() -> None:
+        async with AsyncPublicClient() as client:
+            _install_async_clob(client, _clob_handler([], {"unexpected": "shape"}))
+            await client.get_midpoint(token_id="1")
+
+    with pytest.raises(UnexpectedResponseError):
+        asyncio.run(run())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new CLOB HTTP transport into all client contexts and modifies client shutdown behavior, which could affect resource cleanup and network usage across the SDK. The new `/midpoint` call is small but adds a new external dependency path that needs validation against real API responses.
> 
> **Overview**
> Adds a new internal CLOB action module (`_internal/actions/clob.py`) to build and parse the `/midpoint` request/response, returning a `Decimal`.
> 
> Extends all client contexts to include a dedicated `clob` transport, updates all clients to construct and reliably close it, and adds `get_midpoint(token_id)` to both `AsyncPublicClient` and `AsyncSecureClient`.
> 
> Adds unit, transport-mocking, and integration tests covering request formation, response validation/error propagation, and that returned midpoints are `Decimal` values in the `[0,1]` range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ca4a3b2f6b0c95471076f1111f0f8c79c55b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->