### PR TITLE
feat: clob auth and signing foundation

### DIFF
--- a/src/polymarket/__init__.py
+++ b/src/polymarket/__init__.py
@@ -16,6 +16,7 @@ from polymarket.errors import (
 from polymarket.models import (
     Activity,
     ActivityType,
+    ApiKeyCreds,
     BuilderVolumeEntry,
     BuilderVolumeTimePeriod,
     ClosedPosition,
@@ -86,6 +87,7 @@ __all__ = [
     "PRODUCTION",
     "Activity",
     "ActivityType",
+    "ApiKeyCreds",
     "AsyncPaginator",
     "AsyncPublicClient",
     "AsyncSecureClient",

--- a/src/polymarket/_internal/actions/auth.py
+++ b/src/polymarket/_internal/actions/auth.py
@@ -1,0 +1,79 @@
+from typing import cast
+
+from pydantic import TypeAdapter, ValidationError
+
+from polymarket._internal.l1_auth import ApiKeyAuthSignature
+from polymarket.clients._transport import AsyncTransport
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError
+from polymarket.models.clob import ApiKeyCreds
+
+_ApiKeysListAdapter = TypeAdapter(tuple[str, ...])
+
+
+def build_l1_auth_headers(signature: ApiKeyAuthSignature) -> dict[str, str]:
+    return {
+        "POLY_ADDRESS": signature.address,
+        "POLY_NONCE": str(signature.nonce),
+        "POLY_SIGNATURE": signature.signature,
+        "POLY_TIMESTAMP": str(signature.timestamp),
+    }
+
+
+def parse_api_key_creds(data: object) -> ApiKeyCreds:
+    return ApiKeyCreds.parse_response(data)
+
+
+def parse_api_keys_response(data: object) -> tuple[str, ...]:
+    if not isinstance(data, dict):
+        raise UnexpectedResponseError("api keys response did not match expected shape")
+    api_keys = cast(dict[str, object], data).get("apiKeys")
+    try:
+        return _ApiKeysListAdapter.validate_python(api_keys)
+    except ValidationError as error:
+        raise UnexpectedResponseError("api keys response did not match expected shape") from error
+
+
+async def create_api_key(clob: AsyncTransport, signature: ApiKeyAuthSignature) -> ApiKeyCreds:
+    payload = await clob.post_json("/auth/api-key", headers=build_l1_auth_headers(signature))
+    return parse_api_key_creds(payload)
+
+
+async def derive_api_key(clob: AsyncTransport, signature: ApiKeyAuthSignature) -> ApiKeyCreds:
+    payload = await clob.get_json("/auth/derive-api-key", headers=build_l1_auth_headers(signature))
+    return parse_api_key_creds(payload)
+
+
+async def create_or_derive_api_key(
+    clob: AsyncTransport, signature: ApiKeyAuthSignature
+) -> ApiKeyCreds:
+    try:
+        return await create_api_key(clob, signature)
+    except RequestRejectedError as error:
+        if error.status != 400:
+            raise
+    return await derive_api_key(clob, signature)
+
+
+async def fetch_api_keys(secure_clob: AsyncTransport) -> tuple[str, ...]:
+    payload = await secure_clob.get_json("/auth/api-keys")
+    return parse_api_keys_response(payload)
+
+
+async def delete_api_key(secure_clob: AsyncTransport) -> None:
+    payload = await secure_clob.delete_json("/auth/api-key")
+    if payload != "OK":
+        raise UnexpectedResponseError(
+            f"delete api key response did not match expected shape: {payload!r}"
+        )
+
+
+__all__ = [
+    "build_l1_auth_headers",
+    "create_api_key",
+    "create_or_derive_api_key",
+    "delete_api_key",
+    "derive_api_key",
+    "fetch_api_keys",
+    "parse_api_key_creds",
+    "parse_api_keys_response",
+]

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -6,6 +6,7 @@ from eth_account.signers.local import LocalAccount
 
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.environments import Environment
+from polymarket.models.clob import ApiKeyCreds
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,6 +33,8 @@ class AsyncClientContext:
 @dataclass(frozen=True, slots=True)
 class AsyncSecureClientContext(AsyncClientContext):
     signer: LocalAccount
+    credentials: ApiKeyCreds
+    secure_clob: AsyncTransport
 
 
 __all__ = [

--- a/src/polymarket/_internal/hmac.py
+++ b/src/polymarket/_internal/hmac.py
@@ -1,0 +1,34 @@
+import base64
+import binascii
+import hashlib
+import hmac as _hmac
+
+from polymarket.errors import SigningError
+
+
+def build_hmac_signature(
+    *,
+    secret: str,
+    timestamp: int,
+    method: str,
+    path: str,
+    body: str | None = None,
+) -> str:
+    message = f"{timestamp}{method}{path}"
+    if body is not None:
+        message += body
+
+    try:
+        raw_secret = base64.urlsafe_b64decode(_pad_base64(secret))
+        digest = _hmac.new(raw_secret, message.encode("utf-8"), hashlib.sha256).digest()
+    except (binascii.Error, TypeError, ValueError) as error:
+        raise SigningError(f"Failed to compute HMAC signature: {error}") from error
+    return base64.urlsafe_b64encode(digest).decode("ascii")
+
+
+def _pad_base64(value: str) -> str:
+    padding = (-len(value)) % 4
+    return value + ("=" * padding)
+
+
+__all__ = ["build_hmac_signature"]

--- a/src/polymarket/_internal/l1_auth.py
+++ b/src/polymarket/_internal/l1_auth.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass
+from typing import Any
+
+from eth_account.signers.local import LocalAccount
+
+from polymarket.errors import SigningError
+
+_CLOB_AUTH_MESSAGE = "This message attests that I control the given wallet"
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyAuthSignature:
+    address: str
+    nonce: int
+    signature: str
+    timestamp: int
+
+
+def build_api_key_auth_typed_data(
+    *,
+    address: str,
+    chain_id: int,
+    timestamp: int,
+    nonce: int = 0,
+) -> dict[str, Any]:
+    return {
+        "domain": {
+            "name": "ClobAuthDomain",
+            "version": "1",
+            "chainId": chain_id,
+        },
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+            ],
+            "ClobAuth": [
+                {"name": "address", "type": "address"},
+                {"name": "timestamp", "type": "string"},
+                {"name": "nonce", "type": "uint256"},
+                {"name": "message", "type": "string"},
+            ],
+        },
+        "primaryType": "ClobAuth",
+        "message": {
+            "address": address,
+            "timestamp": str(timestamp),
+            "nonce": nonce,
+            "message": _CLOB_AUTH_MESSAGE,
+        },
+    }
+
+
+def sign_api_key_auth(
+    signer: LocalAccount,
+    *,
+    chain_id: int,
+    timestamp: int,
+    nonce: int = 0,
+) -> ApiKeyAuthSignature:
+    typed_data = build_api_key_auth_typed_data(
+        address=signer.address,
+        chain_id=chain_id,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+    try:
+        signed = signer.sign_typed_data(full_message=typed_data)
+    except Exception as error:
+        raise SigningError(f"Failed to sign ClobAuth message: {error}") from error
+    return ApiKeyAuthSignature(
+        address=signer.address,
+        nonce=nonce,
+        signature="0x" + signed.signature.hex(),
+        timestamp=timestamp,
+    )
+
+
+__all__ = [
+    "ApiKeyAuthSignature",
+    "build_api_key_auth_typed_data",
+    "sign_api_key_auth",
+]

--- a/src/polymarket/clients/_transport.py
+++ b/src/polymarket/clients/_transport.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json as _json
 import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -104,6 +105,9 @@ class SyncTransport:
         return response
 
 
+HeaderResolver = Callable[[str, str, str | None], Awaitable[Mapping[str, str]]]
+
+
 class AsyncTransport:
     def __init__(
         self,
@@ -112,6 +116,7 @@ class AsyncTransport:
         options: TransportOptions | None = None,
         logger: logging.Logger | None = None,
         client: httpx.AsyncClient | None = None,
+        header_resolver: HeaderResolver | None = None,
     ) -> None:
         opts = options or TransportOptions()
         self._owns_client = client is None
@@ -123,14 +128,16 @@ class AsyncTransport:
             event_hooks=dict(opts.event_hooks) if opts.event_hooks else None,
         )
         self._logger = logger
+        self._header_resolver = header_resolver
 
     async def get_json(
         self,
         path: str,
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> Any:
-        response = await self._request("GET", path, params=params)
+        response = await self._request("GET", path, params=params, headers=headers)
         return _read_json(response)
 
     async def get_bytes(
@@ -138,18 +145,31 @@ class AsyncTransport:
         path: str,
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> bytes:
-        response = await self._request("GET", path, params=params)
+        response = await self._request("GET", path, params=params, headers=headers)
         return response.content
 
     async def post_json(
         self,
         path: str,
         *,
-        json: object,
+        json: object | None = None,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> Any:
-        response = await self._request("POST", path, params=params, json=json)
+        response = await self._request("POST", path, params=params, json=json, headers=headers)
+        return _read_json(response)
+
+    async def delete_json(
+        self,
+        path: str,
+        *,
+        json: object | None = None,
+        params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        response = await self._request("DELETE", path, params=params, json=json, headers=headers)
         return _read_json(response)
 
     async def close(self) -> None:
@@ -163,11 +183,29 @@ class AsyncTransport:
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
         json: object | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> httpx.Response:
+        body_str: str | None = None
+        content: bytes | None = None
+        merged_headers: dict[str, str] = dict(headers) if headers else {}
+
+        if json is not None:
+            body_str = _json.dumps(json, separators=(",", ":"))
+            content = body_str.encode("utf-8")
+            merged_headers.setdefault("Content-Type", "application/json")
+
+        if self._header_resolver is not None:
+            resolved = await self._header_resolver(method, path, body_str)
+            merged_headers.update(resolved)
+
         started = time.perf_counter()
         try:
             response = await self._client.request(
-                method, path, params=_clean_params(params), json=json
+                method,
+                path,
+                params=_clean_params(params),
+                content=content,
+                headers=merged_headers or None,
             )
         except httpx.HTTPError as error:
             _log_failure(self._logger, method, path, error, started)

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1,14 +1,16 @@
 """Asynchronous secure Polymarket client."""
 
 import logging
-from collections.abc import Sequence
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import Self, cast
+from typing import Self, TypeAlias, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
+from polymarket._internal.actions import auth as _auth_actions
 from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
@@ -35,10 +37,13 @@ from polymarket._internal.dispatch import (
     async_paginate_offset,
     async_paginate_page_based,
 )
+from polymarket._internal.hmac import build_hmac_signature
+from polymarket._internal.l1_auth import sign_api_key_auth
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION, Environment
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models import (
+    ApiKeyCreds,
     Comment,
     Event,
     LastTradePrice,
@@ -82,33 +87,19 @@ from polymarket.pagination import AsyncPaginator
 
 _CREATE_TOKEN = object()
 
+_L2HeaderResolver: TypeAlias = Callable[[str, str, str | None], Awaitable[Mapping[str, str]]]
+
 
 class AsyncSecureClient:
     def __init__(
         self,
         *,
-        private_key: str,
-        environment: Environment = PRODUCTION,
-        logger: logging.Logger | None = None,
+        ctx: AsyncSecureClientContext,
         _create_token: object | None = None,
     ) -> None:
         if _create_token is not _CREATE_TOKEN:
             raise RuntimeError("Use AsyncSecureClient.create(...) to create a secure client")
-        if not private_key:
-            raise UserInputError("private_key is required")
-
-        try:
-            signer = cast(LocalAccount, Account.from_key(private_key))
-        except (ValueError, TypeError) as error:
-            raise UserInputError(f"Invalid private_key: {error}") from error
-
-        self._ctx = AsyncSecureClientContext(
-            environment=environment,
-            gamma=AsyncTransport(base_url=environment.gamma_url, logger=logger),
-            data=AsyncTransport(base_url=environment.data_url, logger=logger),
-            clob=AsyncTransport(base_url=environment.clob_url, logger=logger),
-            signer=signer,
-        )
+        self._ctx = ctx
 
     @classmethod
     async def create(
@@ -116,22 +107,56 @@ class AsyncSecureClient:
         *,
         private_key: str,
         environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        nonce: int = 0,
+        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
-        client = cls(
-            private_key=private_key,
-            environment=environment,
-            logger=logger,
-            _create_token=_CREATE_TOKEN,
-        )
+        if not private_key:
+            raise UserInputError("private_key is required")
+        _validate_nonce(nonce)
+        if credentials is not None and nonce != 0:
+            raise UserInputError("nonce cannot be combined with credentials.")
         try:
-            return await client._login()
+            signer = cast(LocalAccount, Account.from_key(private_key))
+        except (ValueError, TypeError) as error:
+            raise UserInputError(f"Invalid private_key: {error}") from error
+
+        gamma = AsyncTransport(base_url=environment.gamma_url, logger=logger)
+        data = AsyncTransport(base_url=environment.data_url, logger=logger)
+        clob = AsyncTransport(base_url=environment.clob_url, logger=logger)
+
+        try:
+            resolved_credentials = await _bootstrap_credentials(
+                environment=environment,
+                signer=signer,
+                clob=clob,
+                provided=credentials,
+                nonce=nonce,
+                validate=validate_credentials,
+                logger=logger,
+            )
+            secure_clob = AsyncTransport(
+                base_url=environment.clob_url,
+                logger=logger,
+                header_resolver=_make_l2_header_resolver(signer, resolved_credentials),
+            )
         except BaseException:
-            await client.close()
+            await gamma.close()
+            await data.close()
+            await clob.close()
             raise
 
-    async def _login(self) -> Self:
-        return self
+        ctx = AsyncSecureClientContext(
+            environment=environment,
+            gamma=gamma,
+            data=data,
+            clob=clob,
+            signer=signer,
+            credentials=resolved_credentials,
+            secure_clob=secure_clob,
+        )
+        return cls(ctx=ctx, _create_token=_CREATE_TOKEN)
 
     @property
     def environment(self) -> Environment:
@@ -140,6 +165,10 @@ class AsyncSecureClient:
     @property
     def wallet(self) -> str:
         return self._ctx.signer.address
+
+    @property
+    def credentials(self) -> ApiKeyCreds:
+        return self._ctx.credentials
 
     async def __aenter__(self) -> Self:
         return self
@@ -159,7 +188,10 @@ class AsyncSecureClient:
             try:
                 await self._ctx.data.close()
             finally:
-                await self._ctx.clob.close()
+                try:
+                    await self._ctx.clob.close()
+                finally:
+                    await self._ctx.secure_clob.close()
 
     def _user_or_signer(self, user: str | None) -> str:
         return self._ctx.signer.address if user is None else user
@@ -851,3 +883,90 @@ class AsyncSecureClient:
             interval=interval,
         )
         return _clob_actions.parse_price_history(await self._ctx.clob.get_json(path, params=params))
+
+    async def fetch_api_keys(self) -> tuple[str, ...]:
+        return await _auth_actions.fetch_api_keys(self._ctx.secure_clob)
+
+    async def delete_api_key(self) -> None:
+        # NOTE: leaves the client alive with revoked credentials; the next
+        # authenticated call will surface a 401. A proper end_authentication()
+        # lifecycle lands in a follow-up PR.
+        await _auth_actions.delete_api_key(self._ctx.secure_clob)
+
+
+def _validate_nonce(nonce: object) -> None:
+    if isinstance(nonce, bool) or not isinstance(nonce, int):
+        raise UserInputError("nonce must be a non-negative integer.")
+    if nonce < 0:
+        raise UserInputError("nonce must be a non-negative integer.")
+
+
+async def _bootstrap_credentials(
+    *,
+    environment: Environment,
+    signer: LocalAccount,
+    clob: AsyncTransport,
+    provided: ApiKeyCreds | None,
+    nonce: int,
+    validate: bool,
+    logger: logging.Logger | None,
+) -> ApiKeyCreds:
+    if provided is not None and (
+        not validate
+        or await _credentials_are_active(
+            environment=environment,
+            signer=signer,
+            credentials=provided,
+            logger=logger,
+        )
+    ):
+        return provided
+
+    signature = sign_api_key_auth(
+        signer, chain_id=environment.chain_id, timestamp=int(time.time()), nonce=nonce
+    )
+    return await _auth_actions.create_or_derive_api_key(clob, signature)
+
+
+async def _credentials_are_active(
+    *,
+    environment: Environment,
+    signer: LocalAccount,
+    credentials: ApiKeyCreds,
+    logger: logging.Logger | None,
+) -> bool:
+    probe = AsyncTransport(
+        base_url=environment.clob_url,
+        logger=logger,
+        header_resolver=_make_l2_header_resolver(signer, credentials),
+    )
+    try:
+        keys = await _auth_actions.fetch_api_keys(probe)
+    except RequestRejectedError as error:
+        if error.status == 401:
+            return False
+        raise
+    finally:
+        await probe.close()
+    return credentials.key in keys
+
+
+def _make_l2_header_resolver(signer: LocalAccount, credentials: ApiKeyCreds) -> _L2HeaderResolver:
+    async def resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
+        timestamp = int(time.time())
+        signature = build_hmac_signature(
+            secret=credentials.secret,
+            timestamp=timestamp,
+            method=method,
+            path=path,
+            body=body,
+        )
+        return {
+            "POLY_ADDRESS": signer.address,
+            "POLY_API_KEY": credentials.key,
+            "POLY_PASSPHRASE": credentials.passphrase,
+            "POLY_SIGNATURE": signature,
+            "POLY_TIMESTAMP": str(timestamp),
+        }
+
+    return resolver

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1,5 +1,3 @@
-"""Asynchronous secure Polymarket client."""
-
 import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -40,6 +38,7 @@ from polymarket._internal.dispatch import (
 from polymarket._internal.hmac import build_hmac_signature
 from polymarket._internal.l1_auth import sign_api_key_auth
 from polymarket.clients._transport import AsyncTransport
+from polymarket.clients.async_public import AsyncPublicClient
 from polymarket.environments import PRODUCTION, Environment
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models import (
@@ -99,7 +98,21 @@ class AsyncSecureClient:
     ) -> None:
         if _create_token is not _CREATE_TOKEN:
             raise RuntimeError("Use AsyncSecureClient.create(...) to create a secure client")
-        self._ctx = ctx
+        self._ended = False
+        self._ctx_inner = ctx
+
+    @property
+    def _ctx(self) -> AsyncSecureClientContext:
+        if self._ended:
+            raise RuntimeError(
+                "AsyncSecureClient has ended authentication; use the returned "
+                "AsyncPublicClient or create a new SecureClient."
+            )
+        return self._ctx_inner
+
+    @_ctx.setter
+    def _ctx(self, value: AsyncSecureClientContext) -> None:
+        self._ctx_inner = value
 
     @classmethod
     async def create(
@@ -182,16 +195,17 @@ class AsyncSecureClient:
         await self.close()
 
     async def close(self) -> None:
+        ctx = self._ctx_inner
         try:
-            await self._ctx.gamma.close()
+            await ctx.gamma.close()
         finally:
             try:
-                await self._ctx.data.close()
+                await ctx.data.close()
             finally:
                 try:
-                    await self._ctx.clob.close()
+                    await ctx.clob.close()
                 finally:
-                    await self._ctx.secure_clob.close()
+                    await ctx.secure_clob.close()
 
     def _user_or_signer(self, user: str | None) -> str:
         return self._ctx.signer.address if user is None else user
@@ -888,10 +902,19 @@ class AsyncSecureClient:
         return await _auth_actions.fetch_api_keys(self._ctx.secure_clob)
 
     async def delete_api_key(self) -> None:
-        # NOTE: leaves the client alive with revoked credentials; the next
-        # authenticated call will surface a 401. A proper end_authentication()
-        # lifecycle lands in a follow-up PR.
         await _auth_actions.delete_api_key(self._ctx.secure_clob)
+
+    async def end_authentication(self) -> "AsyncPublicClient":
+        environment = self._ctx.environment
+        try:
+            await self.delete_api_key()
+        except RequestRejectedError as error:
+            if error.status not in (401, 404):
+                raise
+        finally:
+            await self.close()
+            self._ended = True
+        return AsyncPublicClient(environment=environment)
 
 
 def _validate_nonce(nonce: object) -> None:

--- a/src/polymarket/models/__init__.py
+++ b/src/polymarket/models/__init__.py
@@ -1,4 +1,5 @@
 from polymarket.models.clob import (
+    ApiKeyCreds,
     LastTradePrice,
     LastTradePriceForToken,
     OrderBook,
@@ -73,6 +74,7 @@ from polymarket.models.types import (
 __all__ = [
     "Activity",
     "ActivityType",
+    "ApiKeyCreds",
     "LastTradePrice",
     "LastTradePriceForToken",
     "OrderBook",

--- a/src/polymarket/models/clob/__init__.py
+++ b/src/polymarket/models/clob/__init__.py
@@ -1,9 +1,11 @@
+from polymarket.models.clob.api_key import ApiKeyCreds
 from polymarket.models.clob.last_trade import LastTradePrice, LastTradePriceForToken
 from polymarket.models.clob.order_book import OrderBook, OrderBookLevel
 from polymarket.models.clob.price_history import PriceHistoryInterval, PriceHistoryPoint
 from polymarket.models.clob.requests import PriceRequest
 
 __all__ = [
+    "ApiKeyCreds",
     "LastTradePrice",
     "LastTradePriceForToken",
     "OrderBook",

--- a/src/polymarket/models/clob/api_key.py
+++ b/src/polymarket/models/clob/api_key.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from polymarket.models.base import BaseModel
+
+
+class ApiKeyCreds(BaseModel):
+    key: str = Field(validation_alias="apiKey")
+    passphrase: str = Field(repr=False)
+    secret: str = Field(repr=False)
+
+
+__all__ = ["ApiKeyCreds"]

--- a/tests/integration/test_clob.py
+++ b/tests/integration/test_clob.py
@@ -16,8 +16,6 @@ from polymarket import (
 )
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-# Fake creds — the AsyncSecureClient under test is only used for public CLOB
-# reads (no L2 headers sent), so the credentials never leave the client.
 FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 

--- a/tests/integration/test_clob.py
+++ b/tests/integration/test_clob.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 
 from polymarket import (
+    ApiKeyCreds,
     AsyncPublicClient,
     AsyncSecureClient,
     LastTradePrice,
@@ -15,6 +16,9 @@ from polymarket import (
 )
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+# Fake creds — the AsyncSecureClient under test is only used for public CLOB
+# reads (no L2 headers sent), so the credentials never leave the client.
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 @pytest.mark.integration
@@ -32,7 +36,9 @@ def test_async_public_get_midpoint_returns_decimal_in_unit_range(active_clob_tok
 @pytest.mark.integration
 def test_async_secure_get_midpoint_returns_decimal_in_unit_range(active_clob_token: str) -> None:
     async def run() -> Decimal:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             return await client.get_midpoint(token_id=active_clob_token)
         finally:

--- a/tests/unit/test_api_key_creds.py
+++ b/tests/unit/test_api_key_creds.py
@@ -1,0 +1,29 @@
+from polymarket import ApiKeyCreds
+
+
+def test_api_key_creds_repr_does_not_leak_secret_or_passphrase() -> None:
+    creds = ApiKeyCreds(key="visible-key", passphrase="sneaky-passphrase", secret="sneaky-secret")
+
+    rendered = repr(creds)
+
+    assert "visible-key" in rendered
+    assert "sneaky-passphrase" not in rendered
+    assert "sneaky-secret" not in rendered
+
+
+def test_api_key_creds_str_does_not_leak_secret_or_passphrase() -> None:
+    creds = ApiKeyCreds(key="visible-key", passphrase="sneaky-passphrase", secret="sneaky-secret")
+
+    rendered = str(creds)
+
+    assert "visible-key" in rendered
+    assert "sneaky-passphrase" not in rendered
+    assert "sneaky-secret" not in rendered
+
+
+def test_api_key_creds_attributes_still_accessible() -> None:
+    creds = ApiKeyCreds(key="k", passphrase="p", secret="s")
+
+    assert creds.key == "k"
+    assert creds.passphrase == "p"
+    assert creds.secret == "s"

--- a/tests/unit/test_auth_actions.py
+++ b/tests/unit/test_auth_actions.py
@@ -1,0 +1,62 @@
+import pytest
+
+from polymarket._internal.actions.auth import (
+    build_l1_auth_headers,
+    parse_api_key_creds,
+    parse_api_keys_response,
+)
+from polymarket._internal.l1_auth import ApiKeyAuthSignature
+from polymarket.errors import UnexpectedResponseError
+
+
+def _sig() -> ApiKeyAuthSignature:
+    return ApiKeyAuthSignature(address="0xabc", nonce=0, signature="0xsig", timestamp=1700000000)
+
+
+def test_build_l1_auth_headers_includes_all_four_fields() -> None:
+    headers = build_l1_auth_headers(_sig())
+
+    assert headers == {
+        "POLY_ADDRESS": "0xabc",
+        "POLY_NONCE": "0",
+        "POLY_SIGNATURE": "0xsig",
+        "POLY_TIMESTAMP": "1700000000",
+    }
+
+
+def test_parse_api_key_creds_renames_wire_apikey_to_key() -> None:
+    creds = parse_api_key_creds({"apiKey": "k", "secret": "s", "passphrase": "p"})
+
+    assert creds.key == "k"
+    assert creds.secret == "s"
+    assert creds.passphrase == "p"
+
+
+def test_parse_api_key_creds_rejects_missing_field() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_api_key_creds({"apiKey": "k", "secret": "s"})
+
+
+def test_parse_api_key_creds_rejects_non_dict() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_api_key_creds([])
+
+
+def test_parse_api_keys_response_returns_tuple_of_strings() -> None:
+    keys = parse_api_keys_response({"apiKeys": ["a", "b"]})
+
+    assert keys == ("a", "b")
+
+
+def test_parse_api_keys_response_accepts_empty_list() -> None:
+    assert parse_api_keys_response({"apiKeys": []}) == ()
+
+
+def test_parse_api_keys_response_rejects_missing_field() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_api_keys_response({})
+
+
+def test_parse_api_keys_response_rejects_non_string_entry() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_api_keys_response({"apiKeys": [1, 2]})

--- a/tests/unit/test_auth_transport.py
+++ b/tests/unit/test_auth_transport.py
@@ -1,0 +1,323 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import json
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, AsyncSecureClient
+from polymarket._internal.context import AsyncSecureClientContext
+from polymarket.clients._transport import AsyncTransport
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_clob(client: AsyncSecureClient, handler: httpx.MockTransport, *, secure: bool) -> None:
+    if secure:
+        transport = AsyncTransport(
+            base_url="https://clob.test",
+            client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+            header_resolver=client._ctx.secure_clob._header_resolver,
+        )
+        client._ctx = AsyncSecureClientContext(
+            environment=client._ctx.environment,
+            gamma=client._ctx.gamma,
+            data=client._ctx.data,
+            clob=client._ctx.clob,
+            signer=client._ctx.signer,
+            credentials=client._ctx.credentials,
+            secure_clob=transport,
+        )
+    else:
+        transport = AsyncTransport(
+            base_url="https://clob.test",
+            client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+        )
+        client._ctx = AsyncSecureClientContext(
+            environment=client._ctx.environment,
+            gamma=client._ctx.gamma,
+            data=client._ctx.data,
+            clob=transport,
+            signer=client._ctx.signer,
+            credentials=client._ctx.credentials,
+            secure_clob=client._ctx.secure_clob,
+        )
+
+
+def test_create_or_derive_api_key_posts_l1_headers_on_first_attempt() -> None:
+    from eth_account import Account
+
+    from polymarket._internal.actions.auth import create_or_derive_api_key
+    from polymarket._internal.l1_auth import sign_api_key_auth
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200, json={"apiKey": "k", "secret": "s", "passphrase": "p"}, request=request
+        )
+
+    transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(
+            base_url="https://clob.test", transport=httpx.MockTransport(handler)
+        ),
+    )
+
+    async def run() -> ApiKeyCreds:
+        signer: Any = Account.from_key(PRIVATE_KEY)
+        signature = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+        creds = await create_or_derive_api_key(transport, signature)
+        await transport.close()
+        return creds
+
+    creds = asyncio.run(run())
+
+    assert creds.key == "k"
+    assert len(captured) == 1
+    assert captured[0].method == "POST"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+    assert captured[0].headers.get("POLY_ADDRESS")
+    assert captured[0].headers.get("POLY_SIGNATURE", "").startswith("0x")
+    assert captured[0].headers.get("POLY_TIMESTAMP") == "1700000000"
+    assert captured[0].headers.get("POLY_NONCE") == "0"
+
+
+def test_async_secure_create_falls_back_to_derive_on_400() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if request.method == "POST" and path == "/auth/api-key":
+            return httpx.Response(400, json={"error": "already exists"}, request=request)
+        if request.method == "GET" and path == "/auth/derive-api-key":
+            return httpx.Response(
+                200,
+                json={"apiKey": "derived", "secret": "s", "passphrase": "p"},
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    intercept = httpx.MockTransport(handler)
+    clob_transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(base_url="https://clob.test", transport=intercept),
+    )
+
+    from eth_account import Account
+
+    from polymarket._internal.actions.auth import create_or_derive_api_key
+    from polymarket._internal.l1_auth import sign_api_key_auth
+
+    async def run() -> ApiKeyCreds:
+        signer: Any = Account.from_key(PRIVATE_KEY)
+        signature = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+        creds = await create_or_derive_api_key(clob_transport, signature)
+        await clob_transport.close()
+        return creds
+
+    creds = asyncio.run(run())
+
+    assert creds.key == "derived"
+    assert len(captured) == 2
+    assert captured[0].method == "POST"
+    assert captured[1].method == "GET"
+    assert urlparse(str(captured[1].url)).path == "/auth/derive-api-key"
+
+
+def test_async_secure_create_with_credentials_skips_auth_flow() -> None:
+    async def run() -> None:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            assert client.credentials is FAKE_CREDS
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+
+def test_fetch_api_keys_sends_l2_headers() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> tuple[str, ...]:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            _install_clob(client, _capture(captured, 200, {"apiKeys": ["k1", "k2"]}), secure=True)
+            return await client.fetch_api_keys()
+        finally:
+            await client.close()
+
+    keys = asyncio.run(run())
+
+    assert keys == ("k1", "k2")
+    assert captured[0].method == "GET"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-keys"
+    headers = captured[0].headers
+    assert headers.get("POLY_ADDRESS")
+    assert headers.get("POLY_API_KEY") == FAKE_CREDS.key
+    assert headers.get("POLY_PASSPHRASE") == FAKE_CREDS.passphrase
+    assert headers.get("POLY_SIGNATURE")
+    assert headers.get("POLY_TIMESTAMP")
+
+
+def test_delete_api_key_succeeds_on_ok_response() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> None:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            _install_clob(client, _capture(captured, 200, "OK"), secure=True)
+            await client.delete_api_key()
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+    assert captured[0].method == "DELETE"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+
+
+def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
+    async def run() -> None:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            _install_clob(client, _capture([], 200, "FAIL"), secure=True)
+            await client.delete_api_key()
+        finally:
+            await client.close()
+
+    with pytest.raises(UnexpectedResponseError):
+        asyncio.run(run())
+
+
+def test_fetch_api_keys_propagates_401_as_request_rejected() -> None:
+    async def run() -> tuple[str, ...]:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            _install_clob(client, _capture([], 401, {"error": "invalid"}), secure=True)
+            return await client.fetch_api_keys()
+        finally:
+            await client.close()
+
+    with pytest.raises(RequestRejectedError) as info:
+        asyncio.run(run())
+    assert info.value.status == 401
+
+
+def test_async_secure_create_rejects_credentials_with_nonzero_nonce() -> None:
+    from polymarket.errors import UserInputError
+
+    async def run() -> None:
+        await AsyncSecureClient.create(private_key=PRIVATE_KEY, credentials=FAKE_CREDS, nonce=1)
+
+    with pytest.raises(UserInputError, match="nonce cannot be combined"):
+        asyncio.run(run())
+
+
+def test_async_secure_create_rejects_negative_nonce() -> None:
+    from polymarket.errors import UserInputError
+
+    async def run() -> None:
+        await AsyncSecureClient.create(private_key=PRIVATE_KEY, nonce=-1)
+
+    with pytest.raises(UserInputError, match="non-negative integer"):
+        asyncio.run(run())
+
+
+def test_async_secure_create_rejects_bool_nonce() -> None:
+    from polymarket.errors import UserInputError
+
+    async def run() -> None:
+        await AsyncSecureClient.create(private_key=PRIVATE_KEY, nonce=True)  # type: ignore[arg-type]
+
+    with pytest.raises(UserInputError, match="non-negative integer"):
+        asyncio.run(run())
+
+
+def test_validated_credentials_pass_through_when_active() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if urlparse(str(request.url)).path == "/auth/api-keys":
+            return httpx.Response(200, json={"apiKeys": [FAKE_CREDS.key]}, request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    intercept = httpx.MockTransport(handler)
+
+    async def run() -> AsyncSecureClient:
+        from eth_account import Account
+
+        from polymarket._internal.actions.auth import fetch_api_keys
+        from polymarket.clients.async_secure import _make_l2_header_resolver
+
+        signer: Any = Account.from_key(PRIVATE_KEY)
+        probe = AsyncTransport(
+            base_url="https://clob.test",
+            client=httpx.AsyncClient(base_url="https://clob.test", transport=intercept),
+            header_resolver=_make_l2_header_resolver(signer, FAKE_CREDS),
+        )
+        keys = await fetch_api_keys(probe)
+        await probe.close()
+        assert FAKE_CREDS.key in keys
+        return cast(Any, None)
+
+    asyncio.run(run())
+
+    assert len(captured) == 1
+    assert urlparse(str(captured[0].url)).path == "/auth/api-keys"
+
+
+def test_l2_signature_includes_canonical_body_for_authenticated_post() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> None:
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
+        try:
+            transport = AsyncTransport(
+                base_url="https://clob.test",
+                client=httpx.AsyncClient(
+                    base_url="https://clob.test",
+                    transport=_capture(captured, 200, "OK"),
+                ),
+                header_resolver=client._ctx.secure_clob._header_resolver,
+            )
+            await transport.post_json("/some-endpoint", json={"a": 1, "b": 2})
+            await transport.close()
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+
+    request = captured[0]
+    assert request.method == "POST"
+    body_str = json.dumps({"a": 1, "b": 2}, separators=(",", ":"))
+    assert request.content == body_str.encode("utf-8")
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.headers["POLY_SIGNATURE"]

--- a/tests/unit/test_bootstrap_credentials.py
+++ b/tests/unit/test_bootstrap_credentials.py
@@ -1,0 +1,185 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+from typing import Any, cast
+
+import pytest
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+
+from polymarket import ApiKeyCreds
+from polymarket._internal.l1_auth import ApiKeyAuthSignature
+from polymarket.clients import async_secure as _module
+from polymarket.clients._transport import AsyncTransport
+from polymarket.environments import PRODUCTION
+from polymarket.errors import RequestRejectedError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+PROVIDED = ApiKeyCreds(key="provided-key", passphrase="p", secret="dGVzdA==")
+FRESH = ApiKeyCreds(key="fresh-key", passphrase="p2", secret="ZnJlc2g=")
+
+
+def _signer() -> LocalAccount:
+    return cast(LocalAccount, Account.from_key(PRIVATE_KEY))
+
+
+def _clob() -> AsyncTransport:
+    return AsyncTransport(base_url="https://clob.test")
+
+
+def test_bootstrap_returns_provided_credentials_when_validation_disabled() -> None:
+    async def run() -> ApiKeyCreds:
+        return await _module._bootstrap_credentials(
+            environment=PRODUCTION,
+            signer=_signer(),
+            clob=_clob(),
+            provided=PROVIDED,
+            nonce=0,
+            validate=False,
+            logger=None,
+        )
+
+    assert asyncio.run(run()) is PROVIDED
+
+
+def test_bootstrap_returns_provided_when_validation_confirms_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def mock_active(**_kwargs: Any) -> bool:
+        return True
+
+    async def explode(*_args: Any, **_kwargs: Any) -> ApiKeyCreds:
+        raise AssertionError("L1 fallback should not run when creds are active")
+
+    monkeypatch.setattr(_module, "_credentials_are_active", mock_active)
+    monkeypatch.setattr(_module._auth_actions, "create_or_derive_api_key", explode)
+
+    async def run() -> ApiKeyCreds:
+        return await _module._bootstrap_credentials(
+            environment=PRODUCTION,
+            signer=_signer(),
+            clob=_clob(),
+            provided=PROVIDED,
+            nonce=0,
+            validate=True,
+            logger=None,
+        )
+
+    assert asyncio.run(run()) is PROVIDED
+
+
+def test_bootstrap_falls_back_to_l1_when_provided_creds_are_inactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def mock_inactive(**_kwargs: Any) -> bool:
+        return False
+
+    async def mock_fresh(_clob: AsyncTransport, _sig: ApiKeyAuthSignature) -> ApiKeyCreds:
+        return FRESH
+
+    monkeypatch.setattr(_module, "_credentials_are_active", mock_inactive)
+    monkeypatch.setattr(_module._auth_actions, "create_or_derive_api_key", mock_fresh)
+
+    async def run() -> ApiKeyCreds:
+        return await _module._bootstrap_credentials(
+            environment=PRODUCTION,
+            signer=_signer(),
+            clob=_clob(),
+            provided=PROVIDED,
+            nonce=0,
+            validate=True,
+            logger=None,
+        )
+
+    assert asyncio.run(run()) is FRESH
+
+
+def test_bootstrap_does_fresh_l1_when_no_credentials_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_signatures: list[ApiKeyAuthSignature] = []
+
+    async def mock_fresh(_clob: AsyncTransport, sig: ApiKeyAuthSignature) -> ApiKeyCreds:
+        seen_signatures.append(sig)
+        return FRESH
+
+    async def never_called(**_kwargs: Any) -> bool:
+        raise AssertionError("validation should not run when no creds provided")
+
+    monkeypatch.setattr(_module._auth_actions, "create_or_derive_api_key", mock_fresh)
+    monkeypatch.setattr(_module, "_credentials_are_active", never_called)
+
+    async def run() -> ApiKeyCreds:
+        return await _module._bootstrap_credentials(
+            environment=PRODUCTION,
+            signer=_signer(),
+            clob=_clob(),
+            provided=None,
+            nonce=7,
+            validate=True,
+            logger=None,
+        )
+
+    result = asyncio.run(run())
+
+    assert result is FRESH
+    assert len(seen_signatures) == 1
+    assert seen_signatures[0].nonce == 7
+
+
+def test_credentials_are_active_returns_false_on_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_401(_transport: AsyncTransport) -> tuple[str, ...]:
+        raise RequestRejectedError("unauthorized", status=401)
+
+    monkeypatch.setattr(_module._auth_actions, "fetch_api_keys", raise_401)
+
+    async def run() -> bool:
+        return await _module._credentials_are_active(
+            environment=PRODUCTION,
+            signer=_signer(),
+            credentials=PROVIDED,
+            logger=None,
+        )
+
+    assert asyncio.run(run()) is False
+
+
+def test_credentials_are_active_returns_false_when_key_not_listed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def returns_other_keys(_transport: AsyncTransport) -> tuple[str, ...]:
+        return ("some-other-key",)
+
+    monkeypatch.setattr(_module._auth_actions, "fetch_api_keys", returns_other_keys)
+
+    async def run() -> bool:
+        return await _module._credentials_are_active(
+            environment=PRODUCTION,
+            signer=_signer(),
+            credentials=PROVIDED,
+            logger=None,
+        )
+
+    assert asyncio.run(run()) is False
+
+
+def test_credentials_are_active_propagates_non_401_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_500(_transport: AsyncTransport) -> tuple[str, ...]:
+        raise RequestRejectedError("server error", status=500)
+
+    monkeypatch.setattr(_module._auth_actions, "fetch_api_keys", raise_500)
+
+    async def run() -> bool:
+        return await _module._credentials_are_active(
+            environment=PRODUCTION,
+            signer=_signer(),
+            credentials=PROVIDED,
+            logger=None,
+        )
+
+    with pytest.raises(RequestRejectedError) as info:
+        asyncio.run(run())
+    assert info.value.status == 500

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,12 +1,21 @@
 import asyncio
+from typing import cast
 
 import pytest
 
-from polymarket import AsyncPublicClient, AsyncSecureClient, PublicClient, SecureClient
+from polymarket import (
+    ApiKeyCreds,
+    AsyncPublicClient,
+    AsyncSecureClient,
+    PublicClient,
+    SecureClient,
+)
+from polymarket._internal.context import AsyncSecureClientContext
 from polymarket.errors import UserInputError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 PRIVATE_KEY_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 def test_client_uses_production_by_default() -> None:
@@ -54,7 +63,9 @@ def test_secure_client_supports_context_manager() -> None:
 
 def test_async_secure_client_factory_uses_production_by_default() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             assert client.environment.name == "production"
         finally:
@@ -65,12 +76,14 @@ def test_async_secure_client_factory_uses_production_by_default() -> None:
 
 def test_async_secure_client_requires_factory() -> None:
     with pytest.raises(RuntimeError, match="AsyncSecureClient.create"):
-        AsyncSecureClient(private_key=PRIVATE_KEY)
+        AsyncSecureClient(ctx=cast(AsyncSecureClientContext, object()))
 
 
 def test_async_secure_client_supports_context_manager() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         async with client:
             assert client.environment.name == "production"
 
@@ -84,7 +97,9 @@ def test_secure_client_exposes_signer_wallet() -> None:
 
 def test_async_secure_client_exposes_signer_wallet() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             assert client.wallet == PRIVATE_KEY_ADDRESS
         finally:

--- a/tests/unit/test_client_request_params.py
+++ b/tests/unit/test_client_request_params.py
@@ -7,12 +7,19 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 
-from polymarket import AsyncPublicClient, AsyncSecureClient, PublicClient, SecureClient
+from polymarket import (
+    ApiKeyCreds,
+    AsyncPublicClient,
+    AsyncSecureClient,
+    PublicClient,
+    SecureClient,
+)
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 def _capture(captured: list[httpx.Request], payload: Any = ()) -> httpx.MockTransport:
@@ -122,7 +129,9 @@ def test_async_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async(client, _capture(captured))
             await client.list_trades(event_id=[7]).first_page()
@@ -174,7 +183,9 @@ def test_async_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async(client, _capture(captured))
             await client.list_activity(event_id=[12]).first_page()

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 from polymarket import (
+    ApiKeyCreds,
     AsyncPublicClient,
     AsyncSecureClient,
     LastTradePrice,
@@ -24,6 +25,7 @@ from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import UnexpectedResponseError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 def _clob_handler(captured: list[httpx.Request], payload: object) -> httpx.MockTransport:
@@ -70,7 +72,9 @@ def test_async_secure_get_midpoint_uses_same_clob_endpoint() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> Decimal:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async_clob(client, _clob_handler(captured, {"mid": "0.42"}))
             return await client.get_midpoint(token_id="99")

--- a/tests/unit/test_end_authentication.py
+++ b/tests/unit/test_end_authentication.py
@@ -1,0 +1,152 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import contextlib
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, AsyncPublicClient, AsyncSecureClient
+from polymarket._internal.context import AsyncSecureClientContext
+from polymarket.clients._transport import AsyncTransport
+from polymarket.errors import RequestRejectedError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport) -> None:
+    transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = AsyncSecureClientContext(
+        environment=client._ctx.environment,
+        gamma=client._ctx.gamma,
+        data=client._ctx.data,
+        clob=client._ctx.clob,
+        signer=client._ctx.signer,
+        credentials=client._ctx.credentials,
+        secure_clob=transport,
+    )
+
+
+async def _build_client() -> AsyncSecureClient:
+    return await AsyncSecureClient.create(
+        private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+    )
+
+
+def test_end_authentication_calls_delete_and_returns_async_public_client() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> AsyncPublicClient:
+        client = await _build_client()
+        _install_secure_clob(client, _capture(captured, 200, "OK"))
+        public = await client.end_authentication()
+        return public
+
+    public = asyncio.run(run())
+
+    assert isinstance(public, AsyncPublicClient)
+    assert captured[0].method == "DELETE"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+
+
+def test_end_authentication_returned_public_client_has_same_environment() -> None:
+    async def run() -> AsyncPublicClient:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 200, "OK"))
+        return await client.end_authentication()
+
+    public = asyncio.run(run())
+
+    assert public.environment.name == "production"
+
+
+def test_end_authentication_blocks_subsequent_method_calls() -> None:
+    async def run() -> None:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 200, "OK"))
+        await client.end_authentication()
+        await client.fetch_api_keys()
+
+    with pytest.raises(RuntimeError, match="ended authentication"):
+        asyncio.run(run())
+
+
+def test_end_authentication_blocks_property_access_after_end() -> None:
+    async def run() -> str:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 200, "OK"))
+        await client.end_authentication()
+        return client.wallet
+
+    with pytest.raises(RuntimeError, match="ended authentication"):
+        asyncio.run(run())
+
+
+def test_end_authentication_tolerates_401_on_delete() -> None:
+    async def run() -> AsyncPublicClient:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 401, {"error": "invalid"}))
+        return await client.end_authentication()
+
+    public = asyncio.run(run())
+
+    assert isinstance(public, AsyncPublicClient)
+
+
+def test_end_authentication_tolerates_404_on_delete() -> None:
+    async def run() -> AsyncPublicClient:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 404, {"error": "not found"}))
+        return await client.end_authentication()
+
+    public = asyncio.run(run())
+
+    assert isinstance(public, AsyncPublicClient)
+
+
+def test_end_authentication_propagates_unexpected_errors_from_delete() -> None:
+    async def run() -> None:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 500, {"error": "boom"}))
+        await client.end_authentication()
+
+    with pytest.raises(RequestRejectedError) as info:
+        asyncio.run(run())
+    assert info.value.status == 500
+
+
+def test_end_authentication_marks_client_ended_even_when_delete_fails() -> None:
+    async def run() -> AsyncSecureClient:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 500, {"error": "boom"}))
+        with contextlib.suppress(RequestRejectedError):
+            await client.end_authentication()
+        return client
+
+    client = asyncio.run(run())
+
+    assert client._ended is True
+
+
+def test_close_after_end_authentication_does_not_raise() -> None:
+    async def run() -> None:
+        client = await _build_client()
+        _install_secure_clob(client, _capture([], 200, "OK"))
+        await client.end_authentication()
+        await client.close()
+
+    asyncio.run(run())

--- a/tests/unit/test_hmac.py
+++ b/tests/unit/test_hmac.py
@@ -1,0 +1,82 @@
+import base64
+import hashlib
+import hmac
+
+from polymarket._internal.hmac import build_hmac_signature
+
+_SECRET = "dGVzdC1zZWNyZXQ="
+_RAW_SECRET = base64.urlsafe_b64decode(_SECRET)
+
+
+def test_build_hmac_signature_matches_manual_hmac_for_get_request() -> None:
+    timestamp = 1700000000
+    method = "GET"
+    path = "/auth/api-keys"
+
+    signature = build_hmac_signature(
+        secret=_SECRET,
+        timestamp=timestamp,
+        method=method,
+        path=path,
+    )
+
+    expected_message = f"{timestamp}{method}{path}".encode()
+    expected = base64.urlsafe_b64encode(
+        hmac.new(_RAW_SECRET, expected_message, hashlib.sha256).digest()
+    ).decode("ascii")
+    assert signature == expected
+
+
+def test_build_hmac_signature_includes_body_when_provided() -> None:
+    timestamp = 1700000000
+    method = "POST"
+    path = "/orders"
+    body = '{"a":1}'
+
+    signature = build_hmac_signature(
+        secret=_SECRET,
+        timestamp=timestamp,
+        method=method,
+        path=path,
+        body=body,
+    )
+
+    expected_message = f"{timestamp}{method}{path}{body}".encode()
+    expected = base64.urlsafe_b64encode(
+        hmac.new(_RAW_SECRET, expected_message, hashlib.sha256).digest()
+    ).decode("ascii")
+    assert signature == expected
+
+
+def test_build_hmac_signature_is_deterministic_for_same_inputs() -> None:
+    sig_a = build_hmac_signature(secret=_SECRET, timestamp=1700000000, method="GET", path="/foo")
+    sig_b = build_hmac_signature(secret=_SECRET, timestamp=1700000000, method="GET", path="/foo")
+
+    assert sig_a == sig_b
+
+
+def test_build_hmac_signature_differs_with_body_versus_without() -> None:
+    no_body = build_hmac_signature(secret=_SECRET, timestamp=1700000000, method="POST", path="/x")
+    with_body = build_hmac_signature(
+        secret=_SECRET, timestamp=1700000000, method="POST", path="/x", body="{}"
+    )
+
+    assert no_body != with_body
+
+
+def test_build_hmac_signature_accepts_secret_without_padding() -> None:
+    secret_no_pad = "dGVzdC1zZWNyZXQ"
+
+    sig_padded = build_hmac_signature(secret=_SECRET, timestamp=1, method="GET", path="/x")
+    sig_unpadded = build_hmac_signature(secret=secret_no_pad, timestamp=1, method="GET", path="/x")
+
+    assert sig_padded == sig_unpadded
+
+
+def test_build_hmac_signature_wraps_bad_base64_secret_as_signing_error() -> None:
+    import pytest
+
+    from polymarket.errors import SigningError
+
+    with pytest.raises(SigningError, match="HMAC"):
+        build_hmac_signature(secret="!!!not-base64!!!", timestamp=1, method="GET", path="/x")

--- a/tests/unit/test_l1_auth.py
+++ b/tests/unit/test_l1_auth.py
@@ -1,0 +1,83 @@
+from typing import cast
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+
+from polymarket._internal.l1_auth import (
+    build_api_key_auth_typed_data,
+    sign_api_key_auth,
+)
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+
+def test_build_api_key_auth_typed_data_has_clob_auth_primary_type() -> None:
+    payload = build_api_key_auth_typed_data(
+        address=SIGNER_ADDRESS, chain_id=137, timestamp=1700000000
+    )
+
+    assert payload["primaryType"] == "ClobAuth"
+
+
+def test_build_api_key_auth_typed_data_uses_polygon_chain_in_domain() -> None:
+    payload = build_api_key_auth_typed_data(
+        address=SIGNER_ADDRESS, chain_id=137, timestamp=1700000000
+    )
+
+    assert payload["domain"] == {
+        "name": "ClobAuthDomain",
+        "version": "1",
+        "chainId": 137,
+    }
+
+
+def test_build_api_key_auth_typed_data_renders_canonical_message() -> None:
+    payload = build_api_key_auth_typed_data(
+        address=SIGNER_ADDRESS, chain_id=137, timestamp=1700000000, nonce=3
+    )
+
+    assert payload["message"] == {
+        "address": SIGNER_ADDRESS,
+        "timestamp": "1700000000",
+        "nonce": 3,
+        "message": "This message attests that I control the given wallet",
+    }
+
+
+def test_build_api_key_auth_typed_data_defaults_nonce_to_zero() -> None:
+    payload = build_api_key_auth_typed_data(
+        address=SIGNER_ADDRESS, chain_id=137, timestamp=1700000000
+    )
+
+    assert payload["message"]["nonce"] == 0
+
+
+def test_sign_api_key_auth_returns_evm_signature_components() -> None:
+    signer = cast(LocalAccount, Account.from_key(PRIVATE_KEY))
+
+    result = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000, nonce=0)
+
+    assert result.address == SIGNER_ADDRESS
+    assert result.nonce == 0
+    assert result.timestamp == 1700000000
+    assert result.signature.startswith("0x")
+    assert len(result.signature) == 132  # 0x + 130 hex chars (65 bytes)
+
+
+def test_sign_api_key_auth_is_deterministic_for_same_inputs() -> None:
+    signer = cast(LocalAccount, Account.from_key(PRIVATE_KEY))
+
+    sig_a = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+    sig_b = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+
+    assert sig_a.signature == sig_b.signature
+
+
+def test_sign_api_key_auth_signature_changes_with_nonce() -> None:
+    signer = cast(LocalAccount, Account.from_key(PRIVATE_KEY))
+
+    sig_a = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000, nonce=0)
+    sig_b = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000, nonce=1)
+
+    assert sig_a.signature != sig_b.signature

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -7,12 +7,13 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 
-from polymarket import AsyncSecureClient, SecureClient
+from polymarket import ApiKeyCreds, AsyncSecureClient, SecureClient
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 OTHER_WALLET = "0x000000000000000000000000000000000000dEaD"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 def _capturing_handler(captured: list[httpx.Request], payload: Any) -> httpx.MockTransport:
@@ -186,7 +187,9 @@ def test_async_secure_list_positions_defaults_to_signer() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async_data(client, _capturing_handler(captured, []))
             await client.list_positions().first_page()
@@ -201,7 +204,9 @@ def test_async_secure_list_positions_respects_explicit_user() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async_data(client, _capturing_handler(captured, []))
             await client.list_positions(user=OTHER_WALLET).first_page()
@@ -220,7 +225,9 @@ def test_async_secure_download_accounting_snapshot_defaults_to_signer() -> None:
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(private_key=PRIVATE_KEY)
+        client = await AsyncSecureClient.create(
+            private_key=PRIVATE_KEY, credentials=FAKE_CREDS, validate_credentials=False
+        )
         try:
             _install_async_data(client, httpx.MockTransport(handler))
             await client.download_accounting_snapshot()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces new CLOB authentication/signing flows (EIP-712 L1 wallet auth and L2 HMAC request signing) and wires them into `AsyncSecureClient`, which is security-critical and could break authenticated API calls if headers/body canonicalization are incorrect.
> 
> **Overview**
> Adds a first-class CLOB API key credential model (`ApiKeyCreds`) and new auth actions to create/derive/list/delete API keys via `/auth/*` endpoints.
> 
> `AsyncSecureClient` now bootstraps (or accepts) API key credentials, maintains a dedicated `secure_clob` transport that automatically attaches HMAC-signed L2 headers, and provides `fetch_api_keys`, `delete_api_key`, and `end_authentication()` (revokes key, closes transports, and returns an `AsyncPublicClient`).
> 
> `AsyncTransport` is extended to support per-request headers, `DELETE`, and an async `header_resolver` that can sign requests using a canonical JSON body; new helpers implement EIP-712 L1 signing (`sign_api_key_auth`) and HMAC signature generation (`build_hmac_signature`). Extensive unit/integration tests cover credential redaction, auth parsing, header signing, nonce validation, and end-auth behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254f2cdc834e66136b292823a8ddbbe2357283ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->