### PR TITLE
feat: add websocket foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-websocket = ["websockets>=12,<16"]
+websocket = ["websockets>=13,<16"]
 
 [project.urls]
 Homepage = "https://polymarket.com"
@@ -53,6 +53,7 @@ dev = [
   "pyright>=1.1,<2",
   "pytest-watcher>=0.6.3",
   "python-dotenv>=1.2.2",
+  "websockets>=13,<16",
 ]
 
 [tool.hatch.build]

--- a/src/polymarket/_internal/ws/__init__.py
+++ b/src/polymarket/_internal/ws/__init__.py
@@ -1,0 +1,11 @@
+from polymarket._internal.ws.backoff import jittered_backoff
+from polymarket._internal.ws.connection import AsyncWebSocketConnection, ConnectResult
+from polymarket._internal.ws.heartbeat import Heartbeat, NoopHeartbeat
+
+__all__ = [
+    "AsyncWebSocketConnection",
+    "ConnectResult",
+    "Heartbeat",
+    "NoopHeartbeat",
+    "jittered_backoff",
+]

--- a/src/polymarket/_internal/ws/backoff.py
+++ b/src/polymarket/_internal/ws/backoff.py
@@ -1,0 +1,25 @@
+import random
+
+DEFAULT_BASE_DELAY_S = 0.250
+DEFAULT_MAX_DELAY_S = 30.0
+
+
+def jittered_backoff(
+    attempt: int,
+    *,
+    base_s: float = DEFAULT_BASE_DELAY_S,
+    max_s: float = DEFAULT_MAX_DELAY_S,
+    rng: random.Random | None = None,
+) -> float:
+    if attempt < 0:
+        raise ValueError("attempt must be non-negative")
+    if base_s <= 0:
+        raise ValueError("base_s must be positive")
+    if max_s < base_s:
+        raise ValueError("max_s must be >= base_s")
+    # cap the exponebt so base_s * 2**attempt cannot overflow to inf for
+    # large attempt counts before min(..., max_s) gets a chance to clamp.
+    bounded_attempt = min(attempt, 64)
+    cap = min(base_s * (2**bounded_attempt), max_s)
+    draw = rng.random() if rng is not None else random.random()
+    return draw * cap

--- a/src/polymarket/_internal/ws/connection.py
+++ b/src/polymarket/_internal/ws/connection.py
@@ -1,0 +1,259 @@
+import asyncio
+import contextlib
+import json
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from websockets.asyncio.client import ClientConnection
+from websockets.asyncio.client import connect as ws_connect
+from websockets.exceptions import ConnectionClosed, WebSocketException
+from websockets.protocol import State
+
+from polymarket._internal.ws.heartbeat import Heartbeat, NoopHeartbeat
+from polymarket.errors import TransportError
+
+OnMessage = Callable[[Any], None]
+OnClose = Callable[[], None]
+OnError = Callable[[BaseException], None]
+
+DEFAULT_WATCHDOG_INTERVAL_S = 5.0
+DEFAULT_OPEN_TIMEOUT_S = 10.0
+
+
+@dataclass(frozen=True)
+class ConnectResult:
+    reused: bool
+
+
+def _socket_is_open(socket: ClientConnection | None) -> bool:
+    return socket is not None and socket.state is State.OPEN
+
+
+class AsyncWebSocketConnection:
+    def __init__(
+        self,
+        *,
+        heartbeat: Heartbeat | None = None,
+        logger: logging.Logger | None = None,
+        watchdog_interval_s: float = DEFAULT_WATCHDOG_INTERVAL_S,
+        open_timeout_s: float = DEFAULT_OPEN_TIMEOUT_S,
+    ) -> None:
+        if watchdog_interval_s <= 0:
+            raise ValueError("watchdog_interval_s must be positive")
+        self._heartbeat: Heartbeat = heartbeat or NoopHeartbeat()
+        self._logger = logger or logging.getLogger("polymarket.ws")
+        self._watchdog_interval_s = watchdog_interval_s
+        self._open_timeout_s = open_timeout_s
+        self._socket: ClientConnection | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._watchdog_task: asyncio.Task[None] | None = None
+        self._connecting: asyncio.Task[ConnectResult] | None = None
+        self._closing: asyncio.Task[None] | None = None
+        self._on_close: OnClose | None = None
+        self._on_error: OnError | None = None
+
+    @property
+    def is_open(self) -> bool:
+        return _socket_is_open(self._socket)
+
+    async def connect(
+        self,
+        *,
+        url: str,
+        on_message: OnMessage,
+        on_close: OnClose,
+        on_error: OnError,
+        headers: Mapping[str, str] | None = None,
+    ) -> ConnectResult:
+        existing = self._socket
+        if existing is not None:
+            if _socket_is_open(existing):
+                return ConnectResult(reused=True)
+            # Socket is CLOSING/CLOSED but the read-loop finalizer has not run
+            # yet. Detach so a fresh open can proceed; the in-flight reader
+            # task will see `self._socket is not existing` and skip on_close.
+            self._socket = None
+        if self._connecting is not None:
+            return await self._connecting
+        task = asyncio.create_task(
+            self._open(
+                url=url,
+                on_message=on_message,
+                on_close=on_close,
+                on_error=on_error,
+                headers=headers,
+            )
+        )
+        self._connecting = task
+        try:
+            return await task
+        finally:
+            if self._connecting is task:
+                self._connecting = None
+
+    async def _open(
+        self,
+        *,
+        url: str,
+        on_message: OnMessage,
+        on_close: OnClose,
+        on_error: OnError,
+        headers: Mapping[str, str] | None,
+    ) -> ConnectResult:
+        additional_headers = dict(headers) if headers else None
+        try:
+            socket = await ws_connect(
+                url,
+                additional_headers=additional_headers,
+                open_timeout=self._open_timeout_s,
+            )
+        except (OSError, TimeoutError, WebSocketException) as error:
+            raise TransportError(str(error) or f"WebSocket connection failed: {url}") from error
+        self._socket = socket
+        self._on_close = on_close
+        self._on_error = on_error
+        self._reader_task = asyncio.create_task(self._read_loop(socket, on_message))
+        try:
+            await self._heartbeat.start(self._send_text_if_open)
+        except BaseException:
+            await self._abort_open(socket)
+            raise
+        self._watchdog_task = asyncio.create_task(self._watchdog_loop(socket))
+        return ConnectResult(reused=False)
+
+    async def _abort_open(self, socket: ClientConnection) -> None:
+        self._socket = None
+        self._on_close = None
+        self._on_error = None
+        try:
+            await socket.close()
+        except Exception:
+            self._logger.debug("error closing socket during aborted open", exc_info=True)
+        if self._reader_task is not None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._reader_task
+            self._reader_task = None
+
+    async def _read_loop(self, socket: ClientConnection, on_message: OnMessage) -> None:
+        try:
+            async for raw in socket:
+                if self._socket is not socket:
+                    return
+                if isinstance(raw, bytes):
+                    try:
+                        text = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        continue
+                else:
+                    text = raw
+                if self._heartbeat.handle(text):
+                    continue
+                try:
+                    parsed = json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+                try:
+                    on_message(parsed)
+                except Exception:
+                    self._logger.exception("on_message callback raised")
+        except ConnectionClosed:
+            pass
+        except Exception as exc:
+            if self._socket is socket and self._on_error is not None:
+                try:
+                    self._on_error(exc)
+                except Exception:
+                    self._logger.exception("on_error callback raised")
+        finally:
+            if self._socket is socket:
+                await self._handle_unexpected_close(socket)
+
+    async def _handle_unexpected_close(self, socket: ClientConnection) -> None:
+        self._socket = None
+        on_close = self._on_close
+        self._on_close = None
+        self._on_error = None
+        await self._heartbeat.stop()
+        if self._watchdog_task is not None:
+            self._watchdog_task.cancel()
+            self._watchdog_task = None
+        if on_close is not None:
+            try:
+                on_close()
+            except Exception:
+                self._logger.exception("on_close callback raised")
+
+    async def _watchdog_loop(self, socket: ClientConnection) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._watchdog_interval_s)
+                if self._socket is not socket:
+                    return
+                if self._heartbeat.is_stale(time.monotonic()):
+                    self._logger.warning("WebSocket heartbeat stale; closing")
+                    try:
+                        await socket.close()
+                    except Exception:
+                        self._logger.debug("error closing stale socket", exc_info=True)
+                    return
+        except asyncio.CancelledError:
+            return
+
+    async def send(self, payload: Any) -> None:
+        socket = self._socket
+        if not _socket_is_open(socket):
+            raise RuntimeError("WebSocket is not connected")
+        text = payload if isinstance(payload, str) else json.dumps(payload, separators=(",", ":"))
+        try:
+            assert socket is not None
+            await socket.send(text)
+        except ConnectionClosed as error:
+            raise TransportError("WebSocket is closed") from error
+
+    async def _send_text_if_open(self, text: str) -> None:
+        socket = self._socket
+        if not _socket_is_open(socket):
+            return
+        assert socket is not None
+        with contextlib.suppress(ConnectionClosed):
+            await socket.send(text)
+
+    async def close(self) -> None:
+        if self._closing is None:
+            self._closing = asyncio.create_task(self._shutdown())
+        closing = self._closing
+        try:
+            await closing
+        finally:
+            if self._closing is closing:
+                self._closing = None
+
+    async def _shutdown(self) -> None:
+        if self._connecting is not None:
+            with contextlib.suppress(Exception):
+                await self._connecting
+        socket = self._socket
+        self._socket = None
+        self._on_close = None
+        self._on_error = None
+        await self._heartbeat.stop()
+        watchdog = self._watchdog_task
+        self._watchdog_task = None
+        if watchdog is not None:
+            watchdog.cancel()
+        if socket is not None:
+            try:
+                await socket.close()
+            except Exception:
+                self._logger.debug("error closing socket on shutdown", exc_info=True)
+        reader = self._reader_task
+        self._reader_task = None
+        if reader is not None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await reader
+        if watchdog is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await watchdog

--- a/src/polymarket/_internal/ws/connection.py
+++ b/src/polymarket/_internal/ws/connection.py
@@ -72,10 +72,9 @@ class AsyncWebSocketConnection:
         if existing is not None:
             if _socket_is_open(existing):
                 return ConnectResult(reused=True)
-            # Socket is CLOSING/CLOSED but the read-loop finalizer has not run
-            # yet. Detach so a fresh open can proceed; the in-flight reader
-            # task will see `self._socket is not existing` and skip on_close.
-            self._socket = None
+            # Stale socket: route through close() so the finalizer's
+            # heartbeat.stop() and watchdog cancel run before re-opening.
+            await self.close()
         if self._connecting is not None:
             return await self._connecting
         task = asyncio.create_task(
@@ -117,7 +116,7 @@ class AsyncWebSocketConnection:
         self._on_error = on_error
         self._reader_task = asyncio.create_task(self._read_loop(socket, on_message))
         try:
-            await self._heartbeat.start(self._send_text_if_open)
+            await self._heartbeat.start(self.send)
         except BaseException:
             await self._abort_open(socket)
             raise
@@ -136,6 +135,14 @@ class AsyncWebSocketConnection:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._reader_task
             self._reader_task = None
+
+    def _claim_socket(self, expected: ClientConnection) -> bool:
+        # Atomic check-and-clear: no await between the two lines, so only
+        # one caller can claim cleanup ownership for any given socket.
+        if self._socket is not expected:
+            return False
+        self._socket = None
+        return True
 
     async def _read_loop(self, socket: ClientConnection, on_message: OnMessage) -> None:
         try:
@@ -168,23 +175,20 @@ class AsyncWebSocketConnection:
                 except Exception:
                     self._logger.exception("on_error callback raised")
         finally:
-            if self._socket is socket:
-                await self._handle_unexpected_close(socket)
-
-    async def _handle_unexpected_close(self, socket: ClientConnection) -> None:
-        self._socket = None
-        on_close = self._on_close
-        self._on_close = None
-        self._on_error = None
-        await self._heartbeat.stop()
-        if self._watchdog_task is not None:
-            self._watchdog_task.cancel()
-            self._watchdog_task = None
-        if on_close is not None:
-            try:
-                on_close()
-            except Exception:
-                self._logger.exception("on_close callback raised")
+            if self._claim_socket(socket):
+                on_close = self._on_close
+                self._on_close = None
+                self._on_error = None
+                watchdog = self._watchdog_task
+                self._watchdog_task = None
+                await self._heartbeat.stop()
+                if watchdog is not None:
+                    watchdog.cancel()
+                if on_close is not None:
+                    try:
+                        on_close()
+                    except Exception:
+                        self._logger.exception("on_close callback raised")
 
     async def _watchdog_loop(self, socket: ClientConnection) -> None:
         try:
@@ -202,24 +206,19 @@ class AsyncWebSocketConnection:
         except asyncio.CancelledError:
             return
 
-    async def send(self, payload: Any) -> None:
+    async def send(self, payload: Any) -> bool:
+        # Best-effort: returns False on disconnect rather than raising. The
+        # reconnect path is expected to replay any frames that were missed.
         socket = self._socket
         if not _socket_is_open(socket):
-            raise RuntimeError("WebSocket is not connected")
+            return False
         text = payload if isinstance(payload, str) else json.dumps(payload, separators=(",", ":"))
         try:
             assert socket is not None
             await socket.send(text)
-        except ConnectionClosed as error:
-            raise TransportError("WebSocket is closed") from error
-
-    async def _send_text_if_open(self, text: str) -> None:
-        socket = self._socket
-        if not _socket_is_open(socket):
-            return
-        assert socket is not None
-        with contextlib.suppress(ConnectionClosed):
-            await socket.send(text)
+        except ConnectionClosed:
+            return False
+        return True
 
     async def close(self) -> None:
         if self._closing is None:
@@ -236,21 +235,26 @@ class AsyncWebSocketConnection:
             with contextlib.suppress(Exception):
                 await self._connecting
         socket = self._socket
-        self._socket = None
-        self._on_close = None
-        self._on_error = None
-        await self._heartbeat.stop()
+        # If the reader finalizer claimed first, cleanup is done — just
+        # await the leftover tasks below.
+        claimed = socket is not None and self._claim_socket(socket)
         watchdog = self._watchdog_task
         self._watchdog_task = None
-        if watchdog is not None:
-            watchdog.cancel()
-        if socket is not None:
-            try:
-                await socket.close()
-            except Exception:
-                self._logger.debug("error closing socket on shutdown", exc_info=True)
         reader = self._reader_task
         self._reader_task = None
+        if claimed:
+            # User-initiated close: suppress on_close to distinguish from
+            # an unexpected disconnect.
+            self._on_close = None
+            self._on_error = None
+            await self._heartbeat.stop()
+            if watchdog is not None:
+                watchdog.cancel()
+            if socket is not None:
+                try:
+                    await socket.close()
+                except Exception:
+                    self._logger.debug("error closing socket on shutdown", exc_info=True)
         if reader is not None:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await reader

--- a/src/polymarket/_internal/ws/heartbeat.py
+++ b/src/polymarket/_internal/ws/heartbeat.py
@@ -1,7 +1,7 @@
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
 
-SendText = Callable[[str], Awaitable[None]]
+SendText = Callable[[str], Awaitable[bool]]
 
 
 @runtime_checkable
@@ -13,7 +13,7 @@ class Heartbeat(Protocol):
 
 
 class NoopHeartbeat:
-    async def start(self, send: SendText) -> None:
+    async def start(self, send: SendText) -> None:  # noqa: ARG002
         return None
 
     async def stop(self) -> None:

--- a/src/polymarket/_internal/ws/heartbeat.py
+++ b/src/polymarket/_internal/ws/heartbeat.py
@@ -1,0 +1,26 @@
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+SendText = Callable[[str], Awaitable[None]]
+
+
+@runtime_checkable
+class Heartbeat(Protocol):
+    async def start(self, send: SendText) -> None: ...
+    async def stop(self) -> None: ...
+    def handle(self, message: str) -> bool: ...
+    def is_stale(self, now: float) -> bool: ...
+
+
+class NoopHeartbeat:
+    async def start(self, send: SendText) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    def handle(self, message: str) -> bool:
+        return False
+
+    def is_stale(self, now: float) -> bool:
+        return False

--- a/tests/unit/test_ws_backoff.py
+++ b/tests/unit/test_ws_backoff.py
@@ -1,0 +1,61 @@
+import math
+import random
+
+import pytest
+
+from polymarket._internal.ws.backoff import jittered_backoff
+
+
+def test_returns_zero_when_rng_draws_zero() -> None:
+    class ZeroRng(random.Random):
+        def random(self) -> float:
+            return 0.0
+
+    assert jittered_backoff(0, rng=ZeroRng()) == 0.0
+    assert jittered_backoff(5, rng=ZeroRng()) == 0.0
+
+
+def test_returns_near_cap_when_rng_draws_one() -> None:
+    class OneRng(random.Random):
+        def random(self) -> float:
+            return 1.0 - 1e-12
+
+    base = 0.25
+    max_s = 30.0
+    assert math.isclose(jittered_backoff(0, base_s=base, max_s=max_s, rng=OneRng()), base)
+    assert math.isclose(jittered_backoff(3, base_s=base, max_s=max_s, rng=OneRng()), base * 8)
+    assert math.isclose(jittered_backoff(100, base_s=base, max_s=max_s, rng=OneRng()), max_s)
+
+
+def test_stays_within_bounds_across_many_draws() -> None:
+    rng = random.Random(1234)
+    for attempt in range(0, 12):
+        cap = min(0.25 * (2**attempt), 30.0)
+        for _ in range(50):
+            value = jittered_backoff(attempt, rng=rng)
+            assert 0.0 <= value <= cap
+
+
+def test_rejects_negative_attempt() -> None:
+    with pytest.raises(ValueError, match="attempt"):
+        jittered_backoff(-1)
+
+
+def test_rejects_non_positive_base() -> None:
+    with pytest.raises(ValueError, match="base_s"):
+        jittered_backoff(0, base_s=0)
+
+
+def test_rejects_max_less_than_base() -> None:
+    with pytest.raises(ValueError, match="max_s"):
+        jittered_backoff(0, base_s=1.0, max_s=0.5)
+
+
+def test_huge_attempt_does_not_overflow_and_returns_finite_value() -> None:
+    class OneRng(random.Random):
+        def random(self) -> float:
+            return 1.0 - 1e-12
+
+    value = jittered_backoff(10_000, base_s=0.25, max_s=30.0, rng=OneRng())
+    assert math.isfinite(value)
+    assert math.isclose(value, 30.0)

--- a/tests/unit/test_ws_connection.py
+++ b/tests/unit/test_ws_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -288,13 +289,12 @@ def test_send_str_is_passed_through_verbatim() -> None:
     asyncio.run(run())
 
 
-def test_send_raises_when_not_connected() -> None:
-    async def run() -> None:
+def test_send_returns_false_when_not_connected() -> None:
+    async def run() -> bool:
         conn = AsyncWebSocketConnection()
-        with pytest.raises(RuntimeError, match="not connected"):
-            await conn.send({"x": 1})
+        return await conn.send({"x": 1})
 
-    asyncio.run(run())
+    assert asyncio.run(run()) is False
 
 
 def test_heartbeat_consumes_pong_before_json_parsing() -> None:
@@ -402,11 +402,36 @@ def test_connect_failure_wraps_as_transport_error() -> None:
     asyncio.run(run())
 
 
-def test_send_after_server_close_raises_transport_error() -> None:
+def test_send_returns_true_on_success() -> None:
+    received: list[str] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            assert isinstance(raw, str)
+            received.append(raw)
+
+    async def run() -> bool:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            ok = await conn.send({"hello": "world"})
+            await _wait_until(lambda: received == ['{"hello":"world"}'])
+            await conn.close()
+            return ok
+
+    assert asyncio.run(run()) is True
+
+
+def test_send_returns_false_after_server_close() -> None:
     async def handler(ws: ServerConnection) -> None:
         await ws.close()
 
-    async def run() -> None:
+    async def run() -> bool:
         closed = asyncio.Event()
         async with ws_server(handler) as url:
             conn = AsyncWebSocketConnection()
@@ -417,11 +442,137 @@ def test_send_after_server_close_raises_transport_error() -> None:
                 on_error=lambda _e: None,
             )
             await asyncio.wait_for(closed.wait(), timeout=2.0)
-            with pytest.raises(RuntimeError, match="not connected"):
-                await conn.send({"x": 1})
+            ok = await conn.send({"x": 1})
             await conn.close()
+            return ok
 
-    asyncio.run(run())
+    assert asyncio.run(run()) is False
+
+
+def test_reconnect_over_stale_socket_does_not_leak_heartbeat() -> None:
+    """Connecting again while a prior socket is CLOSING (read-loop finalizer
+    not yet run) must not leak the prior heartbeat's ping task. The fix
+    routes the stale-socket path through close(), which calls heartbeat.stop().
+    """
+
+    class CountingHeartbeat:
+        def __init__(self) -> None:
+            self.starts = 0
+            self.stops = 0
+            self._timer: asyncio.Task[None] | None = None
+
+        async def start(self, send: SendText) -> None:
+            self.starts += 1
+            self._timer = asyncio.create_task(self._tick())
+
+        async def stop(self) -> None:
+            self.stops += 1
+            if self._timer is not None:
+                self._timer.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._timer
+                self._timer = None
+
+        def handle(self, message: str) -> bool:
+            return False
+
+        def is_stale(self, now: float) -> bool:
+            return False
+
+        async def _tick(self) -> None:
+            try:
+                while True:
+                    await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                return
+
+    heartbeat = CountingHeartbeat()
+
+    server_closed_first = asyncio.Event()
+
+    async def handler(ws: ServerConnection) -> None:
+        if not server_closed_first.is_set():
+            server_closed_first.set()
+            await ws.close()
+            return
+        async for _ in ws:
+            pass
+
+    async def run() -> tuple[int, int]:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection(heartbeat=heartbeat)
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await asyncio.wait_for(server_closed_first.wait(), timeout=2.0)
+            # Immediately reconnect while the prior socket may still be
+            # CLOSING and its finalizer not yet run.
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await conn.close()
+            return heartbeat.starts, heartbeat.stops
+
+    starts, stops = asyncio.run(run())
+    assert starts == 2
+    assert stops == 2
+
+
+def test_concurrent_cleanup_paths_run_heartbeat_stop_exactly_once() -> None:
+    """Forces overlap between close()'s shutdown and the reader's finalizer
+    by making heartbeat.stop yield control. Verifies the atomic claim keeps
+    cleanup single-owner: heartbeat.stop is called exactly once per socket.
+    """
+
+    class SlowStopHeartbeat:
+        def __init__(self) -> None:
+            self.starts = 0
+            self.stops = 0
+
+        async def start(self, send: SendText) -> None:  # noqa: ARG002
+            self.starts += 1
+
+        async def stop(self) -> None:
+            self.stops += 1
+            # Yield control so other tasks (reader finalizer) can run.
+            await asyncio.sleep(0.01)
+
+        def handle(self, message: str) -> bool:  # noqa: ARG002
+            return False
+
+        def is_stale(self, now: float) -> bool:  # noqa: ARG002
+            return False
+
+    heartbeat = SlowStopHeartbeat()
+    server_closing = asyncio.Event()
+
+    async def handler(ws: ServerConnection) -> None:
+        server_closing.set()
+        await ws.close()
+
+    async def run() -> tuple[int, int]:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection(heartbeat=heartbeat)
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await asyncio.wait_for(server_closing.wait(), timeout=2.0)
+            # Race close() against the reader's finalizer.
+            await conn.close()
+            return heartbeat.starts, heartbeat.stops
+
+    starts, stops = asyncio.run(run())
+    assert starts == 1
+    assert stops == 1
 
 
 def test_on_message_callback_exception_does_not_break_stream() -> None:

--- a/tests/unit/test_ws_connection.py
+++ b/tests/unit/test_ws_connection.py
@@ -1,0 +1,463 @@
+import asyncio
+import json
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from websockets.asyncio.server import ServerConnection, serve
+
+from polymarket._internal.ws.connection import AsyncWebSocketConnection
+from polymarket._internal.ws.heartbeat import SendText
+from polymarket.errors import TransportError
+
+Handler = Callable[[ServerConnection], Awaitable[None]]
+
+
+@asynccontextmanager
+async def ws_server(handler: Handler) -> AsyncGenerator[str, None]:
+    server = await serve(handler, host="127.0.0.1", port=0)
+    try:
+        sockets = next(iter(server.sockets))
+        port = sockets.getsockname()[1]
+        yield f"ws://127.0.0.1:{port}"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def _wait_until(predicate: Callable[[], bool], *, timeout_s: float = 2.0) -> Awaitable[None]:
+    async def wait() -> None:
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while not predicate():
+            if asyncio.get_event_loop().time() > deadline:
+                raise AssertionError("timeout waiting for predicate")
+            await asyncio.sleep(0.01)
+
+    return wait()
+
+
+def test_open_send_receive_close_roundtrip() -> None:
+    server_received: list[str] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            assert isinstance(raw, str)
+            server_received.append(raw)
+            await ws.send(json.dumps({"echo": json.loads(raw)}))
+
+    async def run() -> list[Any]:
+        seen: list[Any] = []
+        closed = asyncio.Event()
+        errors: list[BaseException] = []
+
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            result = await conn.connect(
+                url=url,
+                on_message=seen.append,
+                on_close=closed.set,
+                on_error=errors.append,
+            )
+            assert result.reused is False
+            assert conn.is_open is True
+
+            await conn.send({"hello": "world"})
+            await _wait_until(lambda: len(seen) == 1)
+            await conn.close()
+            assert conn.is_open is False
+
+        assert errors == []
+        return seen
+
+    seen = asyncio.run(run())
+    assert seen == [{"echo": {"hello": "world"}}]
+    assert server_received == ['{"hello":"world"}']
+
+
+def test_close_is_idempotent() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await asyncio.gather(conn.close(), conn.close(), conn.close())
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_close_before_connect_is_noop() -> None:
+    async def run() -> None:
+        conn = AsyncWebSocketConnection()
+        await conn.close()
+
+    asyncio.run(run())
+
+
+def test_second_connect_reuses_open_socket() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            first = await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            second = await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            assert first.reused is False
+            assert second.reused is True
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_concurrent_connect_coalesces() -> None:
+    accept_count = 0
+
+    async def handler(ws: ServerConnection) -> None:
+        nonlocal accept_count
+        accept_count += 1
+        async for _ in ws:
+            pass
+
+    async def run() -> list[Any]:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            results = await asyncio.gather(
+                conn.connect(
+                    url=url,
+                    on_message=lambda _m: None,
+                    on_close=lambda: None,
+                    on_error=lambda _e: None,
+                ),
+                conn.connect(
+                    url=url,
+                    on_message=lambda _m: None,
+                    on_close=lambda: None,
+                    on_error=lambda _e: None,
+                ),
+                conn.connect(
+                    url=url,
+                    on_message=lambda _m: None,
+                    on_close=lambda: None,
+                    on_error=lambda _e: None,
+                ),
+            )
+            await conn.close()
+            return list(results)
+
+    results = asyncio.run(run())
+    assert len(results) == 3
+    assert accept_count == 1
+
+
+def test_server_close_triggers_on_close() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await ws.close()
+
+    async def run() -> None:
+        closed = asyncio.Event()
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=closed.set,
+                on_error=lambda _e: None,
+            )
+            await asyncio.wait_for(closed.wait(), timeout=2.0)
+            assert conn.is_open is False
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_user_close_does_not_fire_on_close() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        closed = asyncio.Event()
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=closed.set,
+                on_error=lambda _e: None,
+            )
+            await conn.close()
+            await asyncio.sleep(0.05)
+            assert not closed.is_set()
+
+    asyncio.run(run())
+
+
+def test_malformed_json_is_dropped_silently() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send("this-is-not-json")
+        await ws.send(json.dumps({"ok": True}))
+        async for _ in ws:
+            pass
+
+    async def run() -> list[Any]:
+        seen: list[Any] = []
+        errors: list[BaseException] = []
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=seen.append,
+                on_close=lambda: None,
+                on_error=errors.append,
+            )
+            await _wait_until(lambda: len(seen) >= 1)
+            await conn.close()
+        assert errors == []
+        return seen
+
+    seen = asyncio.run(run())
+    assert seen == [{"ok": True}]
+
+
+def test_binary_frame_is_decoded_as_utf8_json() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send(json.dumps({"binary": "frame"}).encode("utf-8"))
+        async for _ in ws:
+            pass
+
+    async def run() -> list[Any]:
+        seen: list[Any] = []
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=seen.append,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await _wait_until(lambda: len(seen) == 1)
+            await conn.close()
+        return seen
+
+    seen = asyncio.run(run())
+    assert seen == [{"binary": "frame"}]
+
+
+def test_send_str_is_passed_through_verbatim() -> None:
+    received: list[str] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            assert isinstance(raw, str)
+            received.append(raw)
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await conn.send("PING")
+            await _wait_until(lambda: received == ["PING"])
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_send_raises_when_not_connected() -> None:
+    async def run() -> None:
+        conn = AsyncWebSocketConnection()
+        with pytest.raises(RuntimeError, match="not connected"):
+            await conn.send({"x": 1})
+
+    asyncio.run(run())
+
+
+def test_heartbeat_consumes_pong_before_json_parsing() -> None:
+    class CountingHeartbeat:
+        def __init__(self) -> None:
+            self.handled: list[str] = []
+            self.started = False
+            self.stopped = False
+
+        async def start(self, send: SendText) -> None:
+            self.started = True
+
+        async def stop(self) -> None:
+            self.stopped = True
+
+        def handle(self, message: str) -> bool:
+            if message == "PONG":
+                self.handled.append(message)
+                return True
+            return False
+
+        def is_stale(self, now: float) -> bool:
+            return False
+
+    heartbeat = CountingHeartbeat()
+
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send("PONG")
+        await ws.send(json.dumps({"x": 1}))
+        async for _ in ws:
+            pass
+
+    async def run() -> list[Any]:
+        seen: list[Any] = []
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection(heartbeat=heartbeat)
+            await conn.connect(
+                url=url,
+                on_message=seen.append,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await _wait_until(lambda: len(seen) == 1)
+            await conn.close()
+        return seen
+
+    seen = asyncio.run(run())
+    assert seen == [{"x": 1}]
+    assert heartbeat.handled == ["PONG"]
+    assert heartbeat.started is True
+    assert heartbeat.stopped is True
+
+
+def test_stale_heartbeat_forces_close_and_fires_on_close() -> None:
+    class AlwaysStaleHeartbeat:
+        async def start(self, send: SendText) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+        def handle(self, message: str) -> bool:
+            return False
+
+        def is_stale(self, now: float) -> bool:
+            return True
+
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        closed = asyncio.Event()
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection(
+                heartbeat=AlwaysStaleHeartbeat(), watchdog_interval_s=0.05
+            )
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=closed.set,
+                on_error=lambda _e: None,
+            )
+            await asyncio.wait_for(closed.wait(), timeout=2.0)
+            assert conn.is_open is False
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_connect_failure_wraps_as_transport_error() -> None:
+    async def run() -> None:
+        conn = AsyncWebSocketConnection(open_timeout_s=0.5)
+        with pytest.raises(TransportError) as excinfo:
+            await conn.connect(
+                url="ws://127.0.0.1:1",
+                on_message=lambda _m: None,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+        assert excinfo.value.__cause__ is not None
+        assert conn.is_open is False
+        await conn.close()
+
+    asyncio.run(run())
+
+
+def test_send_after_server_close_raises_transport_error() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await ws.close()
+
+    async def run() -> None:
+        closed = asyncio.Event()
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=lambda _m: None,
+                on_close=closed.set,
+                on_error=lambda _e: None,
+            )
+            await asyncio.wait_for(closed.wait(), timeout=2.0)
+            with pytest.raises(RuntimeError, match="not connected"):
+                await conn.send({"x": 1})
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_on_message_callback_exception_does_not_break_stream() -> None:
+    raised: list[int] = []
+
+    def on_message(msg: Any) -> None:
+        if msg.get("idx") == 1:
+            raised.append(1)
+            raise RuntimeError("boom")
+
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send(json.dumps({"idx": 1}))
+        await ws.send(json.dumps({"idx": 2}))
+        async for _ in ws:
+            pass
+
+    async def run() -> int:
+        seen: list[Any] = []
+
+        def capture(msg: Any) -> None:
+            on_message(msg)
+            seen.append(msg)
+
+        async with ws_server(handler) as url:
+            conn = AsyncWebSocketConnection()
+            await conn.connect(
+                url=url,
+                on_message=capture,
+                on_close=lambda: None,
+                on_error=lambda _e: None,
+            )
+            await _wait_until(lambda: any(s.get("idx") == 2 for s in seen))
+            await conn.close()
+        return len(seen)
+
+    # idx=1 raises before append; idx=2 succeeds and appends → seen has at least idx=2
+    total_seen = asyncio.run(run())
+    assert raised == [1]
+    assert total_seen >= 1

--- a/tests/unit/test_ws_heartbeat.py
+++ b/tests/unit/test_ws_heartbeat.py
@@ -1,0 +1,35 @@
+import asyncio
+
+from polymarket._internal.ws.heartbeat import Heartbeat, NoopHeartbeat
+
+
+def test_noop_heartbeat_satisfies_protocol() -> None:
+    heartbeat: Heartbeat = NoopHeartbeat()
+    assert isinstance(heartbeat, Heartbeat)
+
+
+def test_noop_heartbeat_never_consumes_messages() -> None:
+    heartbeat = NoopHeartbeat()
+    assert heartbeat.handle("PONG") is False
+    assert heartbeat.handle("anything") is False
+    assert heartbeat.handle("") is False
+
+
+def test_noop_heartbeat_never_reports_stale() -> None:
+    heartbeat = NoopHeartbeat()
+    assert heartbeat.is_stale(0.0) is False
+    assert heartbeat.is_stale(1e18) is False
+
+
+def test_noop_heartbeat_start_and_stop_are_safe() -> None:
+    heartbeat = NoopHeartbeat()
+
+    async def noop_send(_: str) -> None:
+        return None
+
+    async def run() -> None:
+        await heartbeat.start(noop_send)
+        await heartbeat.stop()
+        await heartbeat.stop()
+
+    asyncio.run(run())

--- a/tests/unit/test_ws_heartbeat.py
+++ b/tests/unit/test_ws_heartbeat.py
@@ -24,8 +24,8 @@ def test_noop_heartbeat_never_reports_stale() -> None:
 def test_noop_heartbeat_start_and_stop_are_safe() -> None:
     heartbeat = NoopHeartbeat()
 
-    async def noop_send(_: str) -> None:
-        return None
+    async def noop_send(_: str) -> bool:
+        return True
 
     async def run() -> None:
         await heartbeat.start(noop_send)

--- a/uv.lock
+++ b/uv.lock
@@ -688,6 +688,7 @@ dev = [
     { name = "python-dotenv" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
@@ -697,7 +698,7 @@ requires-dist = [
     { name = "eth-utils", specifier = ">=4,<6" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27,<1" },
     { name = "pydantic", specifier = ">=2,<3" },
-    { name = "websockets", marker = "extra == 'websocket'", specifier = ">=12,<16" },
+    { name = "websockets", marker = "extra == 'websocket'", specifier = ">=13,<16" },
 ]
 provides-extras = ["websocket"]
 
@@ -710,6 +711,7 @@ dev = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "respx", specifier = ">=0.22,<1" },
     { name = "ruff", specifier = ">=0.11,<1" },
+    { name = "websockets", specifier = ">=13,<16" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new async WebSocket connection/heartbeat infrastructure with non-trivial concurrency and lifecycle management; bugs here could cause leaked tasks or missed disconnect handling, but it’s isolated to a new internal module and is well-covered by unit tests.
> 
> **Overview**
> Adds a new internal `polymarket._internal.ws` package providing `AsyncWebSocketConnection` with connection reuse/coalescing, best-effort `send()`, watchdog-driven stale-heartbeat shutdown, and explicit callback hooks for message/close/error handling.
> 
> Introduces a `Heartbeat` protocol (with `NoopHeartbeat`) and a `jittered_backoff()` helper for retry timing, plus comprehensive unit tests around connection lifecycle races and backoff bounds.
> 
> Updates the `websocket` extra to require `websockets>=13,<16` and adds the same constraint to dev dependencies (including `uv.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e5d57eb156845dd342606b62b5d04995e3982a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->