### PR TITLE
feat(streams): sports websocket stream

### DIFF
--- a/src/polymarket/_internal/streams/sports/heartbeat.py
+++ b/src/polymarket/_internal/streams/sports/heartbeat.py
@@ -1,0 +1,69 @@
+import asyncio
+import contextlib
+import time
+from collections.abc import Callable
+
+from polymarket._internal.ws.heartbeat import SendText
+
+SPORTS_HEARTBEAT_STALE_S = 30.0
+_PING = "ping"
+_PONG = "pong"
+
+
+class SportsWebSocketHeartbeat:
+    """Server-initiated heartbeat for the Sports stream.
+
+    The server sends raw text ``"ping"`` (lowercase). The client must reply
+    with raw text ``"pong"`` (lowercase). The connection is considered stale
+    if no ping has been received within ``stale_s`` seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        stale_s: float = SPORTS_HEARTBEAT_STALE_S,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if stale_s <= 0:
+            raise ValueError("stale_s must be positive")
+        self._stale_s = stale_s
+        self._clock = clock
+        self._send: SendText | None = None
+        self._last_ping: float = 0.0
+        self._pending_pongs: set[asyncio.Task[bool]] = set()
+
+    async def start(self, send: SendText) -> None:
+        self._send = send
+        self._last_ping = self._clock()
+
+    async def stop(self) -> None:
+        self._send = None
+        # Cancel before awaiting: a stuck send (e.g. a half-dead socket) must
+        # not block shutdown. With cancellation, gather returns promptly.
+        pending = list(self._pending_pongs)
+        self._pending_pongs.clear()
+        for task in pending:
+            if not task.done():
+                task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def handle(self, message: str) -> bool:
+        if message != _PING:
+            return False
+        self._last_ping = self._clock()
+        send = self._send
+        if send is not None:
+            task = asyncio.create_task(_send_pong(send))
+            self._pending_pongs.add(task)
+            task.add_done_callback(self._pending_pongs.discard)
+        return True
+
+    def is_stale(self, now: float) -> bool:
+        return now - self._last_ping > self._stale_s
+
+
+async def _send_pong(send: SendText) -> bool:
+    with contextlib.suppress(Exception):
+        return await send(_PONG)
+    return False

--- a/src/polymarket/_internal/streams/sports/manager.py
+++ b/src/polymarket/_internal/streams/sports/manager.py
@@ -1,0 +1,173 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import contextlib
+import logging
+from types import TracebackType
+from typing import Self
+
+from pydantic import ValidationError
+
+from polymarket._internal.streams.handle import AsyncSubscriptionHandle
+from polymarket._internal.streams.reconnect import ReconnectScheduler
+from polymarket._internal.streams.registry import SubscriptionRegistry
+from polymarket._internal.streams.sports.heartbeat import SportsWebSocketHeartbeat
+from polymarket._internal.ws.connection import AsyncWebSocketConnection, ConnectResult
+from polymarket._internal.ws.heartbeat import Heartbeat
+from polymarket.errors import TransportError
+from polymarket.models.sports_events import SportsEvent, parse_sports_event
+from polymarket.streams._specs import SportsSpec
+
+DEFAULT_QUEUE_SIZE = 1024
+
+
+def _accept_all(_event: SportsEvent) -> bool:
+    return True
+
+
+def _no_state(_subs: object) -> None:
+    return None
+
+
+class SportsStreamManager:
+    """Sports WebSocket stream.
+
+    The server streams immediately on connection open; the client never
+    sends a subscribe frame. Every subscriber receives every event — there
+    is no per-subscription filtering on the wire. Heartbeat is
+    server-initiated: server pings, client pongs.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        logger: logging.Logger | None = None,
+        heartbeat: Heartbeat | None = None,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+    ) -> None:
+        if queue_size <= 0:
+            raise ValueError("queue_size must be positive")
+        self._url = url
+        self._logger = logger or logging.getLogger("polymarket.streams.sports")
+        self._heartbeat: Heartbeat = heartbeat or SportsWebSocketHeartbeat()
+        self._queue_size = queue_size
+        self._connection = AsyncWebSocketConnection(heartbeat=self._heartbeat, logger=self._logger)
+        self._registry: SubscriptionRegistry[SportsSpec, SportsEvent, None] = SubscriptionRegistry(
+            derive_state=_no_state, logger=self._logger
+        )
+        self._scheduler = ReconnectScheduler(logger=self._logger)
+        self._send_lock = asyncio.Lock()
+        self._closed = False
+        self._dropped_events = 0
+
+    @property
+    def is_open(self) -> bool:
+        return self._connection.is_open
+
+    @property
+    def dropped_events(self) -> int:
+        return self._dropped_events
+
+    async def subscribe(self) -> AsyncSubscriptionHandle[SportsEvent]:
+        if self._closed:
+            raise RuntimeError("SportsStreamManager is closed")
+        handle: AsyncSubscriptionHandle[SportsEvent] = AsyncSubscriptionHandle(
+            queue_size=self._queue_size
+        )
+        handle._bind_close(self._on_handle_close)
+
+        async with self._send_lock:
+            self._registry.add(sub=SportsSpec(), matcher=_accept_all, handle=handle)
+            try:
+                await self._open_connection()
+            except BaseException:
+                self._registry.remove_handle(handle)
+                handle._end()
+                if self._registry.is_empty and self._connection.is_open:
+                    self._scheduler.cancel_pending()
+                    try:
+                        await self._connection.close()
+                    except Exception:
+                        self._logger.exception("error closing socket during subscribe rollback")
+                raise
+        return handle
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._scheduler.aclose()
+        self._registry.end_all()
+        await self._connection.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def _open_connection(self) -> ConnectResult:
+        return await self._connection.connect(
+            url=self._url,
+            on_message=self._on_message,
+            on_close=self._on_socket_close,
+            on_error=self._on_socket_error,
+        )
+
+    async def _on_handle_close(self, handle: AsyncSubscriptionHandle[SportsEvent]) -> None:
+        async with self._send_lock:
+            removed = self._registry.remove_handle(handle)
+            if not removed:
+                return
+            if self._registry.is_empty:
+                self._scheduler.cancel_pending()
+                await self._connection.close()
+
+    def _on_message(self, raw: object) -> None:
+        try:
+            event = parse_sports_event(raw)
+        except ValidationError:
+            self._dropped_events += 1
+            self._logger.debug("dropped malformed sports event")
+            return
+        self._registry.dispatch(event)
+
+    def _on_socket_close(self) -> None:
+        if self._closed:
+            return
+        self._scheduler.schedule(
+            reconnect=self._reconnect,
+            should_reconnect=self._should_reconnect,
+        )
+
+    def _on_socket_error(self, exc: BaseException) -> None:
+        self._logger.warning("sports stream reader error: %r", exc)
+
+    def _should_reconnect(self) -> bool:
+        return not self._closed and not self._registry.is_empty
+
+    async def _reconnect(self) -> None:
+        # Lock serializes against subscribe(); sports has no initial frame
+        # to send so this is mostly defensive.
+        async with self._send_lock:
+            if not self._should_reconnect():
+                return
+            try:
+                await self._open_connection()
+            except TransportError as exc:
+                self._logger.info("sports stream reconnect failed: %r; rescheduling", exc)
+                self._scheduler.schedule(
+                    reconnect=self._reconnect,
+                    should_reconnect=self._should_reconnect,
+                )
+                return
+            if self._closed:
+                with contextlib.suppress(Exception):
+                    await self._connection.close()
+                return
+            self._scheduler.reset()

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self, cast, overload
 
 from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
@@ -84,12 +84,14 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
+from polymarket.models.sports_events import SportsEvent
 from polymarket.models.types import ConditionId
 from polymarket.pagination import AsyncPaginator, Page
-from polymarket.streams._specs import Subscription, _normalize_market_specs
+from polymarket.streams._specs import MarketSpec, SportsSpec, Subscription, _normalize_specs
 
 if TYPE_CHECKING:
     from polymarket._internal.streams.clob.market import ClobMarketStreamManager
+    from polymarket._internal.streams.sports.manager import SportsStreamManager
 
 
 _WEBSOCKET_EXTRA_HINT = (
@@ -117,47 +119,86 @@ class AsyncPublicClient:
             clob=AsyncTransport(base_url=environment.clob_url, logger=logger),
         )
         self._market_manager: ClobMarketStreamManager | None = None
+        self._sports_manager: SportsStreamManager | None = None
         self._streams_logger = logger
 
     @property
     def environment(self) -> Environment:
         return self._ctx.environment
 
+    @overload
+    async def subscribe(self, specs: MarketSpec, /) -> SubscriptionHandle[MarketEvent]: ...
+    @overload
+    async def subscribe(self, specs: SportsSpec, /) -> SubscriptionHandle[SportsEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[MarketSpec], /
+    ) -> SubscriptionHandle[MarketEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[SportsSpec], /
+    ) -> SubscriptionHandle[SportsEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[MarketSpec | SportsSpec], /
+    ) -> SubscriptionHandle[MarketEvent | SportsEvent]: ...
     async def subscribe(
         self,
         specs: Subscription | Sequence[Subscription],
-    ) -> SubscriptionHandle[MarketEvent]:
-        market_specs = _normalize_market_specs(specs)
-        if self._market_manager is None:
-            try:
-                from polymarket._internal.streams.clob.market import (
-                    ClobMarketStreamManager,
-                )
-            except ImportError as exc:
-                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
-            self._market_manager = ClobMarketStreamManager(
-                url=self._ctx.environment.clob_market_ws_url,
-                logger=self._streams_logger,
-            )
-        handles: list[AsyncSubscriptionHandle[MarketEvent]] = []
+    ) -> SubscriptionHandle[MarketEvent | SportsEvent]:
+        items = _normalize_specs(specs)
+        # AsyncSubscriptionHandle is invariant in T, so per-channel handles
+        # can't widen to the union type at the type level. Cast at the
+        # boundary — the underlying queue holds whatever was pushed into it.
+        handles: list[AsyncSubscriptionHandle[Any]] = []
         try:
-            for spec in market_specs:
-                handles.append(
-                    await self._market_manager.subscribe(
-                        token_ids=spec.token_ids,
-                        custom_feature_enabled=spec.custom_feature_enabled,
+            for spec in items:
+                if isinstance(spec, MarketSpec):
+                    handles.append(
+                        await self._get_market_manager().subscribe(
+                            token_ids=spec.token_ids,
+                            custom_feature_enabled=spec.custom_feature_enabled,
+                        )
                     )
-                )
+                else:
+                    handles.append(await self._get_sports_manager().subscribe())
         except BaseException:
             for handle in handles:
                 with contextlib.suppress(Exception):
                     await handle.close()
             raise
         if len(handles) == 1:
-            return handles[0]
+            return cast(SubscriptionHandle[MarketEvent | SportsEvent], handles[0])
         from polymarket._internal.streams.merged_handle import MergedSubscriptionHandle
 
-        return MergedSubscriptionHandle(handles)
+        return cast(
+            SubscriptionHandle[MarketEvent | SportsEvent],
+            MergedSubscriptionHandle(handles),
+        )
+
+    def _get_market_manager(self) -> "ClobMarketStreamManager":
+        if self._market_manager is None:
+            try:
+                from polymarket._internal.streams.clob.market import ClobMarketStreamManager
+            except ImportError as exc:
+                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
+            self._market_manager = ClobMarketStreamManager(
+                url=self._ctx.environment.clob_market_ws_url,
+                logger=self._streams_logger,
+            )
+        return self._market_manager
+
+    def _get_sports_manager(self) -> "SportsStreamManager":
+        if self._sports_manager is None:
+            try:
+                from polymarket._internal.streams.sports.manager import SportsStreamManager
+            except ImportError as exc:
+                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
+            self._sports_manager = SportsStreamManager(
+                url=self._ctx.environment.sports_ws_url,
+                logger=self._streams_logger,
+            )
+        return self._sports_manager
 
     async def __aenter__(self) -> Self:
         return self
@@ -177,12 +218,16 @@ class AsyncPublicClient:
                 await self._market_manager.close()
         finally:
             try:
-                await self._ctx.gamma.close()
+                if self._sports_manager is not None:
+                    await self._sports_manager.close()
             finally:
                 try:
-                    await self._ctx.data.close()
+                    await self._ctx.gamma.close()
                 finally:
-                    await self._ctx.clob.close()
+                    try:
+                        await self._ctx.data.close()
+                    finally:
+                        await self._ctx.clob.close()
 
     async def get_market(
         self,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Self, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Self, TypeAlias, cast, overload
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -128,13 +128,15 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
+from polymarket.models.sports_events import SportsEvent
 from polymarket.models.types import ConditionId
 from polymarket.pagination import AsyncPaginator, Page
-from polymarket.streams._specs import Subscription, _normalize_market_specs
+from polymarket.streams._specs import MarketSpec, SportsSpec, Subscription, _normalize_specs
 from polymarket.types import EvmAddress, HexString
 
 if TYPE_CHECKING:
     from polymarket._internal.streams.clob.market import ClobMarketStreamManager
+    from polymarket._internal.streams.sports.manager import SportsStreamManager
 
 
 _WEBSOCKET_EXTRA_HINT = (
@@ -160,6 +162,7 @@ class AsyncSecureClient:
         self._ended = False
         self._ctx_inner = ctx
         self._market_manager: ClobMarketStreamManager | None = None
+        self._sports_manager: SportsStreamManager | None = None
         self._streams_logger = logger
 
     @property
@@ -270,41 +273,76 @@ class AsyncSecureClient:
     def credentials(self) -> ApiKeyCreds:
         return self._ctx.credentials
 
+    @overload
+    async def subscribe(self, specs: MarketSpec, /) -> SubscriptionHandle[MarketEvent]: ...
+    @overload
+    async def subscribe(self, specs: SportsSpec, /) -> SubscriptionHandle[SportsEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[MarketSpec], /
+    ) -> SubscriptionHandle[MarketEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[SportsSpec], /
+    ) -> SubscriptionHandle[SportsEvent]: ...
+    @overload
+    async def subscribe(
+        self, specs: Sequence[MarketSpec | SportsSpec], /
+    ) -> SubscriptionHandle[MarketEvent | SportsEvent]: ...
     async def subscribe(
         self,
         specs: Subscription | Sequence[Subscription],
-    ) -> SubscriptionHandle[MarketEvent]:
-        market_specs = _normalize_market_specs(specs)
-        if self._market_manager is None:
-            try:
-                from polymarket._internal.streams.clob.market import (
-                    ClobMarketStreamManager,
-                )
-            except ImportError as exc:
-                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
-            self._market_manager = ClobMarketStreamManager(
-                url=self._ctx.environment.clob_market_ws_url,
-                logger=self._streams_logger,
-            )
-        handles: list[AsyncSubscriptionHandle[MarketEvent]] = []
+    ) -> SubscriptionHandle[MarketEvent | SportsEvent]:
+        items = _normalize_specs(specs)
+        handles: list[AsyncSubscriptionHandle[Any]] = []
         try:
-            for spec in market_specs:
-                handles.append(
-                    await self._market_manager.subscribe(
-                        token_ids=spec.token_ids,
-                        custom_feature_enabled=spec.custom_feature_enabled,
+            for spec in items:
+                if isinstance(spec, MarketSpec):
+                    handles.append(
+                        await self._get_market_manager().subscribe(
+                            token_ids=spec.token_ids,
+                            custom_feature_enabled=spec.custom_feature_enabled,
+                        )
                     )
-                )
+                else:
+                    handles.append(await self._get_sports_manager().subscribe())
         except BaseException:
             for handle in handles:
                 with contextlib.suppress(Exception):
                     await handle.close()
             raise
         if len(handles) == 1:
-            return handles[0]
+            return cast(SubscriptionHandle[MarketEvent | SportsEvent], handles[0])
         from polymarket._internal.streams.merged_handle import MergedSubscriptionHandle
 
-        return MergedSubscriptionHandle(handles)
+        return cast(
+            SubscriptionHandle[MarketEvent | SportsEvent],
+            MergedSubscriptionHandle(handles),
+        )
+
+    def _get_market_manager(self) -> "ClobMarketStreamManager":
+        if self._market_manager is None:
+            try:
+                from polymarket._internal.streams.clob.market import ClobMarketStreamManager
+            except ImportError as exc:
+                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
+            self._market_manager = ClobMarketStreamManager(
+                url=self._ctx.environment.clob_market_ws_url,
+                logger=self._streams_logger,
+            )
+        return self._market_manager
+
+    def _get_sports_manager(self) -> "SportsStreamManager":
+        if self._sports_manager is None:
+            try:
+                from polymarket._internal.streams.sports.manager import SportsStreamManager
+            except ImportError as exc:
+                raise ImportError(_WEBSOCKET_EXTRA_HINT) from exc
+            self._sports_manager = SportsStreamManager(
+                url=self._ctx.environment.sports_ws_url,
+                logger=self._streams_logger,
+            )
+        return self._sports_manager
 
     async def __aenter__(self) -> Self:
         return self
@@ -324,15 +362,19 @@ class AsyncSecureClient:
                 await self._market_manager.close()
         finally:
             try:
-                await ctx.gamma.close()
+                if self._sports_manager is not None:
+                    await self._sports_manager.close()
             finally:
                 try:
-                    await ctx.data.close()
+                    await ctx.gamma.close()
                 finally:
                     try:
-                        await ctx.clob.close()
+                        await ctx.data.close()
                     finally:
-                        await ctx.secure_clob.close()
+                        try:
+                            await ctx.clob.close()
+                        finally:
+                            await ctx.secure_clob.close()
 
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user

--- a/src/polymarket/models/clob/_validators.py
+++ b/src/polymarket/models/clob/_validators.py
@@ -50,9 +50,55 @@ def _parse_epoch_ms_timestamp(value: object) -> object:
         raise ValueError(msg) from error
 
 
+def _parse_epoch_ms_or_iso_timestamp(value: object) -> object:
+    """Permissive timestamp parser.
+
+    Accepts ``int`` (epoch ms), digit-string (epoch ms), and ISO-8601 strings.
+    Returns ``datetime`` (UTC-aware for epoch inputs; the string's own tz for
+    ISO inputs). Empty string / None / boolean / unknown shapes all surface
+    via ``ValueError``.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, bool):
+        msg = f"expected timestamp, got bool {value!r}"
+        raise ValueError(msg)
+    if isinstance(value, int):
+        try:
+            return datetime.fromtimestamp(value / 1000, tz=UTC)
+        except (OverflowError, OSError, ValueError) as error:
+            msg = f"invalid epoch-ms timestamp: {value!r}"
+            raise ValueError(msg) from error
+    if isinstance(value, str):
+        if value.isdecimal():
+            ms = int(value)
+            try:
+                return datetime.fromtimestamp(ms / 1000, tz=UTC)
+            except (OverflowError, OSError, ValueError) as error:
+                msg = f"invalid epoch-ms timestamp: {value!r}"
+                raise ValueError(msg) from error
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as error:
+            msg = f"invalid timestamp: {value!r}"
+            raise ValueError(msg) from error
+    msg = f"expected epoch-ms or ISO timestamp, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
 DecimalString = Annotated[Decimal, BeforeValidator(_require_decimal_string)]
 DecimalishString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
 EpochMsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms_timestamp)]
+EpochMsOrIsoTimestamp = Annotated[
+    datetime | None, BeforeValidator(_parse_epoch_ms_or_iso_timestamp)
+]
 
 
-__all__ = ["DecimalString", "DecimalishString", "EpochMsTimestamp"]
+__all__ = [
+    "DecimalString",
+    "DecimalishString",
+    "EpochMsOrIsoTimestamp",
+    "EpochMsTimestamp",
+]

--- a/src/polymarket/models/sports_events.py
+++ b/src/polymarket/models/sports_events.py
@@ -1,0 +1,63 @@
+from typing import Any, Literal, cast
+
+from pydantic import Field, model_validator
+
+from polymarket.models.base import BaseModel
+from polymarket.models.clob._validators import EpochMsOrIsoTimestamp
+
+
+class SportsGameResult(BaseModel):
+    game_id: int = Field(validation_alias="gameId")
+    sportradar_game_id: str | None = Field(default=None, validation_alias="sportradarGameId")
+    slug: str | None = None
+    league_abbreviation: str = Field(validation_alias="leagueAbbreviation")
+    home_team: str | None = Field(default=None, validation_alias="homeTeam")
+    away_team: str | None = Field(default=None, validation_alias="awayTeam")
+    status: str
+    live: bool
+    ended: bool
+    score: str
+    period: str | None = None
+    elapsed: str | None = None
+    finished_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="finishedTimestamp")
+    turn: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_finished_timestamp(cls, data: Any) -> Any:
+        # Mirror TS's `finishedTimestamp ?? finished_timestamp` (nullish
+        # coalescing). AliasChoices would short-circuit on the first PRESENT
+        # key even if its value is null, which silently drops a valid
+        # snake_case fallback.
+        if not isinstance(data, dict):
+            return data
+        wire = dict(cast(dict[str, Any], data))
+        camel = wire.get("finishedTimestamp")
+        snake = wire.pop("finished_timestamp", None)
+        if camel in (None, "") and snake not in (None, ""):
+            wire["finishedTimestamp"] = snake
+        return wire
+
+
+class SportsResultEvent(BaseModel):
+    topic: Literal["sports"] = "sports"
+    type: Literal["sport_result"] = "sport_result"
+    payload: SportsGameResult
+
+
+SportsEvent = SportsResultEvent
+
+
+def parse_sports_event(raw: object) -> SportsEvent:
+    """Wrap a raw sports game-result payload into the envelope shape."""
+    return SportsResultEvent.model_validate(
+        {"topic": "sports", "type": "sport_result", "payload": raw}
+    )
+
+
+__all__ = [
+    "SportsEvent",
+    "SportsGameResult",
+    "SportsResultEvent",
+    "parse_sports_event",
+]

--- a/src/polymarket/streams/__init__.py
+++ b/src/polymarket/streams/__init__.py
@@ -20,9 +20,14 @@ from polymarket.models.clob.market_events import (
     NewMarketPayload,
     PriceChange,
 )
-from polymarket.streams._specs import MarketSpec, Subscription
+from polymarket.models.sports_events import (
+    SportsEvent,
+    SportsGameResult,
+    SportsResultEvent,
+)
+from polymarket.streams._specs import MarketSpec, SportsSpec, Subscription
 
-StreamEvent = MarketEvent
+StreamEvent = MarketEvent | SportsEvent
 
 __all__ = [
     "MarketBestBidAskEvent",
@@ -43,6 +48,10 @@ __all__ = [
     "NewMarketEvent",
     "NewMarketPayload",
     "PriceChange",
+    "SportsEvent",
+    "SportsGameResult",
+    "SportsResultEvent",
+    "SportsSpec",
     "StreamEvent",
     "Subscription",
     "SubscriptionHandle",

--- a/src/polymarket/streams/_specs.py
+++ b/src/polymarket/streams/_specs.py
@@ -1,6 +1,6 @@
 # pyright: reportUnnecessaryIsInstance=false
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from polymarket.errors import UserInputError
@@ -12,16 +12,16 @@ class MarketSpec:
 
     token_ids: Sequence[str]
     custom_feature_enabled: bool = False
-    topic: Literal["market"] = "market"
+    topic: Literal["market"] = field(default="market", init=False)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.custom_feature_enabled, bool):  # pyright: ignore[reportUnnecessaryIsInstance]
+        if not isinstance(self.custom_feature_enabled, bool):
             raise UserInputError("custom_feature_enabled must be a bool")
         if isinstance(self.token_ids, str | bytes):
             raise UserInputError("token_ids must be a sequence of token ids, not a single string")
         normalized: list[str] = []
         for tid in self.token_ids:
-            if not isinstance(tid, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            if not isinstance(tid, str):
                 raise UserInputError(f"token_id must be a string, got {type(tid).__name__}")
             if not tid:
                 raise UserInputError("token_id must be non-empty")
@@ -31,13 +31,24 @@ class MarketSpec:
         object.__setattr__(self, "token_ids", tuple(normalized))
 
 
-Subscription = MarketSpec
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SportsSpec:
+    """Subscription for the Sports stream.
+
+    Sports has no per-subscription filtering — every subscriber receives
+    every event the server broadcasts.
+    """
+
+    topic: Literal["sports"] = field(default="sports", init=False)
 
 
-def _normalize_market_specs(
+Subscription = MarketSpec | SportsSpec
+
+
+def _normalize_specs(
     specs: Subscription | Sequence[Subscription],
-) -> list[MarketSpec]:
-    if isinstance(specs, MarketSpec):
+) -> list[Subscription]:
+    if isinstance(specs, MarketSpec | SportsSpec):
         return [specs]
     if not isinstance(specs, Sequence) or isinstance(specs, str | bytes):
         raise UserInputError("subscribe() expects a Subscription or a sequence of Subscriptions")
@@ -45,9 +56,9 @@ def _normalize_market_specs(
     if not items:
         raise UserInputError("subscribe() requires at least one subscription")
     for spec in items:
-        if not isinstance(spec, MarketSpec):
+        if not isinstance(spec, MarketSpec | SportsSpec):
             raise UserInputError(f"unsupported subscription type: {type(spec).__name__}")
     return items
 
 
-__all__ = ["MarketSpec", "Subscription", "_normalize_market_specs"]
+__all__ = ["MarketSpec", "SportsSpec", "Subscription", "_normalize_specs"]

--- a/tests/integration/test_sports_stream.py
+++ b/tests/integration/test_sports_stream.py
@@ -1,0 +1,43 @@
+"""Live integration test for the Sports WebSocket stream."""
+
+import asyncio
+
+import pytest
+
+from polymarket import AsyncPublicClient
+from polymarket.environments import PRODUCTION
+from polymarket.streams import SportsSpec
+
+# The server stale threshold is 30s; if pings/pongs aren't flowing both ways
+# the watchdog force-closes inside this window. Sleeping past it proves the
+# heartbeat is live without needing to inspect wire traffic.
+_HEARTBEAT_OBSERVATION_S = 35.0
+
+
+@pytest.mark.integration
+def test_live_sports_stream_clean_shutdown() -> None:
+    async def run() -> None:
+        client = AsyncPublicClient(environment=PRODUCTION)
+        try:
+            async with await client.subscribe(SportsSpec()):
+                await asyncio.sleep(0.5)
+        finally:
+            await client.close()
+
+    asyncio.run(asyncio.wait_for(run(), timeout=15.0))
+
+
+@pytest.mark.integration
+def test_live_sports_stream_survives_past_heartbeat_stale_window() -> None:
+    async def run() -> bool:
+        client = AsyncPublicClient(environment=PRODUCTION)
+        try:
+            async with await client.subscribe(SportsSpec()):
+                await asyncio.sleep(_HEARTBEAT_OBSERVATION_S)
+                manager = client._sports_manager  # pyright: ignore[reportPrivateUsage]
+                assert manager is not None
+                return manager.is_open
+        finally:
+            await client.close()
+
+    assert asyncio.run(asyncio.wait_for(run(), timeout=_HEARTBEAT_OBSERVATION_S + 10.0)) is True

--- a/tests/unit/test_streams_sports_events.py
+++ b/tests/unit/test_streams_sports_events.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from polymarket.models.sports_events import (
+    SportsGameResult,
+    SportsResultEvent,
+    parse_sports_event,
+)
+
+_WIRE: dict[str, Any] = {
+    "gameId": 123,
+    "sportradarGameId": "sr-abc",
+    "slug": "lakers-vs-celtics",
+    "leagueAbbreviation": "NBA",
+    "homeTeam": "LAL",
+    "awayTeam": "BOS",
+    "status": "live",
+    "live": True,
+    "ended": False,
+    "score": "98-102",
+    "period": "Q4",
+    "elapsed": "10:32",
+    "turn": "BOS",
+}
+
+
+def test_sports_event_has_envelope_shape() -> None:
+    event = parse_sports_event(_WIRE)
+    assert event.topic == "sports"
+    assert event.type == "sport_result"
+    assert isinstance(event.payload, SportsGameResult)
+
+
+def test_camelcase_wire_fields_map_to_snake_case() -> None:
+    event = parse_sports_event(_WIRE)
+    assert event.payload.game_id == 123
+    assert event.payload.sportradar_game_id == "sr-abc"
+    assert event.payload.league_abbreviation == "NBA"
+    assert event.payload.home_team == "LAL"
+    assert event.payload.away_team == "BOS"
+
+
+def test_required_fields_only() -> None:
+    minimal: dict[str, Any] = {
+        "gameId": 1,
+        "leagueAbbreviation": "NBA",
+        "status": "scheduled",
+        "live": False,
+        "ended": False,
+        "score": "0-0",
+    }
+    event = parse_sports_event(minimal)
+    assert event.payload.game_id == 1
+    assert event.payload.home_team is None
+    assert event.payload.away_team is None
+    assert event.payload.finished_at is None
+
+
+def test_finished_timestamp_camelcase_parses_to_datetime() -> None:
+    payload = dict(_WIRE) | {"finishedTimestamp": "1710000000000"}
+    event = parse_sports_event(payload)
+    assert event.payload.finished_at == datetime.fromtimestamp(1710000000, tz=UTC)
+
+
+def test_finished_timestamp_snake_case_alias_also_works() -> None:
+    payload = dict(_WIRE) | {"finished_timestamp": "1710000000000"}
+    event = parse_sports_event(payload)
+    assert event.payload.finished_at == datetime.fromtimestamp(1710000000, tz=UTC)
+
+
+def test_null_camelcase_falls_back_to_non_null_snake_case() -> None:
+    # Mirrors TS's `finishedTimestamp ?? finished_timestamp`. AliasChoices
+    # alone would short-circuit on the explicitly-null camelCase key and
+    # silently drop the valid snake_case fallback.
+    payload = dict(_WIRE) | {
+        "finishedTimestamp": None,
+        "finished_timestamp": "1710000000000",
+    }
+    event = parse_sports_event(payload)
+    assert event.payload.finished_at == datetime.fromtimestamp(1710000000, tz=UTC)
+
+
+def test_finished_timestamp_accepts_epoch_ms_as_int() -> None:
+    payload = dict(_WIRE) | {"finishedTimestamp": 1710000000000}
+    event = parse_sports_event(payload)
+    assert event.payload.finished_at == datetime.fromtimestamp(1710000000, tz=UTC)
+
+
+def test_finished_timestamp_accepts_iso_string() -> None:
+    payload = dict(_WIRE) | {"finishedTimestamp": "2024-03-09T12:00:00+00:00"}
+    event = parse_sports_event(payload)
+    assert event.payload.finished_at is not None
+    assert event.payload.finished_at.year == 2024
+
+
+def test_missing_required_field_raises_validation_error() -> None:
+    payload = dict(_WIRE)
+    del payload["gameId"]
+    with pytest.raises(ValidationError):
+        parse_sports_event(payload)
+
+
+def test_envelope_roundtrip_through_model_dump_and_validate() -> None:
+    event = parse_sports_event(_WIRE)
+    dumped = event.model_dump()
+    restored = SportsResultEvent.model_validate(dumped)
+    assert restored.topic == "sports"
+    assert restored.type == "sport_result"
+    assert restored.payload.game_id == 123

--- a/tests/unit/test_streams_sports_heartbeat.py
+++ b/tests/unit/test_streams_sports_heartbeat.py
@@ -1,0 +1,169 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+
+import pytest
+
+from polymarket._internal.streams.sports.heartbeat import SportsWebSocketHeartbeat
+
+
+def test_lowercase_ping_consumed_and_triggers_pong_send() -> None:
+    sent: list[str] = []
+
+    async def fake_send(msg: str) -> bool:
+        sent.append(msg)
+        return True
+
+    async def run() -> tuple[bool, list[str]]:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(fake_send)
+        consumed = hb.handle("ping")
+        await asyncio.sleep(0)  # let the pong task run
+        await hb.stop()
+        return consumed, sent
+
+    consumed, sent = asyncio.run(run())
+    assert consumed is True
+    assert sent == ["pong"]
+
+
+def test_uppercase_PING_is_not_a_heartbeat() -> None:
+    sent: list[str] = []
+
+    async def fake_send(msg: str) -> bool:
+        sent.append(msg)
+        return True
+
+    async def run() -> tuple[bool, list[str]]:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(fake_send)
+        consumed = hb.handle("PING")
+        await asyncio.sleep(0)
+        await hb.stop()
+        return consumed, sent
+
+    consumed, sent = asyncio.run(run())
+    assert consumed is False
+    assert sent == []
+
+
+def test_arbitrary_text_is_not_a_heartbeat() -> None:
+    async def fake_send(_msg: str) -> bool:
+        return True
+
+    async def run() -> bool:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(fake_send)
+        consumed = hb.handle("hello")
+        await hb.stop()
+        return consumed
+
+    assert asyncio.run(run()) is False
+
+
+def test_is_stale_before_any_ping_received_after_start() -> None:
+    async def run() -> bool:
+        hb = SportsWebSocketHeartbeat(stale_s=0.01)
+        await hb.start(_unused_send)
+        await asyncio.sleep(0.05)
+        result = hb.is_stale(_now())
+        await hb.stop()
+        return result
+
+    assert asyncio.run(run()) is True
+
+
+def test_is_stale_resets_on_ping() -> None:
+    async def fake_send(_msg: str) -> bool:
+        return True
+
+    async def run() -> tuple[bool, bool]:
+        hb = SportsWebSocketHeartbeat(stale_s=0.05)
+        await hb.start(fake_send)
+        await asyncio.sleep(0.1)
+        before = hb.is_stale(_now())
+        hb.handle("ping")
+        after = hb.is_stale(_now())
+        await asyncio.sleep(0)
+        await hb.stop()
+        return before, after
+
+    before, after = asyncio.run(run())
+    assert before is True
+    assert after is False
+
+
+def test_stop_does_not_hang_when_pong_send_is_stuck() -> None:
+    """A pong send that never returns (stuck socket) must not block stop().
+    stop() is awaited before the socket itself is closed, so blocking here
+    would deadlock client.close()."""
+
+    started = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def stuck_send(_msg: str) -> bool:
+        started.set()
+        await never_release.wait()
+        return True
+
+    async def run() -> None:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(stuck_send)
+        hb.handle("ping")
+        await started.wait()
+        # Should return promptly via cancellation, not hang on the stuck send.
+        await asyncio.wait_for(hb.stop(), timeout=1.0)
+
+    asyncio.run(run())
+
+
+def test_stop_awaits_pending_pong_tasks() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    completed: list[bool] = []
+
+    async def slow_send(_msg: str) -> bool:
+        started.set()
+        await release.wait()
+        completed.append(True)
+        return True
+
+    async def run() -> bool:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(slow_send)
+        hb.handle("ping")
+        await started.wait()
+        release.set()
+        await hb.stop()
+        return all(completed)
+
+    assert asyncio.run(run()) is True
+
+
+def test_pong_send_errors_are_swallowed() -> None:
+    async def failing_send(_msg: str) -> bool:
+        raise RuntimeError("socket dead")
+
+    async def run() -> None:
+        hb = SportsWebSocketHeartbeat()
+        await hb.start(failing_send)
+        hb.handle("ping")
+        await asyncio.sleep(0)
+        await hb.stop()
+
+    asyncio.run(run())  # must not raise
+
+
+async def _unused_send(_msg: str) -> bool:
+    return True
+
+
+def _now() -> float:
+    import time
+
+    return time.monotonic()
+
+
+@pytest.mark.parametrize("stale_s", [0, -1.0])
+def test_invalid_stale_raises(stale_s: float) -> None:
+    with pytest.raises(ValueError, match="stale_s"):
+        SportsWebSocketHeartbeat(stale_s=stale_s)

--- a/tests/unit/test_streams_sports_manager.py
+++ b/tests/unit/test_streams_sports_manager.py
@@ -1,0 +1,252 @@
+import asyncio
+import json
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from websockets.asyncio.server import ServerConnection, serve
+
+from polymarket._internal.streams.sports.manager import SportsStreamManager
+from polymarket.models.sports_events import SportsResultEvent
+
+Handler = Callable[[ServerConnection], Awaitable[None]]
+
+
+@asynccontextmanager
+async def ws_server(handler: Handler) -> AsyncGenerator[str, None]:
+    server = await serve(handler, host="127.0.0.1", port=0)
+    try:
+        port = next(iter(server.sockets)).getsockname()[1]
+        yield f"ws://127.0.0.1:{port}"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def _game_frame(game_id: int = 1) -> dict[str, Any]:
+    return {
+        "gameId": game_id,
+        "leagueAbbreviation": "NBA",
+        "status": "live",
+        "live": True,
+        "ended": False,
+        "score": "0-0",
+    }
+
+
+def test_no_client_frame_sent_on_connect() -> None:
+    received: list[str] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            received.append(str(raw))
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                handle = await mgr.subscribe()
+                await asyncio.sleep(0.1)
+                await handle.close()
+            finally:
+                await mgr.close()
+
+    asyncio.run(run())
+    # Sports never sends a subscribe frame; we also never pinged so no pong.
+    assert received == []
+
+
+def test_server_ping_triggers_pong_response() -> None:
+    received: list[str] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send("ping")
+        async for raw in ws:
+            received.append(str(raw))
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                handle = await mgr.subscribe()
+                deadline = asyncio.get_event_loop().time() + 2.0
+                while not received:
+                    if asyncio.get_event_loop().time() > deadline:
+                        raise AssertionError("pong not observed")
+                    await asyncio.sleep(0.02)
+                await handle.close()
+            finally:
+                await mgr.close()
+
+    asyncio.run(run())
+    assert received == ["pong"]
+
+
+def test_event_broadcast_to_all_subscribers() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        # Stream events on a loop so subscribers registered after the first
+        # event still see one within the test window.
+        try:
+            for _ in range(50):
+                await ws.send(json.dumps(_game_frame(42)))
+                await asyncio.sleep(0.02)
+        except Exception:
+            return
+
+    async def run() -> tuple[int, int]:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                h1 = await mgr.subscribe()
+                h2 = await mgr.subscribe()
+                e1 = await asyncio.wait_for(h1.__aiter__().__anext__(), timeout=2.0)
+                e2 = await asyncio.wait_for(h2.__aiter__().__anext__(), timeout=2.0)
+                assert isinstance(e1, SportsResultEvent)
+                assert isinstance(e2, SportsResultEvent)
+                game1 = e1.payload.game_id
+                game2 = e2.payload.game_id
+                await h1.close()
+                await h2.close()
+                return game1, game2
+            finally:
+                await mgr.close()
+
+    g1, g2 = asyncio.run(run())
+    assert g1 == 42
+    assert g2 == 42
+
+
+def test_malformed_event_dropped_and_counter_increments() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send(json.dumps({"this": "is not a sport result"}))
+        await ws.send(json.dumps(_game_frame(7)))
+        async for _ in ws:
+            pass
+
+    async def run() -> tuple[int, int]:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                handle = await mgr.subscribe()
+                event = await asyncio.wait_for(handle.__aiter__().__anext__(), timeout=2.0)
+                assert isinstance(event, SportsResultEvent)
+                game_id = event.payload.game_id
+                await asyncio.sleep(0.05)
+                dropped = mgr.dropped_events
+                await handle.close()
+                return game_id, dropped
+            finally:
+                await mgr.close()
+
+    game_id, dropped = asyncio.run(run())
+    assert game_id == 7
+    assert dropped == 1
+
+
+def test_last_handle_close_drops_socket() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> bool:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                handle = await mgr.subscribe()
+                await asyncio.sleep(0.05)
+                await handle.close()
+                await asyncio.sleep(0.1)
+                return mgr.is_open
+            finally:
+                await mgr.close()
+
+    assert asyncio.run(run()) is False
+
+
+def test_manager_remains_usable_after_last_handle_drops_socket() -> None:
+    accepts = 0
+
+    async def handler(ws: ServerConnection) -> None:
+        nonlocal accepts
+        accepts += 1
+        async for _ in ws:
+            pass
+
+    async def run() -> int:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                h1 = await mgr.subscribe()
+                await asyncio.sleep(0.05)
+                await h1.close()
+                await asyncio.sleep(0.1)
+                h2 = await mgr.subscribe()
+                await asyncio.sleep(0.05)
+                await h2.close()
+                return accepts
+            finally:
+                await mgr.close()
+
+    assert asyncio.run(run()) == 2
+
+
+def test_reconnect_does_not_send_any_frame() -> None:
+    received_per_connection: list[list[str]] = []
+    connect_count = 0
+
+    async def handler(ws: ServerConnection) -> None:
+        nonlocal connect_count
+        connect_count += 1
+        my_received: list[str] = []
+        received_per_connection.append(my_received)
+        if connect_count == 1:
+            # Close immediately so the manager schedules a reconnect.
+            await ws.close()
+            return
+        async for raw in ws:
+            my_received.append(str(raw))
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            try:
+                handle = await mgr.subscribe()
+                await asyncio.sleep(1.5)
+                await handle.close()
+            finally:
+                await mgr.close()
+
+    asyncio.run(run())
+    assert connect_count >= 2
+    # Neither connection received a client-sent subscribe frame.
+    for frames in received_per_connection:
+        assert frames == []
+
+
+def test_handle_close_idempotent_and_manager_close_ends_handles() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            mgr = SportsStreamManager(url=url)
+            handle = await mgr.subscribe()
+            await asyncio.gather(handle.close(), handle.close())
+            handle2 = await mgr.subscribe()
+            await mgr.close()
+            with pytest.raises(StopAsyncIteration):
+                await handle2.__aiter__().__anext__()
+
+    asyncio.run(run())
+
+
+def test_subscribe_after_manager_close_raises() -> None:
+    async def run() -> None:
+        mgr = SportsStreamManager(url="ws://127.0.0.1:1")
+        await mgr.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            await mgr.subscribe()
+
+    asyncio.run(run())

--- a/tests/unit/test_streams_subscribe_router.py
+++ b/tests/unit/test_streams_subscribe_router.py
@@ -28,6 +28,22 @@ async def ws_server(handler: Handler) -> AsyncGenerator[str, None]:
 
 
 def _env_with_market_ws(url: str) -> Environment:
+    return _env_with(clob_market_ws_url=url)
+
+
+def _env_with_sports_ws(url: str) -> Environment:
+    return _env_with(sports_ws_url=url)
+
+
+def _env_with_both(market_url: str, sports_url: str) -> Environment:
+    return _env_with(clob_market_ws_url=market_url, sports_ws_url=sports_url)
+
+
+def _env_with(
+    *,
+    clob_market_ws_url: str = PRODUCTION.clob_market_ws_url,
+    sports_ws_url: str = PRODUCTION.sports_ws_url,
+) -> Environment:
     return Environment(
         name="test",
         chain_id=PRODUCTION.chain_id,
@@ -47,13 +63,13 @@ def _env_with_market_ws(url: str) -> Environment:
         safe_multisend=PRODUCTION.safe_multisend,
         relay_hub=PRODUCTION.relay_hub,
         clob_url=PRODUCTION.clob_url,
-        clob_market_ws_url=url,
+        clob_market_ws_url=clob_market_ws_url,
         clob_user_ws_url=PRODUCTION.clob_user_ws_url,
         relayer_url=PRODUCTION.relayer_url,
         gamma_url=PRODUCTION.gamma_url,
         data_url=PRODUCTION.data_url,
         rtds_ws_url=PRODUCTION.rtds_ws_url,
-        sports_ws_url=PRODUCTION.sports_ws_url,
+        sports_ws_url=sports_ws_url,
     )
 
 
@@ -148,7 +164,7 @@ def test_subscribe_rejects_bare_string() -> None:
         client = AsyncPublicClient()
         try:
             with pytest.raises(UserInputError, match="sequence of Subscriptions"):
-                await client.subscribe("not-a-spec")  # pyright: ignore[reportArgumentType]
+                await client.subscribe("not-a-spec")  # pyright: ignore[reportCallIssue, reportArgumentType]
         finally:
             await client.close()
 
@@ -160,7 +176,7 @@ def test_subscribe_rejects_unknown_spec_type() -> None:
         client = AsyncPublicClient()
         try:
             with pytest.raises(UserInputError, match="unsupported"):
-                await client.subscribe([object()])  # pyright: ignore[reportArgumentType]
+                await client.subscribe([object()])  # pyright: ignore[reportCallIssue, reportArgumentType]
         finally:
             await client.close()
 
@@ -281,6 +297,19 @@ def test_merged_handle_uses_bounded_queue_with_drop_oldest() -> None:
     assert dropped > 0
 
 
+def test_market_spec_topic_field_is_not_caller_settable() -> None:
+    # Discriminator is fixed by class; caller can't lie about it.
+    with pytest.raises(TypeError):
+        MarketSpec(token_ids=["a"], topic="sports")  # pyright: ignore[reportCallIssue]
+
+
+def test_sports_spec_topic_field_is_not_caller_settable() -> None:
+    from polymarket.streams import SportsSpec
+
+    with pytest.raises(TypeError):
+        SportsSpec(topic="market")  # pyright: ignore[reportCallIssue]
+
+
 def test_close_cascades_to_streams() -> None:
     async def handler(ws: ServerConnection) -> None:
         async for _ in ws:
@@ -298,3 +327,112 @@ def test_close_cascades_to_streams() -> None:
             return True
 
     assert asyncio.run(run()) is True
+
+
+def test_subscribe_with_sports_spec_returns_sports_handle() -> None:
+    from polymarket.models.sports_events import SportsResultEvent
+    from polymarket.streams import SportsSpec
+
+    async def handler(ws: ServerConnection) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "gameId": 1,
+                    "leagueAbbreviation": "NBA",
+                    "status": "live",
+                    "live": True,
+                    "ended": False,
+                    "score": "0-0",
+                }
+            )
+        )
+        async for _ in ws:
+            pass
+
+    async def run() -> int:
+        async with ws_server(handler) as url:
+            client = AsyncPublicClient(environment=_env_with_sports_ws(url))
+            try:
+                async with await client.subscribe(SportsSpec()) as stream:
+                    event = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+                    assert isinstance(event, SportsResultEvent)
+                    return event.payload.game_id
+            finally:
+                await client.close()
+
+    assert asyncio.run(run()) == 1
+
+
+def test_subscribe_with_mixed_market_and_sports_specs_returns_merged_handle() -> None:
+    from polymarket.streams import SportsSpec
+
+    async def market_handler(ws: ServerConnection) -> None:
+        await ws.recv()  # initial subscribe frame
+        await ws.send(
+            json.dumps(
+                {
+                    "event_type": "book",
+                    "market": "m",
+                    "asset_id": "a",
+                    "bids": [{"price": "0.49", "size": "100"}],
+                    "asks": [{"price": "0.51", "size": "100"}],
+                }
+            )
+        )
+        async for _ in ws:
+            pass
+
+    async def sports_handler(ws: ServerConnection) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "gameId": 99,
+                    "leagueAbbreviation": "NBA",
+                    "status": "live",
+                    "live": True,
+                    "ended": False,
+                    "score": "1-1",
+                }
+            )
+        )
+        async for _ in ws:
+            pass
+
+    async def run() -> set[str]:
+        async with ws_server(market_handler) as market_url, ws_server(sports_handler) as sports_url:
+            client = AsyncPublicClient(environment=_env_with_both(market_url, sports_url))
+            try:
+                async with await client.subscribe(
+                    [MarketSpec(token_ids=["a"]), SportsSpec()]
+                ) as stream:
+                    seen: set[str] = set()
+                    while len(seen) < 2:
+                        event = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+                        seen.add(event.topic)
+                    return seen
+            finally:
+                await client.close()
+
+    assert asyncio.run(run()) == {"market", "sports"}
+
+
+def test_close_cascades_to_both_managers() -> None:
+    from polymarket.streams import SportsSpec
+
+    async def handler(ws: ServerConnection) -> None:
+        async for _ in ws:
+            pass
+
+    async def run() -> None:
+        async with ws_server(handler) as market_url, ws_server(handler) as sports_url:
+            client = AsyncPublicClient(environment=_env_with_both(market_url, sports_url))
+            mh = await client.subscribe(MarketSpec(token_ids=["a"]))
+            sh = await client.subscribe(SportsSpec())
+            await asyncio.sleep(0.05)
+            await client.close()
+            with pytest.raises(StopAsyncIteration):
+                await mh.__aiter__().__anext__()
+            with pytest.raises(StopAsyncIteration):
+                await sh.__aiter__().__anext__()
+
+    asyncio.run(run())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new WebSocket stream with custom heartbeat/reconnect behavior and expands client `subscribe()` routing, which could affect stream lifecycle/cleanup and event typing. Also adds a more-permissive timestamp validator that may change parsing behavior for any models adopting it.
> 
> **Overview**
> Adds a new **Sports WebSocket stream** alongside the existing market stream, including `SportsStreamManager` (auto-connect/no subscribe frame, reconnect scheduling, dropped-event tracking) and a server-initiated `ping`/client `pong` heartbeat with stale-connection detection.
> 
> Extends `AsyncPublicClient` and `AsyncSecureClient` `subscribe()` to accept `SportsSpec` (and mixed `MarketSpec`+`SportsSpec`), routing to the appropriate manager and merging handles when needed; `close()` now also tears down the sports stream manager.
> 
> Introduces `SportsGameResult`/`SportsEvent` models plus a new `EpochMsOrIsoTimestamp` validator for permissive timestamp parsing, and updates public `streams` exports/spec normalization; adds unit + live integration tests covering sports events, heartbeat behavior, and subscribe routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e51936f478b78c4e7d6b4c883612e506c7ddf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->