### PR TITLE
refactor: hide validator-decorated decimal aliases from public surface

### DIFF
--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -16,28 +16,30 @@ from polymarket.models.clob import (
     PriceHistoryPoint,
     PriceRequest,
 )
-from polymarket.models.clob._validators import DecimalString
+from polymarket.models.clob._validators import (
+    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.types import OrderSide
 
 
 class _MidpointResponse(BaseModel):
-    mid: DecimalString
+    mid: _DecimalFromString
 
 
 class _PriceResponse(BaseModel):
-    price: DecimalString
+    price: _DecimalFromString
 
 
 class _SpreadResponse(BaseModel):
-    spread: DecimalString
+    spread: _DecimalFromString
 
 
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[str, DecimalString])
-_SpreadsAdapter = TypeAdapter(dict[str, DecimalString])
-_PricesAdapter = TypeAdapter(dict[str, dict[OrderSide, DecimalString]])
+_MidpointsAdapter = TypeAdapter(dict[str, _DecimalFromString])
+_SpreadsAdapter = TypeAdapter(dict[str, _DecimalFromString])
+_PricesAdapter = TypeAdapter(dict[str, dict[OrderSide, _DecimalFromString]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])

--- a/src/polymarket/models/clob/_validators.py
+++ b/src/polymarket/models/clob/_validators.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import BeforeValidator
 
@@ -148,8 +148,13 @@ def _parse_expiration_timestamp(value: object) -> object:
     return _parse_epoch_seconds_timestamp(value)
 
 
-DecimalString = Annotated[Decimal, BeforeValidator(_require_decimal_string)]
-DecimalishString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
+if TYPE_CHECKING:
+    _DecimalFromString = Decimal
+    _DecimalFromNumberOrString = Decimal
+else:
+    _DecimalFromString = Annotated[Decimal, BeforeValidator(_require_decimal_string)]
+    _DecimalFromNumberOrString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
+
 EpochMsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms_timestamp)]
 EpochMsOrIsoTimestamp = Annotated[
     datetime | None, BeforeValidator(_parse_epoch_ms_or_iso_timestamp)
@@ -162,8 +167,6 @@ ExpirationTimestamp = Annotated[datetime | None, BeforeValidator(_parse_expirati
 
 
 __all__ = [
-    "DecimalString",
-    "DecimalishString",
     "EpochMsOrIsoTimestamp",
     "EpochMsTimestamp",
     "EpochSecondsOrMsTimestamp",

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -6,7 +6,9 @@ from typing import Any, Literal, TypeAlias, cast
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalString
+from polymarket.models.clob._validators import (
+    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.types import OrderSide, TokenId
 
 AssetType: TypeAlias = Literal["COLLATERAL", "CONDITIONAL"]
@@ -56,9 +58,9 @@ class OpenOrder(BaseModel):
     owner: str
     maker_address: str = Field(validation_alias="maker_address")
     side: OrderSide
-    price: DecimalString
-    original_size: DecimalString = Field(validation_alias="original_size")
-    size_matched: DecimalString = Field(validation_alias="size_matched")
+    price: _DecimalFromString
+    original_size: _DecimalFromString = Field(validation_alias="original_size")
+    size_matched: _DecimalFromString = Field(validation_alias="size_matched")
     outcome: str
     order_type: str = Field(validation_alias="order_type")
     status: str
@@ -83,10 +85,10 @@ class MakerOrder(BaseModel):
     maker_address: str = Field(validation_alias="maker_address")
     owner: str
     side: OrderSide
-    price: DecimalString
-    matched_amount: DecimalString = Field(validation_alias="matched_amount")
+    price: _DecimalFromString
+    matched_amount: _DecimalFromString = Field(validation_alias="matched_amount")
     outcome: str
-    fee_rate_bps: DecimalString | None = Field(default=None, validation_alias="fee_rate_bps")
+    fee_rate_bps: _DecimalFromString | None = Field(default=None, validation_alias="fee_rate_bps")
 
     @field_validator("fee_rate_bps", mode="before")
     @classmethod
@@ -103,11 +105,11 @@ class ClobTrade(BaseModel):
     taker_order_id: str = Field(validation_alias="taker_order_id")
     side: OrderSide
     trader_side: Literal["TAKER", "MAKER"] = Field(validation_alias="trader_side")
-    price: DecimalString
-    size: DecimalString
+    price: _DecimalFromString
+    size: _DecimalFromString
     outcome: str
     status: str
-    fee_rate_bps: DecimalString = Field(validation_alias="fee_rate_bps")
+    fee_rate_bps: _DecimalFromString = Field(validation_alias="fee_rate_bps")
     bucket_index: int = Field(validation_alias="bucket_index")
     transaction_hash: str = Field(validation_alias="transaction_hash")
     maker_orders: tuple[MakerOrder, ...] = Field(validation_alias="maker_orders")

--- a/src/polymarket/models/clob/last_trade.py
+++ b/src/polymarket/models/clob/last_trade.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalString
+from polymarket.models.clob._validators import (
+    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.types import OrderSide, TokenId
 
 
 class LastTradePrice(BaseModel):
-    price: DecimalString
+    price: _DecimalFromString
     side: OrderSide
 
 
 class LastTradePriceForToken(BaseModel):
     token_id: TokenId
-    price: DecimalString
+    price: _DecimalFromString
     side: OrderSide
 
 

--- a/src/polymarket/models/clob/market_events.py
+++ b/src/polymarket/models/clob/market_events.py
@@ -3,7 +3,10 @@ from typing import Annotated, Any, Literal, cast
 from pydantic import BeforeValidator, Field, TypeAdapter
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalishString, EpochMsTimestamp
+from polymarket.models.clob._validators import (
+    EpochMsTimestamp,
+    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import ConditionId, TokenId
 
@@ -25,12 +28,12 @@ class MarketEventMessage(BaseModel):
 
 class PriceChange(BaseModel):
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: DecimalishString
-    size: DecimalishString
+    price: _DecimalFromNumberOrString
+    size: _DecimalFromNumberOrString
     side: _OrderSide
     hash: str | None = None
-    best_bid: DecimalishString | None = None
-    best_ask: DecimalishString | None = None
+    best_bid: _DecimalFromNumberOrString | None = None
+    best_ask: _DecimalFromNumberOrString | None = None
 
 
 # --- Payloads (the variant-specific data; lifted out of the wire's top level) ---
@@ -43,10 +46,10 @@ class MarketBookPayload(BaseModel):
     asks: tuple[OrderBookLevel, ...]
     hash: str | None = None
     timestamp: EpochMsTimestamp = None
-    min_order_size: DecimalishString | None = None
-    tick_size: DecimalishString | None = None
+    min_order_size: _DecimalFromNumberOrString | None = None
+    tick_size: _DecimalFromNumberOrString | None = None
     neg_risk: bool | None = None
-    last_trade_price: DecimalishString | None = None
+    last_trade_price: _DecimalFromNumberOrString | None = None
 
 
 class MarketPriceChangePayload(BaseModel):
@@ -58,10 +61,10 @@ class MarketPriceChangePayload(BaseModel):
 class MarketLastTradePricePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: DecimalishString
-    size: DecimalishString | None = None
+    price: _DecimalFromNumberOrString
+    size: _DecimalFromNumberOrString | None = None
     side: _OrderSide
-    fee_rate_bps: DecimalishString | None = None
+    fee_rate_bps: _DecimalFromNumberOrString | None = None
     transaction_hash: str | None = None
     timestamp: EpochMsTimestamp = None
 
@@ -69,17 +72,17 @@ class MarketLastTradePricePayload(BaseModel):
 class MarketTickSizeChangePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    old_tick_size: DecimalishString | None = None
-    new_tick_size: DecimalishString
+    old_tick_size: _DecimalFromNumberOrString | None = None
+    new_tick_size: _DecimalFromNumberOrString
     timestamp: EpochMsTimestamp = None
 
 
 class MarketBestBidAskPayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    best_bid: DecimalishString | None = None
-    best_ask: DecimalishString | None = None
-    spread: DecimalishString | None = None
+    best_bid: _DecimalFromNumberOrString | None = None
+    best_ask: _DecimalFromNumberOrString | None = None
+    spread: _DecimalFromNumberOrString | None = None
     timestamp: EpochMsTimestamp = None
 
 
@@ -98,11 +101,11 @@ class NewMarketPayload(BaseModel):
     active: bool | None = None
     clob_token_ids: tuple[str, ...] | None = None
     sports_market_type: str | None = None
-    line: DecimalishString | None = None
+    line: _DecimalFromNumberOrString | None = None
     game_start_time: EpochMsTimestamp = None
-    order_price_min_tick_size: DecimalishString | None = None
+    order_price_min_tick_size: _DecimalFromNumberOrString | None = None
     group_item_title: str | None = None
-    taker_base_fee: DecimalishString | None = None
+    taker_base_fee: _DecimalFromNumberOrString | None = None
     fees_enabled: bool | None = None
     fee_schedule: object | None = None
 

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -5,13 +5,15 @@ from datetime import UTC, datetime
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalString
+from polymarket.models.clob._validators import (
+    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.types import TokenId
 
 
 class OrderBookLevel(BaseModel):
-    price: DecimalString
-    size: DecimalString
+    price: _DecimalFromString
+    size: _DecimalFromString
 
 
 class OrderBook(BaseModel):
@@ -20,10 +22,10 @@ class OrderBook(BaseModel):
     timestamp: datetime | None = None
     bids: tuple[OrderBookLevel, ...]
     asks: tuple[OrderBookLevel, ...]
-    min_order_size: DecimalString
-    tick_size: DecimalString
+    min_order_size: _DecimalFromString
+    tick_size: _DecimalFromString
     neg_risk: bool
-    last_trade_price: DecimalString | None = None
+    last_trade_price: _DecimalFromString | None = None
     hash: str
 
     @field_validator("timestamp", mode="before")

--- a/src/polymarket/models/clob/order_response.py
+++ b/src/polymarket/models/clob/order_response.py
@@ -6,7 +6,9 @@ from typing import Literal, TypeAlias
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalString
+from polymarket.models.clob._validators import (
+    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.types import TransactionHash
 
 OrderPostStatus: TypeAlias = Literal["live", "matched", "delayed"]
@@ -42,11 +44,11 @@ _ERROR_MSG_TO_CODE: dict[str, OrderResponseErrorCode] = {
 
 class RawOrderResponse(BaseModel):
     error_msg: str = Field(validation_alias="errorMsg")
-    making_amount: DecimalString = Field(validation_alias="makingAmount")
+    making_amount: _DecimalFromString = Field(validation_alias="makingAmount")
     order_id: str = Field(validation_alias="orderID")
     status: str
     success: bool
-    taking_amount: DecimalString = Field(validation_alias="takingAmount")
+    taking_amount: _DecimalFromString = Field(validation_alias="takingAmount")
     trade_ids: tuple[str, ...] = Field(default=(), validation_alias="tradeIDs")
     transactions_hashes: tuple[str, ...] = Field(default=(), validation_alias="transactionsHashes")
 

--- a/src/polymarket/models/clob/rewards.py
+++ b/src/polymarket/models/clob/rewards.py
@@ -6,7 +6,9 @@ from typing import TypeAlias
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalishString
+from polymarket.models.clob._validators import (
+    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.types import ConditionId, TokenId
 
 
@@ -51,8 +53,10 @@ class CurrentRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: DecimalishString = Field(validation_alias="rate_per_day")
-    total_rewards: DecimalishString | None = Field(default=None, validation_alias="total_rewards")
+    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
+    total_rewards: _DecimalFromNumberOrString | None = Field(
+        default=None, validation_alias="total_rewards"
+    )
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -68,20 +72,20 @@ class CurrentRewardConfig(BaseModel):
 class CurrentReward(BaseModel):
     condition_id: ConditionId = Field(validation_alias="condition_id")
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: DecimalishString | None = Field(
+    rewards_min_size: _DecimalFromNumberOrString | None = Field(
         default=None, validation_alias="rewards_min_size"
     )
     rewards_config: tuple[CurrentRewardConfig, ...] = Field(
         default=(), validation_alias="rewards_config"
     )
-    sponsored_daily_rate: DecimalishString | None = Field(
+    sponsored_daily_rate: _DecimalFromNumberOrString | None = Field(
         default=None, validation_alias="sponsored_daily_rate"
     )
     sponsors_count: int | None = Field(default=None, validation_alias="sponsors_count")
-    native_daily_rate: DecimalishString | None = Field(
+    native_daily_rate: _DecimalFromNumberOrString | None = Field(
         default=None, validation_alias="native_daily_rate"
     )
-    total_daily_rate: DecimalishString | None = Field(
+    total_daily_rate: _DecimalFromNumberOrString | None = Field(
         default=None, validation_alias="total_daily_rate"
     )
 
@@ -90,8 +94,10 @@ class MarketRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: DecimalishString = Field(validation_alias="rate_per_day")
-    total_rewards: DecimalishString | None = Field(default=None, validation_alias="total_rewards")
+    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
+    total_rewards: _DecimalFromNumberOrString | None = Field(
+        default=None, validation_alias="total_rewards"
+    )
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -107,7 +113,7 @@ class MarketRewardConfig(BaseModel):
 class MarketRewardToken(BaseModel):
     token_id: TokenId = Field(validation_alias="token_id")
     outcome: str
-    price: DecimalishString
+    price: _DecimalFromNumberOrString
 
 
 class MarketReward(BaseModel):
@@ -117,7 +123,7 @@ class MarketReward(BaseModel):
     event_slug: str | None = Field(default=None, validation_alias="event_slug")
     image: str | None = None
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: DecimalishString | None = Field(
+    rewards_min_size: _DecimalFromNumberOrString | None = Field(
         default=None, validation_alias="rewards_min_size"
     )
     market_competitiveness: float | None = Field(
@@ -131,10 +137,10 @@ class MarketReward(BaseModel):
 
 class UserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: DecimalishString = Field(validation_alias="asset_rate")
+    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
     condition_id: ConditionId = Field(validation_alias="condition_id")
     date: datetime
-    earnings: DecimalishString
+    earnings: _DecimalFromNumberOrString
     maker_address: str = Field(validation_alias="maker_address")
 
     @field_validator("date", mode="before")
@@ -145,9 +151,9 @@ class UserEarning(BaseModel):
 
 class TotalUserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: DecimalishString = Field(validation_alias="asset_rate")
+    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
     date: datetime
-    earnings: DecimalishString
+    earnings: _DecimalFromNumberOrString
     maker_address: str = Field(validation_alias="maker_address")
 
     @field_validator("date", mode="before")
@@ -159,9 +165,9 @@ class TotalUserEarning(BaseModel):
 class UserRewardsConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     end_date: datetime = Field(validation_alias="end_date")
-    rate_per_day: DecimalishString = Field(validation_alias="rate_per_day")
+    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
     start_date: datetime = Field(validation_alias="start_date")
-    total_rewards: DecimalishString = Field(validation_alias="total_rewards")
+    total_rewards: _DecimalFromNumberOrString = Field(validation_alias="total_rewards")
 
     @field_validator("start_date", "end_date", mode="before")
     @classmethod
@@ -171,8 +177,8 @@ class UserRewardsConfig(BaseModel):
 
 class EarningBreakdown(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: DecimalishString = Field(validation_alias="asset_rate")
-    earnings: DecimalishString
+    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
+    earnings: _DecimalFromNumberOrString
 
 
 class UserRewardsEarning(BaseModel):
@@ -187,7 +193,7 @@ class UserRewardsEarning(BaseModel):
     question: str
     rewards_config: tuple[UserRewardsConfig, ...] = Field(validation_alias="rewards_config")
     rewards_max_spread: float = Field(validation_alias="rewards_max_spread")
-    rewards_min_size: DecimalishString = Field(validation_alias="rewards_min_size")
+    rewards_min_size: _DecimalFromNumberOrString = Field(validation_alias="rewards_min_size")
     tokens: tuple[MarketRewardToken, ...]
 
 

--- a/src/polymarket/models/clob/user_events.py
+++ b/src/polymarket/models/clob/user_events.py
@@ -4,10 +4,10 @@ from pydantic import AliasChoices, BeforeValidator, Field, TypeAdapter, Validati
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    DecimalishString,
     EpochSecondsOrMsTimestamp,
     EpochSecondsTimestamp,
     ExpirationTimestamp,
+    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import TokenId
 
@@ -56,9 +56,9 @@ class UserOrderPayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
     side: _OrderSide
-    original_size: DecimalishString
-    size_matched: DecimalishString
-    price: DecimalishString
+    original_size: _DecimalFromNumberOrString
+    size_matched: _DecimalFromNumberOrString
+    price: _DecimalFromNumberOrString
     order_event_type: _OrderEventType = Field(validation_alias="type")
     timestamp: EpochSecondsOrMsTimestamp = None
     created_at: EpochSecondsTimestamp = None
@@ -75,9 +75,9 @@ class UserTradeMakerOrder(BaseModel):
     order_id: str
     owner: str
     maker_address: str | None = None
-    matched_amount: DecimalishString
-    price: DecimalishString
-    fee_rate_bps: DecimalishString | None = None
+    matched_amount: _DecimalFromNumberOrString
+    price: _DecimalFromNumberOrString
+    fee_rate_bps: _DecimalFromNumberOrString | None = None
     token_id: TokenId = Field(validation_alias="asset_id")
     side: _OrderSide
     outcome: str | None = None
@@ -90,12 +90,12 @@ class UserTradePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
     side: _OrderSide
-    size: DecimalishString
-    price: DecimalishString
+    size: _DecimalFromNumberOrString
+    price: _DecimalFromNumberOrString
     status: _TradeStatusValidator
     owner: str
     timestamp: EpochSecondsOrMsTimestamp = None
-    fee_rate_bps: DecimalishString | None = None
+    fee_rate_bps: _DecimalFromNumberOrString | None = None
     matched_at: EpochSecondsTimestamp = Field(
         default=None, validation_alias=AliasChoices("match_time", "matchtime")
     )

--- a/src/polymarket/models/rtds_events.py
+++ b/src/polymarket/models/rtds_events.py
@@ -3,7 +3,10 @@ from typing import Any, Literal, cast
 from pydantic import Field, TypeAdapter, model_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import DecimalishString, EpochMsOrIsoTimestamp
+from polymarket.models.clob._validators import (
+    EpochMsOrIsoTimestamp,
+    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.gamma.comment import (
     Comment,
     CommentMedia,
@@ -85,7 +88,7 @@ CommentsEvent = (
 class PriceUpdatePayload(BaseModel):
     symbol: str
     timestamp: int
-    value: DecimalishString
+    value: _DecimalFromNumberOrString
 
 
 class CryptoPricesBinanceEvent(BaseModel):
@@ -107,7 +110,7 @@ CryptoPricesEvent = CryptoPricesBinanceEvent | CryptoPricesChainlinkEvent
 
 class EquityPriceUpdatePayload(BaseModel):
     symbol: str
-    value: DecimalishString
+    value: _DecimalFromNumberOrString
     timestamp: int
     received_at: int | None = None
     is_carried_forward: bool | None = None
@@ -126,7 +129,7 @@ class EquityPriceUpdatePayload(BaseModel):
 
 class EquityPriceSnapshotEntry(BaseModel):
     timestamp: int
-    value: DecimalishString
+    value: _DecimalFromNumberOrString
 
 
 class EquityPriceSubscribePayload(BaseModel):

--- a/tests/unit/test_decimal_field_contract.py
+++ b/tests/unit/test_decimal_field_contract.py
@@ -1,0 +1,86 @@
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+
+from polymarket.errors import UnexpectedResponseError
+from polymarket.models.clob.order_book import OrderBookLevel
+from polymarket.models.rtds_events import PriceUpdatePayload
+
+
+class TestStrictStringFieldsExposeBareDecimal:
+    def test_model_fields_annotation_is_bare_decimal(self) -> None:
+        assert OrderBookLevel.model_fields["price"].annotation is Decimal
+        assert OrderBookLevel.model_fields["size"].annotation is Decimal
+
+    def test_get_type_hints_resolves_to_bare_decimal(self) -> None:
+        hints = get_type_hints(OrderBookLevel)
+        assert hints["price"] is Decimal
+        assert hints["size"] is Decimal
+
+
+class TestStrictStringValidatorAcceptsAndRejects:
+    def test_string_input_parses_to_decimal(self) -> None:
+        level = OrderBookLevel.parse_response({"price": "0.5", "size": "10"})
+        assert isinstance(level.price, Decimal)
+        assert level.price == Decimal("0.5")
+        assert isinstance(level.size, Decimal)
+        assert level.size == Decimal("10")
+
+    def test_direct_decimal_input_is_accepted(self) -> None:
+        level = OrderBookLevel.parse_response({"price": Decimal("0.5"), "size": Decimal("10")})
+        assert level.price == Decimal("0.5")
+        assert level.size == Decimal("10")
+
+    def test_float_input_is_rejected(self) -> None:
+        with pytest.raises(UnexpectedResponseError):
+            OrderBookLevel.parse_response({"price": 0.5, "size": "10"})
+
+    def test_int_input_is_rejected(self) -> None:
+        with pytest.raises(UnexpectedResponseError):
+            OrderBookLevel.parse_response({"price": 1, "size": "10"})
+
+    def test_bool_input_is_rejected(self) -> None:
+        with pytest.raises(UnexpectedResponseError):
+            OrderBookLevel.parse_response({"price": True, "size": "10"})
+
+
+class TestNumberOrStringValidatorAcceptsBroaderInput:
+    def test_string_input_parses_to_decimal(self) -> None:
+        payload = PriceUpdatePayload.parse_response(
+            {"symbol": "BTC", "timestamp": 0, "value": "1.5"}
+        )
+        assert isinstance(payload.value, Decimal)
+        assert payload.value == Decimal("1.5")
+
+    def test_int_input_parses_to_decimal(self) -> None:
+        payload = PriceUpdatePayload.parse_response({"symbol": "BTC", "timestamp": 0, "value": 1})
+        assert payload.value == Decimal("1")
+
+    def test_float_input_parses_to_decimal(self) -> None:
+        payload = PriceUpdatePayload.parse_response({"symbol": "BTC", "timestamp": 0, "value": 1.5})
+        assert payload.value == Decimal("1.5")
+
+    def test_direct_decimal_input_is_accepted(self) -> None:
+        payload = PriceUpdatePayload.parse_response(
+            {"symbol": "BTC", "timestamp": 0, "value": Decimal("1.5")}
+        )
+        assert payload.value == Decimal("1.5")
+
+    def test_bool_input_is_rejected(self) -> None:
+        with pytest.raises(UnexpectedResponseError):
+            PriceUpdatePayload.parse_response({"symbol": "BTC", "timestamp": 0, "value": True})
+
+
+class TestNoDecimalStringAliasLeaksToPublicSurface:
+    def test_validators_module_does_not_export_old_names(self) -> None:
+        from polymarket.models.clob import _validators
+
+        assert "DecimalString" not in _validators.__all__
+        assert "DecimalishString" not in _validators.__all__
+
+    def test_validators_module_does_not_define_old_names(self) -> None:
+        from polymarket.models.clob import _validators
+
+        assert not hasattr(_validators, "DecimalString")
+        assert not hasattr(_validators, "DecimalishString")

--- a/tests/unit/test_rewards_models.py
+++ b/tests/unit/test_rewards_models.py
@@ -4,7 +4,9 @@ from decimal import Decimal
 import pytest
 
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.clob._validators import DecimalishString
+from polymarket.models.clob._validators import (
+    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.clob.rewards import (
     CurrentReward,
     EarningBreakdown,
@@ -182,7 +184,7 @@ def test_decimalish_string_accepts_int() -> None:
     from pydantic import BaseModel as _Base
 
     class Foo(_Base):
-        v: DecimalishString
+        v: _DecimalFromNumberOrString
 
     assert Foo.model_validate({"v": 10}).v == Decimal("10")
 
@@ -191,7 +193,7 @@ def test_decimalish_string_accepts_float_via_str() -> None:
     from pydantic import BaseModel as _Base
 
     class Foo(_Base):
-        v: DecimalishString
+        v: _DecimalFromNumberOrString
 
     assert Foo.model_validate({"v": 0.1}).v == Decimal("0.1")
 
@@ -200,7 +202,7 @@ def test_decimalish_string_accepts_decimal_string() -> None:
     from pydantic import BaseModel as _Base
 
     class Foo(_Base):
-        v: DecimalishString
+        v: _DecimalFromNumberOrString
 
     assert Foo.model_validate({"v": "0.001"}).v == Decimal("0.001")
 
@@ -210,7 +212,7 @@ def test_decimalish_string_rejects_bool() -> None:
     from pydantic import ValidationError
 
     class Foo(_Base):
-        v: DecimalishString
+        v: _DecimalFromNumberOrString
 
     with pytest.raises(ValidationError):
         Foo.model_validate({"v": True})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many Pydantic models’ decimal field annotations/validators; a mistake could subtly change what numeric inputs are accepted/rejected or how types appear to users and type checkers.
> 
> **Overview**
> **Decimal field validation/types are refactored to avoid leaking validator-decorated aliases.** The public `DecimalString`/`DecimalishString` names are removed from `clob._validators` and replaced with private `_DecimalFromString` (string/Decimal only) and `_DecimalFromNumberOrString` (number/string/Decimal) that resolve to bare `Decimal` under `TYPE_CHECKING`.
> 
> All affected CLOB/RTDS models and adapters are updated to use the new private types, and new unit tests assert (1) annotations/type hints remain `Decimal`, (2) strict-vs-permissive input acceptance (rejecting bools; strict also rejects int/float), and (3) the old validator alias names are no longer defined/exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cb2985bfcb292faa4934096a18149846f91540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->