### PR TITLE
feat: typed BUY/SELL overloads for market order methods [DEV-99]

### DIFF
--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Self, TypeAlias, assert_never, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, assert_never, cast, overload
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -1284,7 +1284,49 @@ class AsyncSecureClient:
         draft = await prepare_limit_order_draft(self._ctx, params)
         return await self._sign_order(draft, post_only=params.post_only)
 
+    @overload
     async def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder: ...
+    @overload
+    async def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder: ...
+    async def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder:
+        return await self._prepare_and_sign_market_order(
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            max_spend=max_spend,
+            order_type=order_type,
+            builder_code=builder_code,
+        )
+
+    async def _prepare_and_sign_market_order(
         self,
         *,
         token_id: str,
@@ -1329,6 +1371,27 @@ class AsyncSecureClient:
         )
         return await self.post_order(signed)
 
+    @overload
+    async def place_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> OrderResponse: ...
+    @overload
+    async def place_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> OrderResponse: ...
     async def place_market_order(
         self,
         *,
@@ -1340,7 +1403,7 @@ class AsyncSecureClient:
         order_type: MarketOrderType = "FAK",
         builder_code: str | None = None,
     ) -> OrderResponse:
-        signed = await self.create_market_order(
+        signed = await self._prepare_and_sign_market_order(
             token_id=token_id,
             side=side,
             amount=amount,

--- a/tests/integration/test_clob_orders.py
+++ b/tests/integration/test_clob_orders.py
@@ -263,6 +263,7 @@ async def test_place_market_order_closes_inventory_or_buys_minimum_size(
         deposit_wallet_client, market=market, token_id=token_id
     )
     if position is not None:
+        assert position.size is not None, "expected non-null size on owned position"
         response = await deposit_wallet_client.place_market_order(
             token_id=token_id,
             side="SELL",

--- a/tests/unit/test_market_order_overloads.py
+++ b/tests/unit/test_market_order_overloads.py
@@ -1,0 +1,218 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import asyncio
+import inspect
+from decimal import Decimal
+from typing import Any, cast, get_overloads, get_type_hints
+
+import pytest
+
+from polymarket import ApiKeyCreds, AsyncSecureClient
+from polymarket.errors import UserInputError
+from polymarket.models.types import OrderSide
+
+_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+_SIGNER = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+_FAKE_CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
+
+
+def _make_client() -> AsyncSecureClient:
+    return asyncio.run(
+        AsyncSecureClient.create(
+            private_key=_PRIVATE_KEY,
+            wallet=_SIGNER,
+            credentials=_FAKE_CREDS,
+            validate_credentials=False,
+        )
+    )
+
+
+class TestOverloadStructure:
+    def test_create_market_order_has_two_overloads(self) -> None:
+        overloads = get_overloads(AsyncSecureClient.create_market_order)
+        assert len(overloads) == 2
+
+    def test_place_market_order_has_two_overloads(self) -> None:
+        overloads = get_overloads(AsyncSecureClient.place_market_order)
+        assert len(overloads) == 2
+
+    def test_create_market_order_buy_overload_accepts_amount_rejects_shares(self) -> None:
+        buy_overload = next(
+            o
+            for o in get_overloads(AsyncSecureClient.create_market_order)
+            if "BUY" in repr(inspect.signature(o).parameters["side"].annotation)
+        )
+        params = inspect.signature(buy_overload).parameters
+        assert "amount" in params
+        assert "max_spend" in params
+        assert "shares" not in params
+
+    def test_create_market_order_sell_overload_accepts_shares_rejects_amount(self) -> None:
+        sell_overload = next(
+            o
+            for o in get_overloads(AsyncSecureClient.create_market_order)
+            if "SELL" in repr(inspect.signature(o).parameters["side"].annotation)
+        )
+        params = inspect.signature(sell_overload).parameters
+        assert "shares" in params
+        assert "amount" not in params
+        assert "max_spend" not in params
+
+    def test_place_market_order_buy_overload_accepts_amount_rejects_shares(self) -> None:
+        buy_overload = next(
+            o
+            for o in get_overloads(AsyncSecureClient.place_market_order)
+            if "BUY" in repr(inspect.signature(o).parameters["side"].annotation)
+        )
+        params = inspect.signature(buy_overload).parameters
+        assert "amount" in params
+        assert "max_spend" in params
+        assert "shares" not in params
+
+    def test_place_market_order_sell_overload_accepts_shares_rejects_amount(self) -> None:
+        sell_overload = next(
+            o
+            for o in get_overloads(AsyncSecureClient.place_market_order)
+            if "SELL" in repr(inspect.signature(o).parameters["side"].annotation)
+        )
+        params = inspect.signature(sell_overload).parameters
+        assert "shares" in params
+        assert "amount" not in params
+        assert "max_spend" not in params
+
+    def test_buy_overload_amount_is_required(self) -> None:
+        for method in (AsyncSecureClient.create_market_order, AsyncSecureClient.place_market_order):
+            buy_overload = next(
+                o
+                for o in get_overloads(method)
+                if "BUY" in repr(inspect.signature(o).parameters["side"].annotation)
+            )
+            amount_param = inspect.signature(buy_overload).parameters["amount"]
+            assert amount_param.default is inspect.Parameter.empty, (
+                f"{method.__name__} BUY overload: amount should be required"
+            )
+
+    def test_sell_overload_shares_is_required(self) -> None:
+        for method in (AsyncSecureClient.create_market_order, AsyncSecureClient.place_market_order):
+            sell_overload = next(
+                o
+                for o in get_overloads(method)
+                if "SELL" in repr(inspect.signature(o).parameters["side"].annotation)
+            )
+            shares_param = inspect.signature(sell_overload).parameters["shares"]
+            assert shares_param.default is inspect.Parameter.empty, (
+                f"{method.__name__} SELL overload: shares should be required"
+            )
+
+    def test_buy_overload_side_literal_is_buy_only(self) -> None:
+        for method in (AsyncSecureClient.create_market_order, AsyncSecureClient.place_market_order):
+            hints = get_type_hints(get_overloads(method)[0])
+            side_hint = hints["side"]
+            args = getattr(side_hint, "__args__", ())
+            assert args == ("BUY",), (
+                f"{method.__name__} first overload side should be Literal['BUY']: got {args}"
+            )
+
+    def test_sell_overload_side_literal_is_sell_only(self) -> None:
+        for method in (AsyncSecureClient.create_market_order, AsyncSecureClient.place_market_order):
+            hints = get_type_hints(get_overloads(method)[1])
+            side_hint = hints["side"]
+            args = getattr(side_hint, "__args__", ())
+            assert args == ("SELL",), (
+                f"{method.__name__} second overload side should be Literal['SELL']: got {args}"
+            )
+
+
+class TestRuntimeValidationStillCatchesMisuse:
+    def test_buy_without_amount_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="amount is required"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(token_id="1", side=cast(OrderSide, "BUY"))
+                )
+        finally:
+            asyncio.run(client.close())
+
+    def test_buy_with_shares_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="shares must not be set"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(
+                        token_id="1", side="BUY", amount=Decimal(1), shares=Decimal(1)
+                    )
+                )
+        finally:
+            asyncio.run(client.close())
+
+    def test_sell_without_shares_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="shares is required"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(
+                        token_id="1", side=cast(OrderSide, "SELL")
+                    )
+                )
+        finally:
+            asyncio.run(client.close())
+
+    def test_sell_with_amount_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="amount must not be set"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(
+                        token_id="1", side="SELL", shares=Decimal(1), amount=Decimal(1)
+                    )
+                )
+        finally:
+            asyncio.run(client.close())
+
+    def test_sell_with_max_spend_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="max_spend is only valid for BUY"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(
+                        token_id="1",
+                        side="SELL",
+                        shares=Decimal(1),
+                        max_spend=Decimal(1),
+                    )
+                )
+        finally:
+            asyncio.run(client.close())
+
+    def test_invalid_side_raises(self) -> None:
+        client = _make_client()
+        try:
+            with pytest.raises(UserInputError, match="side must be 'BUY' or 'SELL'"):
+                asyncio.run(
+                    cast(Any, client.create_market_order)(
+                        token_id="1", side="WRONG", amount=Decimal(1)
+                    )
+                )
+        finally:
+            asyncio.run(client.close())
+
+
+class TestPyrightStaticContract:
+    @staticmethod
+    async def _example_buy(client: AsyncSecureClient) -> None:
+        await client.create_market_order(token_id="1", side="BUY", amount=Decimal(2))
+        await client.create_market_order(
+            token_id="1", side="BUY", amount=Decimal(2), max_spend=Decimal(3)
+        )
+        await client.place_market_order(token_id="1", side="BUY", amount=Decimal(2))
+
+    @staticmethod
+    async def _example_sell(client: AsyncSecureClient) -> None:
+        await client.create_market_order(token_id="1", side="SELL", shares=Decimal(5))
+        await client.place_market_order(token_id="1", side="SELL", shares=Decimal(5))
+
+    def test_typed_examples_are_callable(self) -> None:
+        assert inspect.iscoroutinefunction(self._example_buy)
+        assert inspect.iscoroutinefunction(self._example_sell)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the order-creation/placement path for market orders by refactoring shared logic, so any mistakes could affect trading behavior, though changes are primarily typing-focused with coverage added.
> 
> **Overview**
> Adds **typed overloads** to `AsyncSecureClient.create_market_order` and `place_market_order` so BUY requires `amount` (optionally `max_spend`) and SELL requires `shares`, improving static type-checking for incorrect parameter combinations.
> 
> Refactors the shared market-order preparation/signing into `_prepare_and_sign_market_order` and updates `place_market_order` to use it, and tightens an integration test assertion to ensure SELL uses a non-null position size. Adds a new unit test suite validating overload structure and that runtime validation still rejects misuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05911df0a7832f4abdf80dfd65536247f8ed27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->