### PR TITLE
feat: sync parity for public CLOB methods

### DIFF
--- a/src/polymarket/_internal/actions/orders/estimate.py
+++ b/src/polymarket/_internal/actions/orders/estimate.py
@@ -3,24 +3,23 @@ from decimal import Decimal
 
 from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions.orders._numeric import coerce_positive_decimal
-from polymarket._internal.actions.orders.market_data import fetch_tick_size
+from polymarket._internal.actions.orders.market_data import fetch_tick_size, fetch_tick_size_sync
 from polymarket._internal.actions.orders.types import MarketOrderType
-from polymarket._internal.context import AsyncClientContext
+from polymarket._internal.context import AsyncClientContext, SyncClientContext
 from polymarket._internal.validation import require_nonempty
 from polymarket.errors import InsufficientLiquidityError, UnexpectedResponseError, UserInputError
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import OrderSide, TokenId
 
 
-async def estimate_market_price(
-    ctx: AsyncClientContext,
+def _validate_estimate_inputs(
     *,
     token_id: str,
     side: OrderSide,
-    amount: Decimal | int | float | str | None = None,
-    shares: Decimal | int | float | str | None = None,
-    order_type: MarketOrderType = "FOK",
-) -> Decimal:
+    amount: Decimal | int | float | str | None,
+    shares: Decimal | int | float | str | None,
+    order_type: MarketOrderType,
+) -> tuple[TokenId, Decimal]:
     validated_token = TokenId(require_nonempty("token_id", token_id))
     if side == "BUY":
         if amount is None:
@@ -38,8 +37,46 @@ async def estimate_market_price(
         raise UserInputError(f"side must be 'BUY' or 'SELL', got {side!r}.")
     if order_type not in ("FAK", "FOK"):
         raise UserInputError(f"order_type must be 'FAK' or 'FOK', got {order_type!r}.")
+    return validated_token, notional
+
+
+async def estimate_market_price(
+    ctx: AsyncClientContext,
+    *,
+    token_id: str,
+    side: OrderSide,
+    amount: Decimal | int | float | str | None = None,
+    shares: Decimal | int | float | str | None = None,
+    order_type: MarketOrderType = "FOK",
+) -> Decimal:
+    validated_token, notional = _validate_estimate_inputs(
+        token_id=token_id, side=side, amount=amount, shares=shares, order_type=order_type
+    )
     tick_size = await fetch_tick_size(ctx, token_id=validated_token)
     return await resolve_estimated_market_price(
+        ctx,
+        token_id=validated_token,
+        side=side,
+        notional=notional,
+        order_type=order_type,
+        tick_size=tick_size,
+    )
+
+
+def estimate_market_price_sync(
+    ctx: SyncClientContext,
+    *,
+    token_id: str,
+    side: OrderSide,
+    amount: Decimal | int | float | str | None = None,
+    shares: Decimal | int | float | str | None = None,
+    order_type: MarketOrderType = "FOK",
+) -> Decimal:
+    validated_token, notional = _validate_estimate_inputs(
+        token_id=token_id, side=side, amount=amount, shares=shares, order_type=order_type
+    )
+    tick_size = fetch_tick_size_sync(ctx, token_id=validated_token)
+    return resolve_estimated_market_price_sync(
         ctx,
         token_id=validated_token,
         side=side,
@@ -60,6 +97,28 @@ async def resolve_estimated_market_price(
 ) -> Decimal:
     path, params = _clob_actions.build_order_book_request(token_id=token_id)
     book = _clob_actions.parse_order_book(await ctx.clob.get_json(path, params=params))
+    if side == "BUY":
+        price = _calculate_buy_market_price(book.asks, notional, order_type)
+    else:
+        price = _calculate_sell_market_price(book.bids, notional, order_type)
+    if price < tick_size or price > Decimal(1) - tick_size:
+        raise UnexpectedResponseError(
+            f"Resolved market price {price} fell outside the valid range for tick size {tick_size}."
+        )
+    return price
+
+
+def resolve_estimated_market_price_sync(
+    ctx: SyncClientContext,
+    *,
+    token_id: TokenId,
+    side: OrderSide,
+    notional: Decimal,
+    order_type: MarketOrderType,
+    tick_size: Decimal,
+) -> Decimal:
+    path, params = _clob_actions.build_order_book_request(token_id=token_id)
+    book = _clob_actions.parse_order_book(ctx.clob.get_json(path, params=params))
     if side == "BUY":
         price = _calculate_buy_market_price(book.asks, notional, order_type)
     else:
@@ -101,4 +160,9 @@ def _calculate_sell_market_price(
     return bids[0].price
 
 
-__all__ = ["estimate_market_price", "resolve_estimated_market_price"]
+__all__ = [
+    "estimate_market_price",
+    "estimate_market_price_sync",
+    "resolve_estimated_market_price",
+    "resolve_estimated_market_price_sync",
+]

--- a/src/polymarket/_internal/actions/orders/market_data.py
+++ b/src/polymarket/_internal/actions/orders/market_data.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import cast
 
 from polymarket._internal.actions.orders.types import BYTES32_ZERO
-from polymarket._internal.context import AsyncClientContext
+from polymarket._internal.context import AsyncClientContext, SyncClientContext
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.models.clob.builder import BuilderFeeRates
@@ -23,6 +23,12 @@ class PlatformFeeInfo:
 async def fetch_tick_size(ctx: AsyncClientContext, *, token_id: str) -> Decimal:
     validated = require_nonempty("token_id", token_id)
     data = await ctx.clob.get_json("/tick-size", params={"token_id": validated})
+    return _parse_tick_size(data)
+
+
+def fetch_tick_size_sync(ctx: SyncClientContext, *, token_id: str) -> Decimal:
+    validated = require_nonempty("token_id", token_id)
+    data = ctx.clob.get_json("/tick-size", params={"token_id": validated})
     return _parse_tick_size(data)
 
 
@@ -141,5 +147,6 @@ __all__ = [
     "fetch_neg_risk",
     "fetch_platform_fee_info",
     "fetch_tick_size",
+    "fetch_tick_size_sync",
     "resolve_condition_by_token",
 ]

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -2,11 +2,14 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
+from polymarket._internal.actions import rewards as _rewards_actions
 from polymarket._internal.actions.data import (
     ActivitySortBy,
     ActivityTypeFilter,
@@ -23,6 +26,10 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
+from polymarket._internal.actions.orders.estimate import (
+    estimate_market_price_sync as _estimate_market_price_sync,
+)
+from polymarket._internal.actions.orders.types import MarketOrderType
 from polymarket._internal.context import SyncClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -36,7 +43,14 @@ from polymarket.errors import RequestRejectedError
 from polymarket.models import (
     Comment,
     Event,
+    LastTradePrice,
+    LastTradePriceForToken,
     Market,
+    OrderBook,
+    OrderSide,
+    PriceHistoryInterval,
+    PriceHistoryPoint,
+    PriceRequest,
     PublicProfile,
     RelatedTag,
     SearchResults,
@@ -47,6 +61,7 @@ from polymarket.models import (
     TagReference,
     Team,
 )
+from polymarket.models.clob.rewards import CurrentReward, MarketReward
 from polymarket.models.data import (
     Activity,
     BuilderVolumeEntry,
@@ -66,7 +81,8 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.pagination import Paginator
+from polymarket.models.types import ConditionId
+from polymarket.pagination import Page, Paginator
 
 
 class PublicClient:
@@ -737,3 +753,107 @@ class PublicClient:
             sort=sort,
         )
         return sync_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
+
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
+        return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
+
+    def get_price(self, *, token_id: str, side: OrderSide) -> Decimal:
+        path, params = _clob_actions.build_price_request(token_id=token_id, side=side)
+        return _clob_actions.parse_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_prices(
+        self, *, requests: Sequence[PriceRequest]
+    ) -> dict[str, dict[OrderSide, Decimal]]:
+        path, body = _clob_actions.build_prices_request(requests=requests)
+        return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_order_book(self, *, token_id: str) -> OrderBook:
+        path, params = _clob_actions.build_order_book_request(token_id=token_id)
+        return _clob_actions.parse_order_book(self._ctx.clob.get_json(path, params=params))
+
+    def get_order_books(self, *, token_ids: Sequence[str]) -> tuple[OrderBook, ...]:
+        path, body = _clob_actions.build_order_books_request(token_ids=token_ids)
+        return _clob_actions.parse_order_books(self._ctx.clob.post_json(path, json=body))
+
+    def get_spread(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_spread_request(token_id=token_id)
+        return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
+
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
+        return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
+
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+        path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
+        return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_last_trade_prices(
+        self, *, token_ids: Sequence[str]
+    ) -> tuple[LastTradePriceForToken, ...]:
+        path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
+        return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_price_history(
+        self,
+        *,
+        token_id: str,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+        fidelity: int | None = None,
+        interval: PriceHistoryInterval | None = None,
+    ) -> tuple[PriceHistoryPoint, ...]:
+        path, params = _clob_actions.build_price_history_request(
+            token_id=token_id,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fidelity=fidelity,
+            interval=interval,
+        )
+        return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
+
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal:
+        return _estimate_market_price_sync(
+            self._ctx,
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            order_type=order_type,
+        )
+
+    def list_current_rewards(self, *, sponsored: bool | None = None) -> Paginator[CurrentReward]:
+        def fetch(cursor: str | None) -> Page[CurrentReward]:
+            path, params = _rewards_actions.build_list_current_rewards_request(
+                sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_current_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def list_market_rewards(
+        self, *, condition_id: str, sponsored: bool | None = None
+    ) -> Paginator[MarketReward]:
+        def fetch(cursor: str | None) -> Page[MarketReward]:
+            path, params = _rewards_actions.build_list_market_rewards_request(
+                condition_id=ConditionId(condition_id), sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_market_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -2,14 +2,17 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
+from polymarket._internal.actions import rewards as _rewards_actions
 from polymarket._internal.actions.data import (
     ActivitySortBy,
     ActivityTypeFilter,
@@ -26,6 +29,10 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
+from polymarket._internal.actions.orders.estimate import (
+    estimate_market_price_sync as _estimate_market_price_sync,
+)
+from polymarket._internal.actions.orders.types import MarketOrderType
 from polymarket._internal.context import SyncSecureClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -39,7 +46,14 @@ from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models import (
     Comment,
     Event,
+    LastTradePrice,
+    LastTradePriceForToken,
     Market,
+    OrderBook,
+    OrderSide,
+    PriceHistoryInterval,
+    PriceHistoryPoint,
+    PriceRequest,
     PublicProfile,
     RelatedTag,
     SearchResults,
@@ -50,6 +64,7 @@ from polymarket.models import (
     TagReference,
     Team,
 )
+from polymarket.models.clob.rewards import CurrentReward, MarketReward
 from polymarket.models.data import (
     Activity,
     BuilderVolumeEntry,
@@ -69,7 +84,8 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.pagination import Paginator
+from polymarket.models.types import ConditionId
+from polymarket.pagination import Page, Paginator
 
 _CREATE_TOKEN = object()
 
@@ -777,3 +793,107 @@ class SecureClient:
             sort=sort,
         )
         return sync_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
+
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
+        return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
+
+    def get_price(self, *, token_id: str, side: OrderSide) -> Decimal:
+        path, params = _clob_actions.build_price_request(token_id=token_id, side=side)
+        return _clob_actions.parse_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_prices(
+        self, *, requests: Sequence[PriceRequest]
+    ) -> dict[str, dict[OrderSide, Decimal]]:
+        path, body = _clob_actions.build_prices_request(requests=requests)
+        return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_order_book(self, *, token_id: str) -> OrderBook:
+        path, params = _clob_actions.build_order_book_request(token_id=token_id)
+        return _clob_actions.parse_order_book(self._ctx.clob.get_json(path, params=params))
+
+    def get_order_books(self, *, token_ids: Sequence[str]) -> tuple[OrderBook, ...]:
+        path, body = _clob_actions.build_order_books_request(token_ids=token_ids)
+        return _clob_actions.parse_order_books(self._ctx.clob.post_json(path, json=body))
+
+    def get_spread(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_spread_request(token_id=token_id)
+        return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
+
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
+        return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
+
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+        path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
+        return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_last_trade_prices(
+        self, *, token_ids: Sequence[str]
+    ) -> tuple[LastTradePriceForToken, ...]:
+        path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
+        return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_price_history(
+        self,
+        *,
+        token_id: str,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+        fidelity: int | None = None,
+        interval: PriceHistoryInterval | None = None,
+    ) -> tuple[PriceHistoryPoint, ...]:
+        path, params = _clob_actions.build_price_history_request(
+            token_id=token_id,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fidelity=fidelity,
+            interval=interval,
+        )
+        return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
+
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal:
+        return _estimate_market_price_sync(
+            self._ctx,
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            order_type=order_type,
+        )
+
+    def list_current_rewards(self, *, sponsored: bool | None = None) -> Paginator[CurrentReward]:
+        def fetch(cursor: str | None) -> Page[CurrentReward]:
+            path, params = _rewards_actions.build_list_current_rewards_request(
+                sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_current_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def list_market_rewards(
+        self, *, condition_id: str, sponsored: bool | None = None
+    ) -> Paginator[MarketReward]:
+        def fetch(cursor: str | None) -> Page[MarketReward]:
+            path, params = _rewards_actions.build_list_market_rewards_request(
+                condition_id=ConditionId(condition_id), sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_market_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -1,0 +1,375 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+import json
+from decimal import Decimal
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from polymarket import (
+    ApiKeyCreds,
+    LastTradePrice,
+    LastTradePriceForToken,
+    OrderBook,
+    PriceHistoryPoint,
+    PriceRequest,
+    PublicClient,
+    SecureClient,
+)
+from polymarket._internal.context import SyncSecureClientContext
+from polymarket.clients._transport import SyncTransport
+from polymarket.errors import InsufficientLiquidityError, UnexpectedResponseError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _clob_handler(captured: list[httpx.Request], payload: object) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _routed_handler(
+    captured: list[httpx.Request], routes: dict[str, object]
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path in routes:
+            return httpx.Response(200, json=routes[path], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_sync_clob(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = cast(SyncSecureClientContext, dataclasses.replace(client._ctx, clob=transport))
+
+
+def _body(request: httpx.Request) -> object:
+    return json.loads(request.content)
+
+
+def _secure_client() -> SecureClient:
+    return SecureClient.create(private_key=PRIVATE_KEY)
+
+
+class TestGetMidpoint:
+    def test_public_hits_clob_midpoint_with_token_id(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"mid": "0.5125"}))
+            result = client.get_midpoint(token_id="8501497")
+
+        assert result == Decimal("0.5125")
+        assert len(captured) == 1
+        parsed = urlparse(str(captured[0].url))
+        assert captured[0].method == "GET"
+        assert parsed.path == "/midpoint"
+        assert parse_qs(parsed.query) == {"token_id": ["8501497"]}
+
+    def test_secure_uses_same_clob_endpoint(self) -> None:
+        captured: list[httpx.Request] = []
+        with _secure_client() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"mid": "0.42"}))
+            result = client.get_midpoint(token_id="99")
+
+        assert result == Decimal("0.42")
+        assert urlparse(str(captured[0].url)).path == "/midpoint"
+
+    def test_propagates_malformed_response_error(self) -> None:
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler([], {"unexpected": "shape"}))
+            with pytest.raises(UnexpectedResponseError):
+                client.get_midpoint(token_id="1")
+
+
+class TestGetMidpoints:
+    def test_posts_token_ids_to_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"1": "0.5", "2": "0.4"}))
+            result = client.get_midpoints(token_ids=["1", "2"])
+
+        assert result == {"1": Decimal("0.5"), "2": Decimal("0.4")}
+        assert captured[0].method == "POST"
+        assert urlparse(str(captured[0].url)).path == "/midpoints"
+        assert _body(captured[0]) == [{"token_id": "1"}, {"token_id": "2"}]
+
+
+class TestGetPrice:
+    def test_includes_token_id_and_side(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"price": "0.52"}))
+            result = client.get_price(token_id="123", side="BUY")
+
+        assert result == Decimal("0.52")
+        parsed = urlparse(str(captured[0].url))
+        assert parsed.path == "/price"
+        assert parse_qs(parsed.query) == {"token_id": ["123"], "side": ["BUY"]}
+
+
+class TestGetPrices:
+    def test_posts_token_id_and_side(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: dict[str, dict[str, str]] = {
+            "tok-1": {"BUY": "0.50", "SELL": "0.51"},
+            "tok-2": {"BUY": "0.30"},
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            result = client.get_prices(
+                requests=[
+                    PriceRequest(token_id="tok-1", side="BUY"),
+                    PriceRequest(token_id="tok-1", side="SELL"),
+                    PriceRequest(token_id="tok-2", side="BUY"),
+                ]
+            )
+
+        assert result["tok-1"]["BUY"] == Decimal("0.50")
+        assert urlparse(str(captured[0].url)).path == "/prices"
+        assert captured[0].method == "POST"
+
+
+class TestGetOrderBook:
+    def test_returns_parsed_model(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(
+                    captured,
+                    {
+                        "asset_id": "1",
+                        "market": "0xM",
+                        "bids": [],
+                        "asks": [{"price": "0.5", "size": "10"}],
+                        "min_order_size": "1",
+                        "tick_size": "0.01",
+                        "neg_risk": False,
+                        "hash": "0xhash",
+                        "timestamp": "0",
+                    },
+                ),
+            )
+            book = client.get_order_book(token_id="1")
+
+        assert isinstance(book, OrderBook)
+        assert urlparse(str(captured[0].url)).path == "/book"
+
+
+class TestGetOrderBooks:
+    def test_posts_token_ids(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: list[dict[str, object]] = [
+            {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            }
+        ]
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            books = client.get_order_books(token_ids=["1"])
+
+        assert len(books) == 1
+        assert captured[0].method == "POST"
+        assert urlparse(str(captured[0].url)).path == "/books"
+        assert _body(captured[0]) == [{"token_id": "1"}]
+
+
+class TestGetSpread:
+    def test_returns_decimal(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"spread": "0.02"}))
+            spread = client.get_spread(token_id="1")
+
+        assert spread == Decimal("0.02")
+        assert urlparse(str(captured[0].url)).path == "/spread"
+
+
+class TestGetSpreads:
+    def test_posts_token_ids(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"1": "0.02", "2": "0.03"}))
+            spreads = client.get_spreads(token_ids=["1", "2"])
+
+        assert spreads == {"1": Decimal("0.02"), "2": Decimal("0.03")}
+        assert urlparse(str(captured[0].url)).path == "/spreads"
+
+
+class TestGetLastTradePrice:
+    def test_returns_model(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(captured, {"asset_id": "1", "price": "0.55", "side": "BUY"}),
+            )
+            ltp = client.get_last_trade_price(token_id="1")
+
+        assert isinstance(ltp, LastTradePrice)
+        assert urlparse(str(captured[0].url)).path == "/last-trade-price"
+
+
+class TestGetLastTradePrices:
+    def test_posts_token_ids_at_correct_path(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: list[dict[str, str]] = [
+            {"token_id": "1", "price": "0.5", "side": "BUY"},
+        ]
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            result = client.get_last_trade_prices(token_ids=["1"])
+
+        assert len(result) == 1
+        assert isinstance(result[0], LastTradePriceForToken)
+        assert urlparse(str(captured[0].url)).path == "/last-trades-prices"
+        assert _body(captured[0]) == [{"token_id": "1"}]
+
+
+class TestGetPriceHistory:
+    def test_maps_token_id_to_market_param(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(captured, {"history": [{"t": 1700000000, "p": 0.5}]}),
+            )
+            result = client.get_price_history(token_id="abc")
+
+        assert len(result) == 1
+        assert isinstance(result[0], PriceHistoryPoint)
+        parsed = urlparse(str(captured[0].url))
+        assert parsed.path == "/prices-history"
+        assert parse_qs(parsed.query) == {"market": ["abc"]}
+
+    def test_preserves_camelcase_optional_params_on_wire(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"history": []}))
+            client.get_price_history(
+                token_id="abc",
+                start_ts=1700000000,
+                end_ts=1700001000,
+                fidelity=60,
+                interval="1d",
+            )
+
+        parsed = urlparse(str(captured[0].url))
+        qs = parse_qs(parsed.query)
+        assert qs["market"] == ["abc"]
+        assert qs["startTs"] == ["1700000000"]
+        assert qs["endTs"] == ["1700001000"]
+        assert qs["fidelity"] == ["60"]
+        assert qs["interval"] == ["1d"]
+
+
+class TestEstimateMarketPrice:
+    def test_buy_fetches_tick_size_and_book(self) -> None:
+        captured: list[httpx.Request] = []
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [{"price": "0.49", "size": "100"}],
+                "asks": [{"price": "0.50", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler(captured, routes))
+            price = client.estimate_market_price(token_id="1", side="BUY", amount=Decimal(2))
+
+        assert price == Decimal("0.50")
+        paths = [urlparse(str(r.url)).path for r in captured]
+        assert "/tick-size" in paths
+        assert "/book" in paths
+
+    def test_sell_uses_bids(self) -> None:
+        captured: list[httpx.Request] = []
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [{"price": "0.49", "size": "100"}],
+                "asks": [{"price": "0.50", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler(captured, routes))
+            price = client.estimate_market_price(token_id="1", side="SELL", shares=Decimal(1))
+
+        assert price == Decimal("0.49")
+
+    def test_fok_raises_on_insufficient_liquidity(self) -> None:
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [{"price": "0.50", "size": "1"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler([], routes))
+            with pytest.raises(InsufficientLiquidityError):
+                client.estimate_market_price(
+                    token_id="1", side="BUY", amount=Decimal(1000), order_type="FOK"
+                )
+
+    def test_available_on_secure_client(self) -> None:
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [{"price": "0.5", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with _secure_client() as client:
+            _install_sync_clob(client, _routed_handler([], routes))
+            price = client.estimate_market_price(token_id="1", side="BUY", amount=Decimal(1))
+
+        assert price == Decimal("0.5")

--- a/tests/unit/test_rewards_transport_sync.py
+++ b/tests/unit/test_rewards_transport_sync.py
@@ -1,0 +1,149 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+from typing import Any, cast
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from polymarket import (
+    PublicClient,
+    SecureClient,
+)
+from polymarket._internal.context import SyncSecureClientContext
+from polymarket.clients._transport import SyncTransport
+from polymarket.models.clob.rewards import (
+    CurrentReward,
+    MarketReward,
+)
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+def _routed_handler(
+    captured: list[httpx.Request],
+    routes: dict[tuple[str, str], Any],
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        key = (request.method, path)
+        if key in routes:
+            return httpx.Response(200, json=routes[key], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_sync_clob(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = cast(SyncSecureClientContext, dataclasses.replace(client._ctx, clob=transport))
+
+
+_CURRENT_REWARDS_PAGE: dict[str, Any] = {
+    "limit": 100,
+    "count": 1,
+    "next_cursor": "LTE=",
+    "data": [
+        {
+            "condition_id": "0xCONDITION",
+            "rewards_max_spread": 3.0,
+            "tokens": [],
+        }
+    ],
+}
+
+_MARKET_REWARDS_PAGE: dict[str, Any] = {
+    "limit": 100,
+    "count": 1,
+    "next_cursor": "LTE=",
+    "data": [
+        {
+            "condition_id": "0xCONDITION",
+            "question": "Q?",
+            "tokens": [{"token_id": "8501497", "outcome": "Yes", "price": "0.5"}],
+        }
+    ],
+}
+
+
+class TestListCurrentRewards:
+    def test_public_routes_to_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            page = client.list_current_rewards().first_page()
+
+        assert len(page.items) == 1
+        assert isinstance(page.items[0], CurrentReward)
+        assert captured[0].method == "GET"
+        assert urlparse(str(captured[0].url)).path == "/rewards/markets/current"
+        assert captured[0].headers.get("POLY_SIGNATURE") is None
+
+    def test_public_passes_sponsored_filter(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            client.list_current_rewards(sponsored=True).first_page()
+
+        qs = parse_qs(urlparse(str(captured[0].url)).query)
+        assert qs.get("sponsored") == ["true"]
+
+    def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            page = client.list_current_rewards().first_page()
+
+        assert len(page.items) == 1
+        assert captured[0].headers.get("POLY_SIGNATURE") is None
+
+
+class TestListMarketRewards:
+    def test_public_routes_with_condition_id_in_path(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured,
+                    {("GET", "/rewards/markets/0xCONDITION"): _MARKET_REWARDS_PAGE},
+                ),
+            )
+            page = client.list_market_rewards(condition_id="0xCONDITION").first_page()
+
+        assert len(page.items) == 1
+        assert isinstance(page.items[0], MarketReward)
+        assert urlparse(str(captured[0].url)).path == "/rewards/markets/0xCONDITION"
+
+    def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured,
+                    {("GET", "/rewards/markets/0xCONDITION"): _MARKET_REWARDS_PAGE},
+                ),
+            )
+            page = client.list_market_rewards(condition_id="0xCONDITION").first_page()
+
+        assert len(page.items) == 1
+        assert captured[0].headers.get("POLY_SIGNATURE") is None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds multiple new synchronous CLOB-facing client methods and a sync market price estimator, which expands the SDK surface area and request/response parsing paths. Risk is mainly around wire-compatibility and error handling for new endpoints, but changes are additive and covered by new unit tests.
> 
> **Overview**
> Adds **sync parity for public CLOB data workflows** by exposing new synchronous methods on `PublicClient` and `SecureClient` for midpoint(s), price(s), order book(s), spread(s), last trade price(s), and price history.
> 
> Introduces synchronous market price estimation via `estimate_market_price_sync`/`resolve_estimated_market_price_sync`, including shared input validation and a new `fetch_tick_size_sync` helper.
> 
> Adds synchronous rewards listing APIs (`list_current_rewards`, `list_market_rewards`) and comprehensive unit tests that assert correct HTTP methods/paths/query params and ensure rewards calls remain *unsigned* (no `POLY_SIGNATURE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f764014557b02c2adf312215504272a9b8c3015e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->