### PR TITLE
feat: sync parity for secure CLOB methods

### DIFF
--- a/src/polymarket/_internal/actions/auth.py
+++ b/src/polymarket/_internal/actions/auth.py
@@ -3,7 +3,7 @@ from typing import cast
 from pydantic import TypeAdapter, ValidationError
 
 from polymarket._internal.l1_auth import ApiKeyAuthSignature
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.errors import RequestRejectedError, UnexpectedResponseError
 from polymarket.models.clob import ApiKeyCreds
 
@@ -67,13 +67,52 @@ async def delete_api_key(secure_clob: AsyncTransport) -> None:
         )
 
 
+def create_api_key_sync(clob: SyncTransport, signature: ApiKeyAuthSignature) -> ApiKeyCreds:
+    payload = clob.post_json("/auth/api-key", headers=build_l1_auth_headers(signature))
+    return parse_api_key_creds(payload)
+
+
+def derive_api_key_sync(clob: SyncTransport, signature: ApiKeyAuthSignature) -> ApiKeyCreds:
+    payload = clob.get_json("/auth/derive-api-key", headers=build_l1_auth_headers(signature))
+    return parse_api_key_creds(payload)
+
+
+def create_or_derive_api_key_sync(
+    clob: SyncTransport, signature: ApiKeyAuthSignature
+) -> ApiKeyCreds:
+    try:
+        return create_api_key_sync(clob, signature)
+    except RequestRejectedError as error:
+        if error.status != 400:
+            raise
+    return derive_api_key_sync(clob, signature)
+
+
+def fetch_api_keys_sync(secure_clob: SyncTransport) -> tuple[str, ...]:
+    payload = secure_clob.get_json("/auth/api-keys")
+    return parse_api_keys_response(payload)
+
+
+def delete_api_key_sync(secure_clob: SyncTransport) -> None:
+    payload = secure_clob.delete_json("/auth/api-key")
+    if payload != "OK":
+        raise UnexpectedResponseError(
+            f"delete api key response did not match expected shape: {payload!r}"
+        )
+
+
 __all__ = [
     "build_l1_auth_headers",
     "create_api_key",
+    "create_api_key_sync",
     "create_or_derive_api_key",
+    "create_or_derive_api_key_sync",
     "delete_api_key",
+    "delete_api_key_sync",
     "derive_api_key",
+    "derive_api_key_sync",
     "fetch_api_keys",
+    "fetch_api_keys_sync",
     "parse_api_key_creds",
     "parse_api_keys_response",
 ]

--- a/src/polymarket/_internal/actions/orders/allowance.py
+++ b/src/polymarket/_internal/actions/orders/allowance.py
@@ -1,17 +1,14 @@
 from polymarket._internal.actions import account as _account_actions
 from polymarket._internal.actions.orders.types import OrderDraft
-from polymarket._internal.context import AsyncSecureClientContext
-from polymarket._internal.wallet import signature_type_for
+from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
+from polymarket._internal.request import QueryParamValue
+from polymarket._internal.wallet import WalletType, signature_type_for
 from polymarket.errors import InsufficientAllowanceError
 from polymarket.types import EvmAddress
 
 
-async def ensure_order_allowance(ctx: AsyncSecureClientContext, draft: OrderDraft) -> None:
-    spender = draft.exchange_address
-    current = await _fetch_current_allowance(ctx, draft=draft, spender=spender)
-    if current >= draft.offered_amount:
-        return
-    raise InsufficientAllowanceError(
+def _insufficient_allowance_error(spender: EvmAddress, draft: OrderDraft, current: int) -> str:
+    return (
         f"Insufficient on-chain allowance for spender {spender}: "
         f"have {current} base units, need {draft.offered_amount}. "
         "Run an ERC20/ERC1155 approval transaction and try again. "
@@ -19,24 +16,55 @@ async def ensure_order_allowance(ctx: AsyncSecureClientContext, draft: OrderDraf
     )
 
 
+async def ensure_order_allowance(ctx: AsyncSecureClientContext, draft: OrderDraft) -> None:
+    spender = draft.exchange_address
+    current = await _fetch_current_allowance(ctx, draft=draft, spender=spender)
+    if current >= draft.offered_amount:
+        return
+    raise InsufficientAllowanceError(_insufficient_allowance_error(spender, draft, current))
+
+
+def ensure_order_allowance_sync(ctx: SyncSecureClientContext, draft: OrderDraft) -> None:
+    spender = draft.exchange_address
+    current = _fetch_current_allowance_sync(ctx, draft=draft, spender=spender)
+    if current >= draft.offered_amount:
+        return
+    raise InsufficientAllowanceError(_insufficient_allowance_error(spender, draft, current))
+
+
 async def _fetch_current_allowance(
     ctx: AsyncSecureClientContext, *, draft: OrderDraft, spender: EvmAddress
 ) -> int:
-    signature_type = signature_type_for(ctx.wallet_type)
-    if draft.side == "BUY":
-        path, params = _account_actions.build_balance_allowance_request(
-            asset_type="COLLATERAL", token_id=None, signature_type=signature_type
-        )
-    else:
-        path, params = _account_actions.build_balance_allowance_request(
-            asset_type="CONDITIONAL",
-            token_id=draft.token_id,
-            signature_type=signature_type,
-        )
+    path, params = _balance_allowance_request_for_draft(ctx.wallet_type, draft=draft)
     balance = _account_actions.parse_balance_allowance(
         await ctx.secure_clob.get_json(path, params=params)
     )
     return _allowance_for_spender(balance.allowances, spender)
+
+
+def _fetch_current_allowance_sync(
+    ctx: SyncSecureClientContext, *, draft: OrderDraft, spender: EvmAddress
+) -> int:
+    path, params = _balance_allowance_request_for_draft(ctx.wallet_type, draft=draft)
+    balance = _account_actions.parse_balance_allowance(
+        ctx.secure_clob.get_json(path, params=params)
+    )
+    return _allowance_for_spender(balance.allowances, spender)
+
+
+def _balance_allowance_request_for_draft(
+    wallet_type: WalletType, *, draft: OrderDraft
+) -> tuple[str, dict[str, QueryParamValue]]:
+    signature_type = signature_type_for(wallet_type)
+    if draft.side == "BUY":
+        return _account_actions.build_balance_allowance_request(
+            asset_type="COLLATERAL", token_id=None, signature_type=signature_type
+        )
+    return _account_actions.build_balance_allowance_request(
+        asset_type="CONDITIONAL",
+        token_id=draft.token_id,
+        signature_type=signature_type,
+    )
 
 
 def _allowance_for_spender(allowances: dict[str, int], spender: str) -> int:
@@ -47,4 +75,4 @@ def _allowance_for_spender(allowances: dict[str, int], spender: str) -> int:
     return 0
 
 
-__all__ = ["ensure_order_allowance"]
+__all__ = ["ensure_order_allowance", "ensure_order_allowance_sync"]

--- a/src/polymarket/_internal/actions/orders/estimate.py
+++ b/src/polymarket/_internal/actions/orders/estimate.py
@@ -3,24 +3,23 @@ from decimal import Decimal
 
 from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions.orders._numeric import coerce_positive_decimal
-from polymarket._internal.actions.orders.market_data import fetch_tick_size
+from polymarket._internal.actions.orders.market_data import fetch_tick_size, fetch_tick_size_sync
 from polymarket._internal.actions.orders.types import MarketOrderType
-from polymarket._internal.context import AsyncClientContext
+from polymarket._internal.context import AsyncClientContext, SyncClientContext
 from polymarket._internal.validation import require_nonempty
 from polymarket.errors import InsufficientLiquidityError, UnexpectedResponseError, UserInputError
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import OrderSide, TokenId
 
 
-async def estimate_market_price(
-    ctx: AsyncClientContext,
+def _validate_estimate_inputs(
     *,
     token_id: str,
     side: OrderSide,
-    amount: Decimal | int | float | str | None = None,
-    shares: Decimal | int | float | str | None = None,
-    order_type: MarketOrderType = "FOK",
-) -> Decimal:
+    amount: Decimal | int | float | str | None,
+    shares: Decimal | int | float | str | None,
+    order_type: MarketOrderType,
+) -> tuple[TokenId, Decimal]:
     validated_token = TokenId(require_nonempty("token_id", token_id))
     if side == "BUY":
         if amount is None:
@@ -38,8 +37,46 @@ async def estimate_market_price(
         raise UserInputError(f"side must be 'BUY' or 'SELL', got {side!r}.")
     if order_type not in ("FAK", "FOK"):
         raise UserInputError(f"order_type must be 'FAK' or 'FOK', got {order_type!r}.")
+    return validated_token, notional
+
+
+async def estimate_market_price(
+    ctx: AsyncClientContext,
+    *,
+    token_id: str,
+    side: OrderSide,
+    amount: Decimal | int | float | str | None = None,
+    shares: Decimal | int | float | str | None = None,
+    order_type: MarketOrderType = "FOK",
+) -> Decimal:
+    validated_token, notional = _validate_estimate_inputs(
+        token_id=token_id, side=side, amount=amount, shares=shares, order_type=order_type
+    )
     tick_size = await fetch_tick_size(ctx, token_id=validated_token)
     return await resolve_estimated_market_price(
+        ctx,
+        token_id=validated_token,
+        side=side,
+        notional=notional,
+        order_type=order_type,
+        tick_size=tick_size,
+    )
+
+
+def estimate_market_price_sync(
+    ctx: SyncClientContext,
+    *,
+    token_id: str,
+    side: OrderSide,
+    amount: Decimal | int | float | str | None = None,
+    shares: Decimal | int | float | str | None = None,
+    order_type: MarketOrderType = "FOK",
+) -> Decimal:
+    validated_token, notional = _validate_estimate_inputs(
+        token_id=token_id, side=side, amount=amount, shares=shares, order_type=order_type
+    )
+    tick_size = fetch_tick_size_sync(ctx, token_id=validated_token)
+    return resolve_estimated_market_price_sync(
         ctx,
         token_id=validated_token,
         side=side,
@@ -60,6 +97,28 @@ async def resolve_estimated_market_price(
 ) -> Decimal:
     path, params = _clob_actions.build_order_book_request(token_id=token_id)
     book = _clob_actions.parse_order_book(await ctx.clob.get_json(path, params=params))
+    if side == "BUY":
+        price = _calculate_buy_market_price(book.asks, notional, order_type)
+    else:
+        price = _calculate_sell_market_price(book.bids, notional, order_type)
+    if price < tick_size or price > Decimal(1) - tick_size:
+        raise UnexpectedResponseError(
+            f"Resolved market price {price} fell outside the valid range for tick size {tick_size}."
+        )
+    return price
+
+
+def resolve_estimated_market_price_sync(
+    ctx: SyncClientContext,
+    *,
+    token_id: TokenId,
+    side: OrderSide,
+    notional: Decimal,
+    order_type: MarketOrderType,
+    tick_size: Decimal,
+) -> Decimal:
+    path, params = _clob_actions.build_order_book_request(token_id=token_id)
+    book = _clob_actions.parse_order_book(ctx.clob.get_json(path, params=params))
     if side == "BUY":
         price = _calculate_buy_market_price(book.asks, notional, order_type)
     else:
@@ -101,4 +160,9 @@ def _calculate_sell_market_price(
     return bids[0].price
 
 
-__all__ = ["estimate_market_price", "resolve_estimated_market_price"]
+__all__ = [
+    "estimate_market_price",
+    "estimate_market_price_sync",
+    "resolve_estimated_market_price",
+    "resolve_estimated_market_price_sync",
+]

--- a/src/polymarket/_internal/actions/orders/limit.py
+++ b/src/polymarket/_internal/actions/orders/limit.py
@@ -7,7 +7,12 @@ from polymarket._internal.actions.orders.context import (
     resolve_exchange_address,
     resolve_rounding_config,
 )
-from polymarket._internal.actions.orders.market_data import fetch_neg_risk, fetch_tick_size
+from polymarket._internal.actions.orders.market_data import (
+    fetch_neg_risk,
+    fetch_neg_risk_sync,
+    fetch_tick_size,
+    fetch_tick_size_sync,
+)
 from polymarket._internal.actions.orders.math import (
     decimal_places,
     parse_amount,
@@ -16,7 +21,7 @@ from polymarket._internal.actions.orders.math import (
     round_up,
 )
 from polymarket._internal.actions.orders.types import OrderDraft
-from polymarket._internal.context import AsyncSecureClientContext
+from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -99,6 +104,30 @@ async def prepare_limit_order_draft(
     )
 
 
+def prepare_limit_order_draft_sync(
+    ctx: SyncSecureClientContext, params: PrepareLimitOrderParams
+) -> OrderDraft:
+    tick_size = fetch_tick_size_sync(ctx, token_id=params.token_id)
+    neg_risk = fetch_neg_risk_sync(ctx, token_id=params.token_id)
+    price = _resolve_price(params.price, tick_size)
+    offered, requested = _compute_limit_order_amounts(
+        price=price, size=params.size, side=params.side, tick_size=tick_size
+    )
+    return OrderDraft(
+        chain_id=ctx.environment.chain_id,
+        exchange_address=resolve_exchange_address(ctx.environment, neg_risk),
+        expiration=params.expiration if params.expiration is not None else 0,
+        funder_address=ctx.wallet,
+        offered_amount=offered,
+        order_type="GTC" if params.expiration is None else "GTD",
+        side=params.side,
+        signer=EvmAddress(ctx.signer.address),
+        requested_amount=requested,
+        token_id=params.token_id,
+        builder_code=params.builder_code,
+    )
+
+
 def _compute_limit_order_amounts(
     *, price: Decimal, size: Decimal, side: OrderSide, tick_size: Decimal
 ) -> tuple[int, int]:
@@ -139,5 +168,6 @@ def _resolve_price(price: Decimal, tick_size: Decimal) -> Decimal:
 __all__ = [
     "PrepareLimitOrderParams",
     "prepare_limit_order_draft",
+    "prepare_limit_order_draft_sync",
     "validate_limit_order_params",
 ]

--- a/src/polymarket/_internal/actions/orders/market.py
+++ b/src/polymarket/_internal/actions/orders/market.py
@@ -6,14 +6,22 @@ from polymarket._internal.actions.orders.context import (
     resolve_exchange_address,
     resolve_rounding_config,
 )
-from polymarket._internal.actions.orders.estimate import resolve_estimated_market_price
+from polymarket._internal.actions.orders.estimate import (
+    resolve_estimated_market_price,
+    resolve_estimated_market_price_sync,
+)
 from polymarket._internal.actions.orders.market_data import (
     PlatformFeeInfo,
     fetch_builder_fee_rates,
+    fetch_builder_fee_rates_sync,
     fetch_neg_risk,
+    fetch_neg_risk_sync,
     fetch_platform_fee_info,
+    fetch_platform_fee_info_sync,
     fetch_tick_size,
+    fetch_tick_size_sync,
     resolve_condition_by_token,
+    resolve_condition_by_token_sync,
 )
 from polymarket._internal.actions.orders.math import (
     decimal_places,
@@ -22,7 +30,7 @@ from polymarket._internal.actions.orders.math import (
     round_up,
 )
 from polymarket._internal.actions.orders.types import BYTES32_ZERO, MarketOrderType, OrderDraft
-from polymarket._internal.context import AsyncSecureClientContext
+from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -122,6 +130,40 @@ async def prepare_market_order_draft(
     )
 
 
+def prepare_market_order_draft_sync(
+    ctx: SyncSecureClientContext, params: PrepareMarketOrderParams
+) -> OrderDraft:
+    tick_size = fetch_tick_size_sync(ctx, token_id=params.token_id)
+    notional = params.amount if params.side == "BUY" else params.shares
+    assert notional is not None
+    price = resolve_estimated_market_price_sync(
+        ctx,
+        token_id=params.token_id,
+        side=params.side,
+        notional=notional,
+        order_type=params.order_type,
+        tick_size=tick_size,
+    )
+    neg_risk = fetch_neg_risk_sync(ctx, token_id=params.token_id)
+    resolved_amount = _resolve_buy_amount_for_fees_sync(ctx, params, price=price)
+    offered, requested = _compute_market_order_amounts(
+        amount=resolved_amount, price=price, side=params.side, tick_size=tick_size
+    )
+    return OrderDraft(
+        chain_id=ctx.environment.chain_id,
+        exchange_address=resolve_exchange_address(ctx.environment, neg_risk),
+        expiration=0,
+        funder_address=ctx.wallet,
+        offered_amount=offered,
+        order_type=params.order_type,
+        side=params.side,
+        signer=EvmAddress(ctx.signer.address),
+        requested_amount=requested,
+        token_id=params.token_id,
+        builder_code=params.builder_code,
+    )
+
+
 def _compute_market_order_amounts(
     *, amount: Decimal, price: Decimal, side: OrderSide, tick_size: Decimal
 ) -> tuple[int, int]:
@@ -156,6 +198,26 @@ async def _resolve_buy_amount_for_fees(
     )
 
 
+def _resolve_buy_amount_for_fees_sync(
+    ctx: SyncSecureClientContext, params: PrepareMarketOrderParams, *, price: Decimal
+) -> Decimal:
+    if params.side != "BUY" or params.max_spend is None or params.amount is None:
+        return params.amount if params.amount is not None else params.shares  # type: ignore[return-value]
+    condition_id = resolve_condition_by_token_sync(ctx, token_id=params.token_id)
+    fee_info = fetch_platform_fee_info_sync(ctx, condition_id=condition_id)
+    builder_taker_fee_rate = Decimal(0)
+    if params.builder_code is not None and params.builder_code != BYTES32_ZERO:
+        rates = fetch_builder_fee_rates_sync(ctx, builder_code=params.builder_code)
+        builder_taker_fee_rate = rates.taker
+    return adjust_buy_amount_for_fees(
+        amount=params.amount,
+        price=price,
+        max_spend=params.max_spend,
+        fee=fee_info,
+        builder_taker_fee_rate=builder_taker_fee_rate,
+    )
+
+
 def adjust_buy_amount_for_fees(
     *,
     amount: Decimal,
@@ -177,5 +239,6 @@ __all__ = [
     "PrepareMarketOrderParams",
     "adjust_buy_amount_for_fees",
     "prepare_market_order_draft",
+    "prepare_market_order_draft_sync",
     "validate_market_order_params",
 ]

--- a/src/polymarket/_internal/actions/orders/market_data.py
+++ b/src/polymarket/_internal/actions/orders/market_data.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import cast
 
 from polymarket._internal.actions.orders.types import BYTES32_ZERO
-from polymarket._internal.context import AsyncClientContext
+from polymarket._internal.context import AsyncClientContext, SyncClientContext
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.models.clob.builder import BuilderFeeRates
@@ -23,6 +23,12 @@ class PlatformFeeInfo:
 async def fetch_tick_size(ctx: AsyncClientContext, *, token_id: str) -> Decimal:
     validated = require_nonempty("token_id", token_id)
     data = await ctx.clob.get_json("/tick-size", params={"token_id": validated})
+    return _parse_tick_size(data)
+
+
+def fetch_tick_size_sync(ctx: SyncClientContext, *, token_id: str) -> Decimal:
+    validated = require_nonempty("token_id", token_id)
+    data = ctx.clob.get_json("/tick-size", params={"token_id": validated})
     return _parse_tick_size(data)
 
 
@@ -141,5 +147,6 @@ __all__ = [
     "fetch_neg_risk",
     "fetch_platform_fee_info",
     "fetch_tick_size",
+    "fetch_tick_size_sync",
     "resolve_condition_by_token",
 ]

--- a/src/polymarket/_internal/actions/orders/market_data.py
+++ b/src/polymarket/_internal/actions/orders/market_data.py
@@ -38,9 +38,21 @@ async def fetch_neg_risk(ctx: AsyncClientContext, *, token_id: str) -> bool:
     return _parse_neg_risk(data)
 
 
+def fetch_neg_risk_sync(ctx: SyncClientContext, *, token_id: str) -> bool:
+    validated = require_nonempty("token_id", token_id)
+    data = ctx.clob.get_json("/neg-risk", params={"token_id": validated})
+    return _parse_neg_risk(data)
+
+
 async def resolve_condition_by_token(ctx: AsyncClientContext, *, token_id: TokenId) -> ConditionId:
     validated = require_nonempty("token_id", token_id)
     data = await ctx.clob.get_json(f"/markets-by-token/{validated}")
+    return _parse_condition_by_token(data)
+
+
+def resolve_condition_by_token_sync(ctx: SyncClientContext, *, token_id: TokenId) -> ConditionId:
+    validated = require_nonempty("token_id", token_id)
+    data = ctx.clob.get_json(f"/markets-by-token/{validated}")
     return _parse_condition_by_token(data)
 
 
@@ -52,6 +64,14 @@ async def fetch_platform_fee_info(
     return _parse_platform_fee_info(data)
 
 
+def fetch_platform_fee_info_sync(
+    ctx: SyncClientContext, *, condition_id: ConditionId
+) -> PlatformFeeInfo:
+    validated = require_nonempty("condition_id", condition_id)
+    data = ctx.clob.get_json(f"/clob-markets/{validated}")
+    return _parse_platform_fee_info(data)
+
+
 async def fetch_builder_fee_rates(ctx: AsyncClientContext, *, builder_code: str) -> BuilderFeeRates:
     validated = validate_builder_code(builder_code)
     if validated == BYTES32_ZERO:
@@ -59,6 +79,16 @@ async def fetch_builder_fee_rates(ctx: AsyncClientContext, *, builder_code: str)
             "builder_code must be a real builder; zero (0x000…000) represents no attribution."
         )
     data = await ctx.clob.get_json(f"/fees/builder-fees/{validated}")
+    return BuilderFeeRates.parse_response(data)
+
+
+def fetch_builder_fee_rates_sync(ctx: SyncClientContext, *, builder_code: str) -> BuilderFeeRates:
+    validated = validate_builder_code(builder_code)
+    if validated == BYTES32_ZERO:
+        raise UserInputError(
+            "builder_code must be a real builder; zero (0x000…000) represents no attribution."
+        )
+    data = ctx.clob.get_json(f"/fees/builder-fees/{validated}")
     return BuilderFeeRates.parse_response(data)
 
 
@@ -144,9 +174,13 @@ def _coerce_decimal(value: object, field: str) -> Decimal:
 __all__ = [
     "PlatformFeeInfo",
     "fetch_builder_fee_rates",
+    "fetch_builder_fee_rates_sync",
     "fetch_neg_risk",
+    "fetch_neg_risk_sync",
     "fetch_platform_fee_info",
+    "fetch_platform_fee_info_sync",
     "fetch_tick_size",
     "fetch_tick_size_sync",
     "resolve_condition_by_token",
+    "resolve_condition_by_token_sync",
 ]

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -22,6 +22,10 @@ class SyncClientContext:
 @dataclass(frozen=True, slots=True)
 class SyncSecureClientContext(SyncClientContext):
     signer: LocalAccount
+    credentials: ApiKeyCreds
+    secure_clob: SyncTransport
+    wallet: EvmAddress
+    wallet_type: WalletType
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/polymarket/clients/_transport.py
+++ b/src/polymarket/clients/_transport.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeAlias
 
 import httpx
 
@@ -16,6 +16,9 @@ from polymarket.errors import (
     TransportError,
     UnexpectedResponseError,
 )
+
+SyncHeaderResolver: TypeAlias = Callable[[str, str, str | None], Mapping[str, str]]
+HeaderResolver: TypeAlias = Callable[[str, str, str | None], Awaitable[Mapping[str, str]]]
 
 _DEFAULT_LIMITS = httpx.Limits(
     max_connections=100,
@@ -41,6 +44,7 @@ class SyncTransport:
         options: TransportOptions | None = None,
         logger: logging.Logger | None = None,
         client: httpx.Client | None = None,
+        header_resolver: SyncHeaderResolver | None = None,
     ) -> None:
         opts = options or TransportOptions()
         self._owns_client = client is None
@@ -52,14 +56,16 @@ class SyncTransport:
             event_hooks=dict(opts.event_hooks) if opts.event_hooks else None,
         )
         self._logger = logger
+        self._header_resolver = header_resolver
 
     def get_json(
         self,
         path: str,
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> Any:
-        response = self._request("GET", path, params=params)
+        response = self._request("GET", path, params=params, headers=headers)
         return _read_json(response)
 
     def get_bytes(
@@ -67,19 +73,42 @@ class SyncTransport:
         path: str,
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> bytes:
-        response = self._request("GET", path, params=params)
+        response = self._request("GET", path, params=params, headers=headers)
         return response.content
 
     def post_json(
         self,
         path: str,
         *,
-        json: object,
+        json: object | None = None,
         params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> Any:
-        response = self._request("POST", path, params=params, json=json)
+        response = self._request("POST", path, params=params, json=json, headers=headers)
         return _read_json(response)
+
+    def delete_json(
+        self,
+        path: str,
+        *,
+        json: object | None = None,
+        params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        response = self._request("DELETE", path, params=params, json=json, headers=headers)
+        return _read_json(response)
+
+    def delete(
+        self,
+        path: str,
+        *,
+        json: object | None = None,
+        params: Mapping[str, QueryParamValue | None] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self._request("DELETE", path, params=params, json=json, headers=headers)
 
     def close(self) -> None:
         if self._owns_client:
@@ -92,10 +121,30 @@ class SyncTransport:
         *,
         params: Mapping[str, QueryParamValue | None] | None = None,
         json: object | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> httpx.Response:
+        body_str: str | None = None
+        content: bytes | None = None
+        merged_headers: dict[str, str] = dict(headers) if headers else {}
+
+        if json is not None:
+            body_str = _json.dumps(json, separators=(",", ":"))
+            content = body_str.encode("utf-8")
+            merged_headers.setdefault("Content-Type", "application/json")
+
+        if self._header_resolver is not None:
+            resolved = self._header_resolver(method, path, body_str)
+            merged_headers.update(resolved)
+
         started = time.perf_counter()
         try:
-            response = self._client.request(method, path, params=_clean_params(params), json=json)
+            response = self._client.request(
+                method,
+                path,
+                params=_clean_params(params),
+                content=content,
+                headers=merged_headers or None,
+            )
         except httpx.HTTPError as error:
             _log_failure(self._logger, method, path, error, started)
             raise TransportError(str(error) or "Request failed") from error
@@ -103,9 +152,6 @@ class SyncTransport:
         _log_response(self._logger, method, path, response, started)
         _raise_for_response_status(response)
         return response
-
-
-HeaderResolver = Callable[[str, str, str | None], Awaitable[Mapping[str, str]]]
 
 
 class AsyncTransport:

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -2,11 +2,14 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
+from polymarket._internal.actions import rewards as _rewards_actions
 from polymarket._internal.actions.data import (
     ActivitySortBy,
     ActivityTypeFilter,
@@ -23,6 +26,10 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
+from polymarket._internal.actions.orders.estimate import (
+    estimate_market_price_sync as _estimate_market_price_sync,
+)
+from polymarket._internal.actions.orders.types import MarketOrderType
 from polymarket._internal.context import SyncClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -36,7 +43,14 @@ from polymarket.errors import RequestRejectedError
 from polymarket.models import (
     Comment,
     Event,
+    LastTradePrice,
+    LastTradePriceForToken,
     Market,
+    OrderBook,
+    OrderSide,
+    PriceHistoryInterval,
+    PriceHistoryPoint,
+    PriceRequest,
     PublicProfile,
     RelatedTag,
     SearchResults,
@@ -47,6 +61,7 @@ from polymarket.models import (
     TagReference,
     Team,
 )
+from polymarket.models.clob.rewards import CurrentReward, MarketReward
 from polymarket.models.data import (
     Activity,
     BuilderVolumeEntry,
@@ -66,7 +81,8 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.pagination import Paginator
+from polymarket.models.types import ConditionId
+from polymarket.pagination import Page, Paginator
 
 
 class PublicClient:
@@ -737,3 +753,107 @@ class PublicClient:
             sort=sort,
         )
         return sync_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
+
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
+        return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
+
+    def get_price(self, *, token_id: str, side: OrderSide) -> Decimal:
+        path, params = _clob_actions.build_price_request(token_id=token_id, side=side)
+        return _clob_actions.parse_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_prices(
+        self, *, requests: Sequence[PriceRequest]
+    ) -> dict[str, dict[OrderSide, Decimal]]:
+        path, body = _clob_actions.build_prices_request(requests=requests)
+        return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_order_book(self, *, token_id: str) -> OrderBook:
+        path, params = _clob_actions.build_order_book_request(token_id=token_id)
+        return _clob_actions.parse_order_book(self._ctx.clob.get_json(path, params=params))
+
+    def get_order_books(self, *, token_ids: Sequence[str]) -> tuple[OrderBook, ...]:
+        path, body = _clob_actions.build_order_books_request(token_ids=token_ids)
+        return _clob_actions.parse_order_books(self._ctx.clob.post_json(path, json=body))
+
+    def get_spread(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_spread_request(token_id=token_id)
+        return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
+
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
+        return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
+
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+        path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
+        return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_last_trade_prices(
+        self, *, token_ids: Sequence[str]
+    ) -> tuple[LastTradePriceForToken, ...]:
+        path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
+        return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_price_history(
+        self,
+        *,
+        token_id: str,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+        fidelity: int | None = None,
+        interval: PriceHistoryInterval | None = None,
+    ) -> tuple[PriceHistoryPoint, ...]:
+        path, params = _clob_actions.build_price_history_request(
+            token_id=token_id,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fidelity=fidelity,
+            interval=interval,
+        )
+        return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
+
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal:
+        return _estimate_market_price_sync(
+            self._ctx,
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            order_type=order_type,
+        )
+
+    def list_current_rewards(self, *, sponsored: bool | None = None) -> Paginator[CurrentReward]:
+        def fetch(cursor: str | None) -> Page[CurrentReward]:
+            path, params = _rewards_actions.build_list_current_rewards_request(
+                sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_current_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def list_market_rewards(
+        self, *, condition_id: str, sponsored: bool | None = None
+    ) -> Paginator[MarketReward]:
+        def fetch(cursor: str | None) -> Page[MarketReward]:
+            path, params = _rewards_actions.build_list_market_rewards_request(
+                condition_id=ConditionId(condition_id), sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_market_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1,14 +1,18 @@
 """Synchronous secure Polymarket client."""
 
 import logging
-from collections.abc import Sequence
+import time
+from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import Self, cast
+from typing import TYPE_CHECKING, Self, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from eth_utils.address import to_checksum_address
 
+from polymarket._internal.actions import account as _account_actions
+from polymarket._internal.actions import auth as _auth_actions
 from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
@@ -29,10 +33,29 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
+from polymarket._internal.actions.orders import cancel as _cancel_actions
+from polymarket._internal.actions.orders import post as _post_actions
+from polymarket._internal.actions.orders.allowance import ensure_order_allowance_sync
 from polymarket._internal.actions.orders.estimate import (
     estimate_market_price_sync as _estimate_market_price_sync,
 )
-from polymarket._internal.actions.orders.types import MarketOrderType
+from polymarket._internal.actions.orders.limit import (
+    prepare_limit_order_draft_sync,
+    validate_limit_order_params,
+)
+from polymarket._internal.actions.orders.market import (
+    prepare_market_order_draft_sync,
+    validate_market_order_params,
+)
+from polymarket._internal.actions.orders.orders import (
+    create_signed_order,
+    create_unsigned_order,
+)
+from polymarket._internal.actions.orders.typed_data import (
+    build_order_signature,
+    build_order_typed_data,
+)
+from polymarket._internal.actions.orders.types import OrderDraft
 from polymarket._internal.context import SyncSecureClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -40,15 +63,25 @@ from polymarket._internal.dispatch import (
     sync_paginate_offset,
     sync_paginate_page_based,
 )
-from polymarket.clients._transport import SyncTransport
+from polymarket._internal.hmac import build_hmac_signature
+from polymarket._internal.l1_auth import sign_api_key_auth
+from polymarket._internal.wallet import WalletType, classify_wallet_type, signature_type_for
+from polymarket.clients._transport import SyncHeaderResolver, SyncTransport
 from polymarket.environments import PRODUCTION, Environment
-from polymarket.errors import RequestRejectedError, UserInputError
+from polymarket.errors import RequestRejectedError, SigningError, UserInputError
 from polymarket.models import (
+    ApiKeyCreds,
+    AssetType,
+    BalanceAllowance,
+    BuilderFeeRates,
+    ClobTrade,
     Comment,
     Event,
     LastTradePrice,
     LastTradePriceForToken,
     Market,
+    Notification,
+    OpenOrder,
     OrderBook,
     OrderSide,
     PriceHistoryInterval,
@@ -64,7 +97,17 @@ from polymarket.models import (
     TagReference,
     Team,
 )
-from polymarket.models.clob.rewards import CurrentReward, MarketReward
+from polymarket.models.clob.cancel import CancelOrdersResponse
+from polymarket.models.clob.order_response import OrderResponse
+from polymarket.models.clob.orders import MarketOrderType, SignedOrder
+from polymarket.models.clob.rewards import (
+    CurrentReward,
+    MarketReward,
+    RewardsPercentages,
+    TotalUserEarning,
+    UserEarning,
+    UserRewardsEarning,
+)
 from polymarket.models.data import (
     Activity,
     BuilderVolumeEntry,
@@ -86,67 +129,142 @@ from polymarket.models.data import (
 )
 from polymarket.models.types import ConditionId
 from polymarket.pagination import Page, Paginator
+from polymarket.types import EvmAddress, HexString
+
+if TYPE_CHECKING:
+    from polymarket.clients.public import PublicClient
 
 _CREATE_TOKEN = object()
+
+
+def _validate_nonce(nonce: object) -> None:
+    if isinstance(nonce, bool) or not isinstance(nonce, int):
+        raise UserInputError("nonce must be a non-negative integer.")
+    if nonce < 0:
+        raise UserInputError("nonce must be a non-negative integer.")
 
 
 class SecureClient:
     def __init__(
         self,
         *,
-        private_key: str,
-        environment: Environment = PRODUCTION,
-        logger: logging.Logger | None = None,
+        ctx: SyncSecureClientContext,
         _create_token: object | None = None,
+        logger: logging.Logger | None = None,
     ) -> None:
         if _create_token is not _CREATE_TOKEN:
             raise RuntimeError("Use SecureClient.create(...) to create a secure client")
-        if not private_key:
-            raise UserInputError("private_key is required")
+        self._ended = False
+        self._ctx_inner = ctx
+        self._logger = logger
 
-        try:
-            signer = cast(LocalAccount, Account.from_key(private_key))
-        except (ValueError, TypeError) as error:
-            raise UserInputError(f"Invalid private_key: {error}") from error
+    @property
+    def _ctx(self) -> SyncSecureClientContext:
+        if self._ended:
+            raise RuntimeError(
+                "SecureClient has ended authentication; use the returned PublicClient "
+                "or create a new SecureClient."
+            )
+        return self._ctx_inner
 
-        self._ctx = SyncSecureClientContext(
-            environment=environment,
-            gamma=SyncTransport(base_url=environment.gamma_url, logger=logger),
-            data=SyncTransport(base_url=environment.data_url, logger=logger),
-            clob=SyncTransport(base_url=environment.clob_url, logger=logger),
-            signer=signer,
-        )
+    @_ctx.setter
+    def _ctx(self, value: SyncSecureClientContext) -> None:
+        self._ctx_inner = value
 
     @classmethod
     def create(
         cls,
         *,
         private_key: str,
+        wallet: str,
         environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        nonce: int = 0,
+        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
-        client = cls(
-            private_key=private_key,
-            environment=environment,
-            logger=logger,
-            _create_token=_CREATE_TOKEN,
-        )
+        if not private_key:
+            raise UserInputError("private_key is required")
+        if not wallet:
+            raise UserInputError(
+                "wallet is required. Pass the signer address itself to authenticate as an EOA."
+            )
+        _validate_nonce(nonce)
+        if credentials is not None and nonce != 0:
+            raise UserInputError("nonce cannot be combined with credentials.")
         try:
-            return client._login()
+            signer = cast(LocalAccount, Account.from_key(private_key))
+        except (ValueError, TypeError) as error:
+            raise UserInputError(f"Invalid private_key: {error}") from error
+
+        try:
+            wallet_checksum = to_checksum_address(wallet)
+        except ValueError as error:
+            raise UserInputError(f"Invalid wallet address: {error}") from error
+        wallet_type = classify_wallet_type(
+            signer=signer.address,
+            wallet=wallet_checksum,
+            config=environment.wallet_derivation,
+        )
+        branded_wallet = cast(EvmAddress, wallet_checksum)
+
+        gamma = SyncTransport(base_url=environment.gamma_url, logger=logger)
+        data = SyncTransport(base_url=environment.data_url, logger=logger)
+        clob = SyncTransport(base_url=environment.clob_url, logger=logger)
+
+        try:
+            resolved_credentials = _bootstrap_credentials_sync(
+                environment=environment,
+                signer=signer,
+                clob=clob,
+                provided=credentials,
+                nonce=nonce,
+                validate=validate_credentials,
+                logger=logger,
+            )
+            secure_clob = SyncTransport(
+                base_url=environment.clob_url,
+                logger=logger,
+                header_resolver=_make_l2_header_resolver_sync(signer, resolved_credentials),
+            )
         except BaseException:
-            client.close()
+            gamma.close()
+            data.close()
+            clob.close()
             raise
 
-    def _login(self) -> Self:
-        return self
+        ctx = SyncSecureClientContext(
+            environment=environment,
+            gamma=gamma,
+            data=data,
+            clob=clob,
+            signer=signer,
+            credentials=resolved_credentials,
+            secure_clob=secure_clob,
+            wallet=branded_wallet,
+            wallet_type=wallet_type,
+        )
+        return cls(ctx=ctx, _create_token=_CREATE_TOKEN, logger=logger)
 
     @property
     def environment(self) -> Environment:
         return self._ctx.environment
 
     @property
-    def wallet(self) -> str:
-        return self._ctx.signer.address
+    def wallet(self) -> EvmAddress:
+        return self._ctx.wallet
+
+    @property
+    def signer(self) -> EvmAddress:
+        return cast(EvmAddress, self._ctx.signer.address)
+
+    @property
+    def wallet_type(self) -> WalletType:
+        return self._ctx.wallet_type
+
+    @property
+    def credentials(self) -> ApiKeyCreds:
+        return self._ctx.credentials
 
     def __enter__(self) -> Self:
         return self
@@ -161,16 +279,20 @@ class SecureClient:
 
     def close(self) -> None:
         """Close the underlying network transports."""
+        ctx = self._ctx_inner
         try:
-            self._ctx.gamma.close()
+            ctx.gamma.close()
         finally:
             try:
-                self._ctx.data.close()
+                ctx.data.close()
             finally:
-                self._ctx.clob.close()
+                try:
+                    ctx.clob.close()
+                finally:
+                    ctx.secure_clob.close()
 
-    def _user_or_signer(self, user: str | None) -> str:
-        return self._ctx.signer.address if user is None else user
+    def _user_or_wallet(self, user: str | None) -> str:
+        return self._ctx.wallet if user is None else user
 
     def get_market(
         self,
@@ -333,13 +455,13 @@ class SecureClient:
     ) -> tuple[PortfolioValue, ...]:
         return sync_dispatch(
             self._ctx,
-            _data_actions.get_portfolio_values_spec(user=self._user_or_signer(user), market=market),
+            _data_actions.get_portfolio_values_spec(user=self._user_or_wallet(user), market=market),
         )
 
     def get_traded_market_count(self, *, user: str | None = None) -> TradedMarketCount:
         return sync_dispatch(
             self._ctx,
-            _data_actions.get_traded_market_count_spec(user=self._user_or_signer(user)),
+            _data_actions.get_traded_market_count_spec(user=self._user_or_wallet(user)),
         )
 
     def get_builder_volumes(
@@ -364,7 +486,7 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[Position]:
         spec = _data_actions.list_positions_spec(
-            user=self._user_or_signer(user),
+            user=self._user_or_wallet(user),
             market=market,
             event_id=event_id,
             size_threshold=size_threshold,
@@ -388,7 +510,7 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[ClosedPosition]:
         spec = _data_actions.list_closed_positions_spec(
-            user=self._user_or_signer(user),
+            user=self._user_or_wallet(user),
             market=market,
             event_id=event_id,
             title=title,
@@ -429,7 +551,7 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[Trade]:
         spec = _data_actions.list_trades_spec(
-            user=self._user_or_signer(user),
+            user=self._user_or_wallet(user),
             market=market,
             event_id=event_id,
             side=side,
@@ -454,7 +576,7 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[Activity]:
         spec = _data_actions.list_activity_spec(
-            user=self._user_or_signer(user),
+            user=self._user_or_wallet(user),
             market=market,
             event_id=event_id,
             activity_types=activity_types,
@@ -477,7 +599,7 @@ class SecureClient:
 
     def download_accounting_snapshot(self, *, user: str | None = None) -> bytes:
         path, params = _data_actions.build_accounting_snapshot_request(
-            user=self._user_or_signer(user)
+            user=self._user_or_wallet(user)
         )
         return self._ctx.data.get_bytes(path, params=params)
 
@@ -897,3 +1019,437 @@ class SecureClient:
             )
 
         return Paginator(fetch=fetch)
+
+    def fetch_api_keys(self) -> tuple[str, ...]:
+        return _auth_actions.fetch_api_keys_sync(self._ctx.secure_clob)
+
+    def delete_api_key(self) -> None:
+        _auth_actions.delete_api_key_sync(self._ctx.secure_clob)
+
+    def end_authentication(self) -> "PublicClient":
+        from polymarket.clients.public import PublicClient
+
+        environment = self._ctx.environment
+        try:
+            self.delete_api_key()
+        except RequestRejectedError as error:
+            if error.status not in (401, 404):
+                raise
+        finally:
+            self.close()
+            self._ended = True
+        return PublicClient(environment=environment)
+
+    def get_closed_only_mode(self) -> bool:
+        path, params = _account_actions.build_closed_only_mode_request()
+        return _account_actions.parse_closed_only_mode(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def list_open_orders(
+        self,
+        *,
+        token_id: str | None = None,
+        id: str | None = None,
+        market: str | None = None,
+    ) -> Paginator[OpenOrder]:
+        def fetch(cursor: str | None) -> Page[OpenOrder]:
+            path, params = _account_actions.build_list_open_orders_request(
+                token_id=token_id, id=id, market=market, cursor=cursor
+            )
+            payload = self._ctx.secure_clob.get_json(path, params=params)
+            return _account_actions.parse_open_orders_page(payload)
+
+        return Paginator(fetch=fetch)
+
+    def get_order(self, *, order_id: str) -> OpenOrder:
+        path, params = _account_actions.build_get_order_request(order_id=order_id)
+        return _account_actions.parse_open_order(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def list_account_trades(
+        self,
+        *,
+        token_id: str | None = None,
+        id: str | None = None,
+        market: str | None = None,
+        maker_address: str | None = None,
+        after: str | None = None,
+        before: str | None = None,
+    ) -> Paginator[ClobTrade]:
+        def fetch(cursor: str | None) -> Page[ClobTrade]:
+            path, params = _account_actions.build_list_account_trades_request(
+                token_id=token_id,
+                id=id,
+                market=market,
+                maker_address=maker_address,
+                after=after,
+                before=before,
+                cursor=cursor,
+            )
+            payload = self._ctx.secure_clob.get_json(path, params=params)
+            return _account_actions.parse_account_trades_page(payload)
+
+        return Paginator(fetch=fetch)
+
+    def get_notifications(self) -> tuple[Notification, ...]:
+        path, params = _account_actions.build_notifications_request(
+            signature_type=signature_type_for(self._ctx.wallet_type)
+        )
+        return _account_actions.parse_notifications(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def drop_notifications(self, *, ids: Sequence[int | str]) -> None:
+        path, params = _account_actions.build_drop_notifications_request(
+            ids=ids, signature_type=signature_type_for(self._ctx.wallet_type)
+        )
+        self._ctx.secure_clob.delete(path, params=params)
+
+    def get_balance_allowance(
+        self, *, asset_type: AssetType, token_id: str | None = None
+    ) -> BalanceAllowance:
+        path, params = _account_actions.build_balance_allowance_request(
+            asset_type=asset_type,
+            token_id=token_id,
+            signature_type=signature_type_for(self._ctx.wallet_type),
+        )
+        return _account_actions.parse_balance_allowance(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def create_limit_order(
+        self,
+        *,
+        token_id: str,
+        price: Decimal | int | float | str,
+        size: Decimal | int | float | str,
+        side: OrderSide,
+        post_only: bool = False,
+        expiration: int | None = None,
+        builder_code: str | None = None,
+    ) -> SignedOrder:
+        return self._prepare_and_sign_limit_order(
+            token_id=token_id,
+            price=price,
+            size=size,
+            side=side,
+            post_only=post_only,
+            expiration=expiration,
+            builder_code=builder_code,
+        )
+
+    def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder:
+        return self._prepare_and_sign_market_order(
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            max_spend=max_spend,
+            order_type=order_type,
+            builder_code=builder_code,
+        )
+
+    def place_limit_order(
+        self,
+        *,
+        token_id: str,
+        price: Decimal | int | float | str,
+        size: Decimal | int | float | str,
+        side: OrderSide,
+        post_only: bool = False,
+        expiration: int | None = None,
+        builder_code: str | None = None,
+    ) -> OrderResponse:
+        signed = self._prepare_and_sign_limit_order(
+            token_id=token_id,
+            price=price,
+            size=size,
+            side=side,
+            post_only=post_only,
+            expiration=expiration,
+            builder_code=builder_code,
+        )
+        return self.post_order(signed)
+
+    def place_market_order(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> OrderResponse:
+        signed = self._prepare_and_sign_market_order(
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            max_spend=max_spend,
+            order_type=order_type,
+            builder_code=builder_code,
+        )
+        return self.post_order(signed)
+
+    def get_builder_fee_rates(self, builder_code: str) -> BuilderFeeRates:
+        from polymarket._internal.actions.orders.market_data import fetch_builder_fee_rates_sync
+
+        return fetch_builder_fee_rates_sync(self._ctx, builder_code=builder_code)
+
+    def post_order(self, signed_order: SignedOrder) -> OrderResponse:
+        path, payload = _post_actions.build_post_order_request(
+            signed_order, owner_api_key=self._ctx.credentials.key
+        )
+        return _post_actions.parse_order_response(
+            self._ctx.secure_clob.post_json(path, json=payload)
+        )
+
+    def post_orders(self, signed_orders: Sequence[SignedOrder]) -> tuple[OrderResponse, ...]:
+        path, payload = _post_actions.build_post_orders_request(
+            signed_orders, owner_api_key=self._ctx.credentials.key
+        )
+        return _post_actions.parse_order_responses(
+            self._ctx.secure_clob.post_json(path, json=payload)
+        )
+
+    def cancel_order(self, *, order_id: str) -> CancelOrdersResponse:
+        path, body = _cancel_actions.build_cancel_order_request(order_id=order_id)
+        return _cancel_actions.parse_cancel_orders_response(
+            self._ctx.secure_clob.delete_json(path, json=body)
+        )
+
+    def cancel_orders(self, *, order_ids: Sequence[str]) -> CancelOrdersResponse:
+        path, body = _cancel_actions.build_cancel_orders_request(order_ids=order_ids)
+        return _cancel_actions.parse_cancel_orders_response(
+            self._ctx.secure_clob.delete_json(path, json=body)
+        )
+
+    def cancel_all(self) -> CancelOrdersResponse:
+        path, body = _cancel_actions.build_cancel_all_request()
+        return _cancel_actions.parse_cancel_orders_response(
+            self._ctx.secure_clob.delete_json(path, json=body)
+        )
+
+    def cancel_market_orders(
+        self, *, market: str | None = None, token_id: str | None = None
+    ) -> CancelOrdersResponse:
+        path, body = _cancel_actions.build_cancel_market_orders_request(
+            market=market, token_id=token_id
+        )
+        return _cancel_actions.parse_cancel_orders_response(
+            self._ctx.secure_clob.delete_json(path, json=body)
+        )
+
+    def _prepare_and_sign_limit_order(
+        self,
+        *,
+        token_id: str,
+        price: Decimal | int | float | str,
+        size: Decimal | int | float | str,
+        side: OrderSide,
+        post_only: bool,
+        expiration: int | None,
+        builder_code: str | None,
+    ) -> SignedOrder:
+        params = validate_limit_order_params(
+            token_id=token_id,
+            price=price,
+            size=size,
+            side=side,
+            post_only=post_only,
+            expiration=expiration,
+            builder_code=builder_code,
+        )
+        draft = prepare_limit_order_draft_sync(self._ctx, params)
+        return self._sign_order(draft, post_only=params.post_only)
+
+    def _prepare_and_sign_market_order(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None,
+        shares: Decimal | int | float | str | None,
+        max_spend: Decimal | int | float | str | None,
+        order_type: MarketOrderType,
+        builder_code: str | None,
+    ) -> SignedOrder:
+        params = validate_market_order_params(
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            max_spend=max_spend,
+            order_type=order_type,
+            builder_code=builder_code,
+        )
+        draft = prepare_market_order_draft_sync(self._ctx, params)
+        return self._sign_order(draft, post_only=False)
+
+    def _sign_order(self, draft: OrderDraft, *, post_only: bool) -> SignedOrder:
+        ensure_order_allowance_sync(self._ctx, draft)
+        unsigned = create_unsigned_order(
+            draft, wallet=self._ctx.wallet, wallet_type=self._ctx.wallet_type
+        )
+        typed_data = build_order_typed_data(unsigned)
+        try:
+            signed_message = self._ctx.signer.sign_typed_data(full_message=typed_data)
+        except Exception as error:
+            raise SigningError(f"Failed to sign order: {error}") from error
+        raw_hex = signed_message.signature.hex()
+        signature_hex = HexString(raw_hex if raw_hex.startswith("0x") else "0x" + raw_hex)
+        final_signature = build_order_signature(unsigned, signature_hex)
+        return create_signed_order(unsigned, final_signature, post_only=post_only)
+
+    def get_order_scoring(self, *, order_id: str) -> bool:
+        path, params = _rewards_actions.build_get_order_scoring_request(order_id=order_id)
+        return _rewards_actions.parse_order_scoring(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def get_orders_scoring(self, *, order_ids: Sequence[str]) -> dict[str, bool]:
+        path, body = _rewards_actions.build_get_orders_scoring_request(order_ids=order_ids)
+        return _rewards_actions.parse_orders_scoring(
+            self._ctx.secure_clob.post_json(path, json=body)
+        )
+
+    def list_user_earnings_for_day(self, *, date: str) -> Paginator[UserEarning]:
+        def fetch(cursor: str | None) -> Page[UserEarning]:
+            path, params = _rewards_actions.build_list_user_earnings_for_day_request(
+                date=date,
+                signature_type=signature_type_for(self._ctx.wallet_type),
+                cursor=cursor,
+            )
+            return _rewards_actions.parse_user_earnings_page(
+                self._ctx.secure_clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def get_total_earnings_for_user_for_day(self, *, date: str) -> tuple[TotalUserEarning, ...]:
+        path, params = _rewards_actions.build_total_user_earnings_for_day_request(
+            date=date, signature_type=signature_type_for(self._ctx.wallet_type)
+        )
+        return _rewards_actions.parse_total_user_earnings(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+    def list_user_earnings_and_markets_config(
+        self,
+        *,
+        date: str,
+        no_competition: bool | None = None,
+        order_by: str | None = None,
+        position: str | None = None,
+        page_size: int | None = None,
+    ) -> Paginator[UserRewardsEarning]:
+        def fetch(cursor: str | None) -> Page[UserRewardsEarning]:
+            path, params = _rewards_actions.build_list_user_earnings_and_markets_config_request(
+                date=date,
+                signature_type=signature_type_for(self._ctx.wallet_type),
+                no_competition=no_competition,
+                order_by=order_by,
+                position=position,
+                page_size=page_size,
+                cursor=cursor,
+            )
+            return _rewards_actions.parse_user_rewards_earnings_page(
+                self._ctx.secure_clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def get_reward_percentages(self) -> RewardsPercentages:
+        path, params = _rewards_actions.build_get_reward_percentages_request(
+            signature_type=signature_type_for(self._ctx.wallet_type)
+        )
+        return _rewards_actions.parse_reward_percentages(
+            self._ctx.secure_clob.get_json(path, params=params)
+        )
+
+
+def _bootstrap_credentials_sync(
+    *,
+    environment: Environment,
+    signer: LocalAccount,
+    clob: SyncTransport,
+    provided: ApiKeyCreds | None,
+    nonce: int,
+    validate: bool,
+    logger: logging.Logger | None,
+) -> ApiKeyCreds:
+    if provided is not None and (
+        not validate
+        or _credentials_are_active_sync(
+            environment=environment,
+            signer=signer,
+            credentials=provided,
+            logger=logger,
+        )
+    ):
+        return provided
+
+    signature = sign_api_key_auth(
+        signer, chain_id=environment.chain_id, timestamp=int(time.time()), nonce=nonce
+    )
+    return _auth_actions.create_or_derive_api_key_sync(clob, signature)
+
+
+def _credentials_are_active_sync(
+    *,
+    environment: Environment,
+    signer: LocalAccount,
+    credentials: ApiKeyCreds,
+    logger: logging.Logger | None,
+) -> bool:
+    probe = SyncTransport(
+        base_url=environment.clob_url,
+        logger=logger,
+        header_resolver=_make_l2_header_resolver_sync(signer, credentials),
+    )
+    try:
+        keys = _auth_actions.fetch_api_keys_sync(probe)
+    except RequestRejectedError as error:
+        if error.status == 401:
+            return False
+        raise
+    finally:
+        probe.close()
+    return credentials.key in keys
+
+
+def _make_l2_header_resolver_sync(
+    signer: LocalAccount, credentials: ApiKeyCreds
+) -> SyncHeaderResolver:
+    def resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
+        timestamp = int(time.time())
+        signature = build_hmac_signature(
+            secret=credentials.secret,
+            timestamp=timestamp,
+            method=method,
+            path=path,
+            body=body,
+        )
+        return {
+            "POLY_ADDRESS": signer.address,
+            "POLY_API_KEY": credentials.key,
+            "POLY_PASSPHRASE": credentials.passphrase,
+            "POLY_SIGNATURE": signature,
+            "POLY_TIMESTAMP": str(timestamp),
+        }
+
+    return resolver

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -2,14 +2,17 @@
 
 import logging
 from collections.abc import Sequence
+from decimal import Decimal
 from types import TracebackType
 from typing import Self, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
+from polymarket._internal.actions import clob as _clob_actions
 from polymarket._internal.actions import data as _data_actions
 from polymarket._internal.actions import gamma as _gamma_actions
+from polymarket._internal.actions import rewards as _rewards_actions
 from polymarket._internal.actions.data import (
     ActivitySortBy,
     ActivityTypeFilter,
@@ -26,6 +29,10 @@ from polymarket._internal.actions.gamma import (
     Recurrence,
     TagMatch,
 )
+from polymarket._internal.actions.orders.estimate import (
+    estimate_market_price_sync as _estimate_market_price_sync,
+)
+from polymarket._internal.actions.orders.types import MarketOrderType
 from polymarket._internal.context import SyncSecureClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -39,7 +46,14 @@ from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models import (
     Comment,
     Event,
+    LastTradePrice,
+    LastTradePriceForToken,
     Market,
+    OrderBook,
+    OrderSide,
+    PriceHistoryInterval,
+    PriceHistoryPoint,
+    PriceRequest,
     PublicProfile,
     RelatedTag,
     SearchResults,
@@ -50,6 +64,7 @@ from polymarket.models import (
     TagReference,
     Team,
 )
+from polymarket.models.clob.rewards import CurrentReward, MarketReward
 from polymarket.models.data import (
     Activity,
     BuilderVolumeEntry,
@@ -69,7 +84,8 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.pagination import Paginator
+from polymarket.models.types import ConditionId
+from polymarket.pagination import Page, Paginator
 
 _CREATE_TOKEN = object()
 
@@ -777,3 +793,107 @@ class SecureClient:
             sort=sort,
         )
         return sync_paginate_page_based(self._ctx, spec, page_size=page_size)
+
+    def get_midpoint(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_midpoint_request(token_id=token_id)
+        return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
+
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
+        return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
+
+    def get_price(self, *, token_id: str, side: OrderSide) -> Decimal:
+        path, params = _clob_actions.build_price_request(token_id=token_id, side=side)
+        return _clob_actions.parse_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_prices(
+        self, *, requests: Sequence[PriceRequest]
+    ) -> dict[str, dict[OrderSide, Decimal]]:
+        path, body = _clob_actions.build_prices_request(requests=requests)
+        return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_order_book(self, *, token_id: str) -> OrderBook:
+        path, params = _clob_actions.build_order_book_request(token_id=token_id)
+        return _clob_actions.parse_order_book(self._ctx.clob.get_json(path, params=params))
+
+    def get_order_books(self, *, token_ids: Sequence[str]) -> tuple[OrderBook, ...]:
+        path, body = _clob_actions.build_order_books_request(token_ids=token_ids)
+        return _clob_actions.parse_order_books(self._ctx.clob.post_json(path, json=body))
+
+    def get_spread(self, *, token_id: str) -> Decimal:
+        path, params = _clob_actions.build_spread_request(token_id=token_id)
+        return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
+
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+        path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
+        return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
+
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+        path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
+        return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
+
+    def get_last_trade_prices(
+        self, *, token_ids: Sequence[str]
+    ) -> tuple[LastTradePriceForToken, ...]:
+        path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
+        return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
+
+    def get_price_history(
+        self,
+        *,
+        token_id: str,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+        fidelity: int | None = None,
+        interval: PriceHistoryInterval | None = None,
+    ) -> tuple[PriceHistoryPoint, ...]:
+        path, params = _clob_actions.build_price_history_request(
+            token_id=token_id,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fidelity=fidelity,
+            interval=interval,
+        )
+        return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
+
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: OrderSide,
+        amount: Decimal | int | float | str | None = None,
+        shares: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal:
+        return _estimate_market_price_sync(
+            self._ctx,
+            token_id=token_id,
+            side=side,
+            amount=amount,
+            shares=shares,
+            order_type=order_type,
+        )
+
+    def list_current_rewards(self, *, sponsored: bool | None = None) -> Paginator[CurrentReward]:
+        def fetch(cursor: str | None) -> Page[CurrentReward]:
+            path, params = _rewards_actions.build_list_current_rewards_request(
+                sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_current_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)
+
+    def list_market_rewards(
+        self, *, condition_id: str, sponsored: bool | None = None
+    ) -> Paginator[MarketReward]:
+        def fetch(cursor: str | None) -> Page[MarketReward]:
+            path, params = _rewards_actions.build_list_market_rewards_request(
+                condition_id=ConditionId(condition_id), sponsored=sponsored, cursor=cursor
+            )
+            return _rewards_actions.parse_market_rewards_page(
+                self._ctx.clob.get_json(path, params=params)
+            )
+
+        return Paginator(fetch=fetch)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -45,7 +45,12 @@ def test_async_public_client_supports_context_manager() -> None:
 
 
 def test_secure_client_factory_uses_production_by_default() -> None:
-    client = SecureClient.create(private_key=PRIVATE_KEY)
+    client = SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
     try:
         assert client.environment.name == "production"
     finally:
@@ -53,12 +58,19 @@ def test_secure_client_factory_uses_production_by_default() -> None:
 
 
 def test_secure_client_requires_factory() -> None:
+    from polymarket._internal.context import SyncSecureClientContext
+
     with pytest.raises(RuntimeError, match="SecureClient.create"):
-        SecureClient(private_key=PRIVATE_KEY)
+        SecureClient(ctx=cast(SyncSecureClientContext, object()))
 
 
 def test_secure_client_supports_context_manager() -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         assert client.environment.name == "production"
 
 
@@ -98,7 +110,12 @@ def test_async_secure_client_supports_context_manager() -> None:
 
 
 def test_secure_client_exposes_signer_wallet() -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         assert client.wallet == PRIVATE_KEY_ADDRESS
 
 
@@ -120,7 +137,12 @@ def test_async_secure_client_exposes_signer_wallet() -> None:
 
 def test_secure_client_invalid_key_raises_user_input_error() -> None:
     with pytest.raises(UserInputError, match="Invalid private_key"):
-        SecureClient.create(private_key="not-a-valid-key")
+        SecureClient.create(private_key="not-a-valid-key", wallet=SIGNER_ADDRESS)
+
+
+def test_secure_client_requires_wallet() -> None:
+    with pytest.raises(UserInputError, match="wallet is required"):
+        SecureClient.create(private_key=PRIVATE_KEY, wallet="")
 
 
 def test_async_secure_client_invalid_key_raises_user_input_error() -> None:

--- a/tests/unit/test_client_request_params.py
+++ b/tests/unit/test_client_request_params.py
@@ -116,7 +116,12 @@ def test_async_public_list_trades_passes_event_id() -> None:
 
 def test_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync(client, _capture(captured))
         client.list_trades(event_id=[7]).first_page()
 
@@ -173,7 +178,12 @@ def test_async_public_list_activity_passes_event_id() -> None:
 
 def test_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync(client, _capture(captured))
         client.list_activity(event_id=[12, 13]).first_page()
 
@@ -218,7 +228,12 @@ def test_public_list_positions_passes_event_id() -> None:
 
 def test_secure_list_positions_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync(client, _capture(captured))
         client.list_positions(event_id=[5]).first_page()
 
@@ -244,7 +259,12 @@ def test_secure_list_trades_rejects_market_and_event_id_together() -> None:
     from polymarket.errors import UserInputError
 
     with (
-        SecureClient.create(private_key=PRIVATE_KEY) as client,
+        SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        ) as client,
         pytest.raises(UserInputError, match="Provide market or event_id"),
     ):
         client.list_trades(market=["0xM"], event_id=[1])

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -1,0 +1,375 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+import json
+from decimal import Decimal
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from polymarket import (
+    ApiKeyCreds,
+    LastTradePrice,
+    LastTradePriceForToken,
+    OrderBook,
+    PriceHistoryPoint,
+    PriceRequest,
+    PublicClient,
+    SecureClient,
+)
+from polymarket._internal.context import SyncSecureClientContext
+from polymarket.clients._transport import SyncTransport
+from polymarket.errors import InsufficientLiquidityError, UnexpectedResponseError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _clob_handler(captured: list[httpx.Request], payload: object) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _routed_handler(
+    captured: list[httpx.Request], routes: dict[str, object]
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path in routes:
+            return httpx.Response(200, json=routes[path], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_sync_clob(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = cast(SyncSecureClientContext, dataclasses.replace(client._ctx, clob=transport))
+
+
+def _body(request: httpx.Request) -> object:
+    return json.loads(request.content)
+
+
+def _secure_client() -> SecureClient:
+    return SecureClient.create(private_key=PRIVATE_KEY)
+
+
+class TestGetMidpoint:
+    def test_public_hits_clob_midpoint_with_token_id(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"mid": "0.5125"}))
+            result = client.get_midpoint(token_id="8501497")
+
+        assert result == Decimal("0.5125")
+        assert len(captured) == 1
+        parsed = urlparse(str(captured[0].url))
+        assert captured[0].method == "GET"
+        assert parsed.path == "/midpoint"
+        assert parse_qs(parsed.query) == {"token_id": ["8501497"]}
+
+    def test_secure_uses_same_clob_endpoint(self) -> None:
+        captured: list[httpx.Request] = []
+        with _secure_client() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"mid": "0.42"}))
+            result = client.get_midpoint(token_id="99")
+
+        assert result == Decimal("0.42")
+        assert urlparse(str(captured[0].url)).path == "/midpoint"
+
+    def test_propagates_malformed_response_error(self) -> None:
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler([], {"unexpected": "shape"}))
+            with pytest.raises(UnexpectedResponseError):
+                client.get_midpoint(token_id="1")
+
+
+class TestGetMidpoints:
+    def test_posts_token_ids_to_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"1": "0.5", "2": "0.4"}))
+            result = client.get_midpoints(token_ids=["1", "2"])
+
+        assert result == {"1": Decimal("0.5"), "2": Decimal("0.4")}
+        assert captured[0].method == "POST"
+        assert urlparse(str(captured[0].url)).path == "/midpoints"
+        assert _body(captured[0]) == [{"token_id": "1"}, {"token_id": "2"}]
+
+
+class TestGetPrice:
+    def test_includes_token_id_and_side(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"price": "0.52"}))
+            result = client.get_price(token_id="123", side="BUY")
+
+        assert result == Decimal("0.52")
+        parsed = urlparse(str(captured[0].url))
+        assert parsed.path == "/price"
+        assert parse_qs(parsed.query) == {"token_id": ["123"], "side": ["BUY"]}
+
+
+class TestGetPrices:
+    def test_posts_token_id_and_side(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: dict[str, dict[str, str]] = {
+            "tok-1": {"BUY": "0.50", "SELL": "0.51"},
+            "tok-2": {"BUY": "0.30"},
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            result = client.get_prices(
+                requests=[
+                    PriceRequest(token_id="tok-1", side="BUY"),
+                    PriceRequest(token_id="tok-1", side="SELL"),
+                    PriceRequest(token_id="tok-2", side="BUY"),
+                ]
+            )
+
+        assert result["tok-1"]["BUY"] == Decimal("0.50")
+        assert urlparse(str(captured[0].url)).path == "/prices"
+        assert captured[0].method == "POST"
+
+
+class TestGetOrderBook:
+    def test_returns_parsed_model(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(
+                    captured,
+                    {
+                        "asset_id": "1",
+                        "market": "0xM",
+                        "bids": [],
+                        "asks": [{"price": "0.5", "size": "10"}],
+                        "min_order_size": "1",
+                        "tick_size": "0.01",
+                        "neg_risk": False,
+                        "hash": "0xhash",
+                        "timestamp": "0",
+                    },
+                ),
+            )
+            book = client.get_order_book(token_id="1")
+
+        assert isinstance(book, OrderBook)
+        assert urlparse(str(captured[0].url)).path == "/book"
+
+
+class TestGetOrderBooks:
+    def test_posts_token_ids(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: list[dict[str, object]] = [
+            {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            }
+        ]
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            books = client.get_order_books(token_ids=["1"])
+
+        assert len(books) == 1
+        assert captured[0].method == "POST"
+        assert urlparse(str(captured[0].url)).path == "/books"
+        assert _body(captured[0]) == [{"token_id": "1"}]
+
+
+class TestGetSpread:
+    def test_returns_decimal(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"spread": "0.02"}))
+            spread = client.get_spread(token_id="1")
+
+        assert spread == Decimal("0.02")
+        assert urlparse(str(captured[0].url)).path == "/spread"
+
+
+class TestGetSpreads:
+    def test_posts_token_ids(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"1": "0.02", "2": "0.03"}))
+            spreads = client.get_spreads(token_ids=["1", "2"])
+
+        assert spreads == {"1": Decimal("0.02"), "2": Decimal("0.03")}
+        assert urlparse(str(captured[0].url)).path == "/spreads"
+
+
+class TestGetLastTradePrice:
+    def test_returns_model(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(captured, {"asset_id": "1", "price": "0.55", "side": "BUY"}),
+            )
+            ltp = client.get_last_trade_price(token_id="1")
+
+        assert isinstance(ltp, LastTradePrice)
+        assert urlparse(str(captured[0].url)).path == "/last-trade-price"
+
+
+class TestGetLastTradePrices:
+    def test_posts_token_ids_at_correct_path(self) -> None:
+        captured: list[httpx.Request] = []
+        payload: list[dict[str, str]] = [
+            {"token_id": "1", "price": "0.5", "side": "BUY"},
+        ]
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, payload))
+            result = client.get_last_trade_prices(token_ids=["1"])
+
+        assert len(result) == 1
+        assert isinstance(result[0], LastTradePriceForToken)
+        assert urlparse(str(captured[0].url)).path == "/last-trades-prices"
+        assert _body(captured[0]) == [{"token_id": "1"}]
+
+
+class TestGetPriceHistory:
+    def test_maps_token_id_to_market_param(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _clob_handler(captured, {"history": [{"t": 1700000000, "p": 0.5}]}),
+            )
+            result = client.get_price_history(token_id="abc")
+
+        assert len(result) == 1
+        assert isinstance(result[0], PriceHistoryPoint)
+        parsed = urlparse(str(captured[0].url))
+        assert parsed.path == "/prices-history"
+        assert parse_qs(parsed.query) == {"market": ["abc"]}
+
+    def test_preserves_camelcase_optional_params_on_wire(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(client, _clob_handler(captured, {"history": []}))
+            client.get_price_history(
+                token_id="abc",
+                start_ts=1700000000,
+                end_ts=1700001000,
+                fidelity=60,
+                interval="1d",
+            )
+
+        parsed = urlparse(str(captured[0].url))
+        qs = parse_qs(parsed.query)
+        assert qs["market"] == ["abc"]
+        assert qs["startTs"] == ["1700000000"]
+        assert qs["endTs"] == ["1700001000"]
+        assert qs["fidelity"] == ["60"]
+        assert qs["interval"] == ["1d"]
+
+
+class TestEstimateMarketPrice:
+    def test_buy_fetches_tick_size_and_book(self) -> None:
+        captured: list[httpx.Request] = []
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [{"price": "0.49", "size": "100"}],
+                "asks": [{"price": "0.50", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler(captured, routes))
+            price = client.estimate_market_price(token_id="1", side="BUY", amount=Decimal(2))
+
+        assert price == Decimal("0.50")
+        paths = [urlparse(str(r.url)).path for r in captured]
+        assert "/tick-size" in paths
+        assert "/book" in paths
+
+    def test_sell_uses_bids(self) -> None:
+        captured: list[httpx.Request] = []
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [{"price": "0.49", "size": "100"}],
+                "asks": [{"price": "0.50", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler(captured, routes))
+            price = client.estimate_market_price(token_id="1", side="SELL", shares=Decimal(1))
+
+        assert price == Decimal("0.49")
+
+    def test_fok_raises_on_insufficient_liquidity(self) -> None:
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [{"price": "0.50", "size": "1"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with PublicClient() as client:
+            _install_sync_clob(client, _routed_handler([], routes))
+            with pytest.raises(InsufficientLiquidityError):
+                client.estimate_market_price(
+                    token_id="1", side="BUY", amount=Decimal(1000), order_type="FOK"
+                )
+
+    def test_available_on_secure_client(self) -> None:
+        routes: dict[str, object] = {
+            "/tick-size": {"minimum_tick_size": 0.01},
+            "/book": {
+                "asset_id": "1",
+                "market": "0xM",
+                "bids": [],
+                "asks": [{"price": "0.5", "size": "100"}],
+                "min_order_size": "1",
+                "tick_size": "0.01",
+                "neg_risk": False,
+                "hash": "0xhash",
+                "timestamp": "0",
+            },
+        }
+        with _secure_client() as client:
+            _install_sync_clob(client, _routed_handler([], routes))
+            price = client.estimate_market_price(token_id="1", side="BUY", amount=Decimal(1))
+
+        assert price == Decimal("0.5")

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -23,6 +23,7 @@ from polymarket.clients._transport import SyncTransport
 from polymarket.errors import InsufficientLiquidityError, UnexpectedResponseError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
@@ -60,7 +61,12 @@ def _body(request: httpx.Request) -> object:
 
 
 def _secure_client() -> SecureClient:
-    return SecureClient.create(private_key=PRIVATE_KEY)
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
 
 
 class TestGetMidpoint:

--- a/tests/unit/test_rewards_transport_sync.py
+++ b/tests/unit/test_rewards_transport_sync.py
@@ -1,0 +1,149 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+from typing import Any, cast
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from polymarket import (
+    PublicClient,
+    SecureClient,
+)
+from polymarket._internal.context import SyncSecureClientContext
+from polymarket.clients._transport import SyncTransport
+from polymarket.models.clob.rewards import (
+    CurrentReward,
+    MarketReward,
+)
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+def _routed_handler(
+    captured: list[httpx.Request],
+    routes: dict[tuple[str, str], Any],
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        key = (request.method, path)
+        if key in routes:
+            return httpx.Response(200, json=routes[key], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_sync_clob(client: PublicClient | SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = cast(SyncSecureClientContext, dataclasses.replace(client._ctx, clob=transport))
+
+
+_CURRENT_REWARDS_PAGE: dict[str, Any] = {
+    "limit": 100,
+    "count": 1,
+    "next_cursor": "LTE=",
+    "data": [
+        {
+            "condition_id": "0xCONDITION",
+            "rewards_max_spread": 3.0,
+            "tokens": [],
+        }
+    ],
+}
+
+_MARKET_REWARDS_PAGE: dict[str, Any] = {
+    "limit": 100,
+    "count": 1,
+    "next_cursor": "LTE=",
+    "data": [
+        {
+            "condition_id": "0xCONDITION",
+            "question": "Q?",
+            "tokens": [{"token_id": "8501497", "outcome": "Yes", "price": "0.5"}],
+        }
+    ],
+}
+
+
+class TestListCurrentRewards:
+    def test_public_routes_to_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            page = client.list_current_rewards().first_page()
+
+        assert len(page.items) == 1
+        assert isinstance(page.items[0], CurrentReward)
+        assert captured[0].method == "GET"
+        assert urlparse(str(captured[0].url)).path == "/rewards/markets/current"
+        assert captured[0].headers.get("POLY_SIGNATURE") is None
+
+    def test_public_passes_sponsored_filter(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            client.list_current_rewards(sponsored=True).first_page()
+
+        qs = parse_qs(urlparse(str(captured[0].url)).query)
+        assert qs.get("sponsored") == ["true"]
+
+    def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured, {("GET", "/rewards/markets/current"): _CURRENT_REWARDS_PAGE}
+                ),
+            )
+            page = client.list_current_rewards().first_page()
+
+        assert len(page.items) == 1
+        assert captured[0].headers.get("POLY_SIGNATURE") is None
+
+
+class TestListMarketRewards:
+    def test_public_routes_with_condition_id_in_path(self) -> None:
+        captured: list[httpx.Request] = []
+        with PublicClient() as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured,
+                    {("GET", "/rewards/markets/0xCONDITION"): _MARKET_REWARDS_PAGE},
+                ),
+            )
+            page = client.list_market_rewards(condition_id="0xCONDITION").first_page()
+
+        assert len(page.items) == 1
+        assert isinstance(page.items[0], MarketReward)
+        assert urlparse(str(captured[0].url)).path == "/rewards/markets/0xCONDITION"
+
+    def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
+        captured: list[httpx.Request] = []
+        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+            _install_sync_clob(
+                client,
+                _routed_handler(
+                    captured,
+                    {("GET", "/rewards/markets/0xCONDITION"): _MARKET_REWARDS_PAGE},
+                ),
+            )
+            page = client.list_market_rewards(condition_id="0xCONDITION").first_page()
+
+        assert len(page.items) == 1
+        assert captured[0].headers.get("POLY_SIGNATURE") is None

--- a/tests/unit/test_rewards_transport_sync.py
+++ b/tests/unit/test_rewards_transport_sync.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 
 from polymarket import (
+    ApiKeyCreds,
     PublicClient,
     SecureClient,
 )
@@ -17,6 +18,8 @@ from polymarket.models.clob.rewards import (
 )
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 
 
 def _routed_handler(
@@ -103,7 +106,12 @@ class TestListCurrentRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+        with SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        ) as client:
             _install_sync_clob(
                 client,
                 _routed_handler(
@@ -135,7 +143,12 @@ class TestListMarketRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient.create(private_key=PRIVATE_KEY) as client:
+        with SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        ) as client:
             _install_sync_clob(
                 client,
                 _routed_handler(

--- a/tests/unit/test_secure_account_sync.py
+++ b/tests/unit/test_secure_account_sync.py
@@ -1,0 +1,255 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, SecureClient
+from polymarket._internal.actions.account import END_CURSOR
+from polymarket.clients._transport import SyncTransport
+from polymarket.errors import UserInputError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+_OPEN_ORDER_PAYLOAD: dict[str, Any] = {
+    "asset_id": "8501497",
+    "associate_trades": ["trade-1"],
+    "created_at": 1700000000000,
+    "expiration": 1800000000000,
+    "id": "order-1",
+    "maker_address": "0xMAKER",
+    "market": "0xMARKET",
+    "order_type": "GTC",
+    "original_size": "100",
+    "outcome": "Yes",
+    "owner": "0xOWNER",
+    "price": "0.5",
+    "side": "BUY",
+    "size_matched": "50",
+    "status": "LIVE",
+}
+
+_CLOB_TRADE_PAYLOAD: dict[str, Any] = {
+    "asset_id": "8501497",
+    "bucket_index": 7,
+    "fee_rate_bps": "10",
+    "id": "trade-1",
+    "last_update": 1700000010000,
+    "maker_address": "0xMAKER",
+    "maker_orders": [
+        {
+            "asset_id": "8501497",
+            "fee_rate_bps": "10",
+            "maker_address": "0xMAKER",
+            "matched_amount": "5",
+            "order_id": "order-1",
+            "outcome": "Yes",
+            "owner": "0xOWNER",
+            "price": "0.5",
+            "side": "BUY",
+        }
+    ],
+    "market": "0xMARKET",
+    "match_time": 1700000000000,
+    "outcome": "Yes",
+    "owner": "0xOWNER",
+    "price": "0.5",
+    "side": "BUY",
+    "size": "5",
+    "status": "MINED",
+    "taker_order_id": "order-2",
+    "trader_side": "TAKER",
+    "transaction_hash": "0xTX",
+}
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+
+
+def _assert_l2_headers(request: httpx.Request) -> None:
+    headers = request.headers
+    assert headers.get("POLY_ADDRESS")
+    assert headers.get("POLY_API_KEY") == FAKE_CREDS.key
+    assert headers.get("POLY_PASSPHRASE") == FAKE_CREDS.passphrase
+    assert headers.get("POLY_SIGNATURE")
+    assert headers.get("POLY_TIMESTAMP")
+
+
+def _make_client() -> SecureClient:
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_get_closed_only_mode_returns_bool_and_uses_l2_headers() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, {"closed_only": True}))
+        result = client.get_closed_only_mode()
+
+    assert result is True
+    request = captured[0]
+    assert request.method == "GET"
+    assert urlparse(str(request.url)).path == "/auth/ban-status/closed-only"
+    _assert_l2_headers(request)
+
+
+def test_list_open_orders_paginates_until_end_cursor() -> None:
+    captured: list[httpx.Request] = []
+    responses = iter(
+        [
+            {"data": [_OPEN_ORDER_PAYLOAD], "next_cursor": "cursor-2", "count": 2},
+            {
+                "data": [{**_OPEN_ORDER_PAYLOAD, "id": "order-2"}],
+                "next_cursor": END_CURSOR,
+                "count": 2,
+            },
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=next(responses), request=request)
+
+    with _make_client() as client:
+        _install_secure_clob(client, httpx.MockTransport(handler))
+        ids = [order.id for order in client.list_open_orders(market="0xMARKET").items()]
+
+    assert ids == ["order-1", "order-2"]
+    assert len(captured) == 2
+    assert urlparse(str(captured[0].url)).path == "/data/orders"
+    first_qs = parse_qs(urlparse(str(captured[0].url)).query)
+    assert first_qs.get("market") == ["0xMARKET"]
+    assert "next_cursor" not in first_qs
+    second_qs = parse_qs(urlparse(str(captured[1].url)).query)
+    assert second_qs.get("next_cursor") == ["cursor-2"]
+
+
+def test_get_order_targets_data_order_path() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, _OPEN_ORDER_PAYLOAD))
+        order = client.get_order(order_id="order-1")
+
+    assert order.id == "order-1"
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/data/order/order-1"
+    _assert_l2_headers(request)
+
+
+def test_list_account_trades_paginates_and_passes_filters() -> None:
+    captured: list[httpx.Request] = []
+    responses = iter(
+        [
+            {"data": [_CLOB_TRADE_PAYLOAD], "next_cursor": END_CURSOR, "count": 1},
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=next(responses), request=request)
+
+    with _make_client() as client:
+        _install_secure_clob(client, httpx.MockTransport(handler))
+        trades = [
+            t.id
+            for t in client.list_account_trades(market="0xMARKET", maker_address="0xMAKER").items()
+        ]
+
+    assert trades == ["trade-1"]
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/data/trades"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("market") == ["0xMARKET"]
+    assert qs.get("maker_address") == ["0xMAKER"]
+
+
+def test_get_notifications_includes_signature_type_for_eoa_wallet() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, []))
+        client.get_notifications()
+
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/notifications"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("signature_type") == ["0"]
+    _assert_l2_headers(request)
+
+
+def test_drop_notifications_uses_delete_with_comma_separated_ids() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, "OK"))
+        client.drop_notifications(ids=["a", "b"])
+
+    request = captured[0]
+    assert request.method == "DELETE"
+    assert urlparse(str(request.url)).path == "/notifications"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("ids") == ["a,b"]
+    assert qs.get("signature_type") == ["0"]
+
+
+def test_drop_notifications_rejects_empty_id_list() -> None:
+    with pytest.raises(UserInputError), _make_client() as client:
+        client.drop_notifications(ids=[])
+
+
+def test_get_balance_allowance_for_collateral_omits_token_id() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(
+            client,
+            _capture(captured, 200, {"balance": "1000", "allowances": {}}),
+        )
+        result = client.get_balance_allowance(asset_type="COLLATERAL")
+
+    assert result.balance == 1000
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/balance-allowance"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("asset_type") == ["COLLATERAL"]
+    assert qs.get("signature_type") == ["0"]
+    assert "token_id" not in qs
+
+
+def test_get_balance_allowance_for_conditional_includes_token_id() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(
+            client,
+            _capture(captured, 200, {"balance": "0", "allowances": {}}),
+        )
+        client.get_balance_allowance(asset_type="CONDITIONAL", token_id="8501497")
+
+    qs = parse_qs(urlparse(str(captured[0].url)).query)
+    assert qs.get("asset_type") == ["CONDITIONAL"]
+    assert qs.get("token_id") == ["8501497"]

--- a/tests/unit/test_secure_api_keys_sync.py
+++ b/tests/unit/test_secure_api_keys_sync.py
@@ -1,0 +1,161 @@
+# pyright: reportPrivateUsage=false
+import contextlib
+import dataclasses
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, PublicClient, SecureClient
+from polymarket.clients._transport import SyncTransport
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+
+
+def _make_client() -> SecureClient:
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_fetch_api_keys_sends_l2_headers() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, {"apiKeys": ["k1", "k2"]}))
+        keys = client.fetch_api_keys()
+
+    assert keys == ("k1", "k2")
+    request = captured[0]
+    assert request.method == "GET"
+    assert urlparse(str(request.url)).path == "/auth/api-keys"
+    headers = request.headers
+    assert headers.get("POLY_ADDRESS")
+    assert headers.get("POLY_API_KEY") == FAKE_CREDS.key
+    assert headers.get("POLY_PASSPHRASE") == FAKE_CREDS.passphrase
+    assert headers.get("POLY_SIGNATURE")
+    assert headers.get("POLY_TIMESTAMP")
+
+
+def test_delete_api_key_succeeds_on_ok_response() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, "OK"))
+        client.delete_api_key()
+
+    assert captured[0].method == "DELETE"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+
+
+def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
+    with pytest.raises(UnexpectedResponseError), _make_client() as client:
+        _install_secure_clob(client, _capture([], 200, "FAIL"))
+        client.delete_api_key()
+
+
+def test_end_authentication_calls_delete_and_returns_public_client() -> None:
+    captured: list[httpx.Request] = []
+    client = _make_client()
+    _install_secure_clob(client, _capture(captured, 200, "OK"))
+    public = client.end_authentication()
+
+    assert isinstance(public, PublicClient)
+    assert captured[0].method == "DELETE"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+    public.close()
+
+
+def test_end_authentication_returned_public_client_has_same_environment() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 200, "OK"))
+    public = client.end_authentication()
+
+    assert public.environment.name == "production"
+    public.close()
+
+
+def test_end_authentication_blocks_subsequent_method_calls() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 200, "OK"))
+    client.end_authentication()
+
+    with pytest.raises(RuntimeError, match="ended authentication"):
+        client.fetch_api_keys()
+
+
+def test_end_authentication_blocks_property_access_after_end() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 200, "OK"))
+    client.end_authentication()
+
+    with pytest.raises(RuntimeError, match="ended authentication"):
+        _ = client.wallet
+
+
+def test_end_authentication_tolerates_401_on_delete() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 401, {"error": "invalid"}))
+    public = client.end_authentication()
+
+    assert isinstance(public, PublicClient)
+    public.close()
+
+
+def test_end_authentication_tolerates_404_on_delete() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 404, {"error": "not found"}))
+    public = client.end_authentication()
+
+    assert isinstance(public, PublicClient)
+    public.close()
+
+
+def test_end_authentication_propagates_unexpected_errors_from_delete() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 500, {"error": "boom"}))
+
+    with pytest.raises(RequestRejectedError) as info:
+        client.end_authentication()
+    assert info.value.status == 500
+
+
+def test_end_authentication_marks_client_ended_even_when_delete_fails() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 500, {"error": "boom"}))
+    with contextlib.suppress(RequestRejectedError):
+        client.end_authentication()
+
+    assert client._ended is True
+
+
+def test_close_after_end_authentication_does_not_raise() -> None:
+    client = _make_client()
+    _install_secure_clob(client, _capture([], 200, "OK"))
+    public = client.end_authentication()
+    client.close()
+    public.close()

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -1,0 +1,244 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+import json
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, SecureClient
+from polymarket.clients._transport import SyncTransport
+from polymarket.clients.secure import _make_l2_header_resolver_sync
+from polymarket.errors import RequestRejectedError, UserInputError
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _make_client() -> SecureClient:
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_create_or_derive_api_key_sync_posts_l1_headers_on_first_attempt() -> None:
+    from eth_account import Account
+
+    from polymarket._internal.actions.auth import create_or_derive_api_key_sync
+    from polymarket._internal.l1_auth import sign_api_key_auth
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200, json={"apiKey": "k", "secret": "s", "passphrase": "p"}, request=request
+        )
+
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=httpx.MockTransport(handler)),
+    )
+
+    signer: Any = Account.from_key(PRIVATE_KEY)
+    signature = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+    creds = create_or_derive_api_key_sync(transport, signature)
+    transport.close()
+
+    assert creds.key == "k"
+    assert len(captured) == 1
+    assert captured[0].method == "POST"
+    assert urlparse(str(captured[0].url)).path == "/auth/api-key"
+    assert captured[0].headers.get("POLY_ADDRESS")
+    assert captured[0].headers.get("POLY_SIGNATURE", "").startswith("0x")
+    assert captured[0].headers.get("POLY_TIMESTAMP") == "1700000000"
+    assert captured[0].headers.get("POLY_NONCE") == "0"
+
+
+def test_create_or_derive_api_key_sync_falls_back_to_derive_on_400() -> None:
+    from eth_account import Account
+
+    from polymarket._internal.actions.auth import create_or_derive_api_key_sync
+    from polymarket._internal.l1_auth import sign_api_key_auth
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if request.method == "POST" and path == "/auth/api-key":
+            return httpx.Response(400, json={"error": "already exists"}, request=request)
+        if request.method == "GET" and path == "/auth/derive-api-key":
+            return httpx.Response(
+                200,
+                json={"apiKey": "derived", "secret": "s", "passphrase": "p"},
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=httpx.MockTransport(handler)),
+    )
+
+    signer: Any = Account.from_key(PRIVATE_KEY)
+    signature = sign_api_key_auth(signer, chain_id=137, timestamp=1700000000)
+    creds = create_or_derive_api_key_sync(transport, signature)
+    transport.close()
+
+    assert creds.key == "derived"
+    assert len(captured) == 2
+    assert captured[0].method == "POST"
+    assert captured[1].method == "GET"
+    assert urlparse(str(captured[1].url)).path == "/auth/derive-api-key"
+
+
+def test_create_with_credentials_skips_auth_flow_when_validation_disabled() -> None:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
+        assert client.credentials is FAKE_CREDS
+
+
+def test_create_validates_credentials_via_fetch_api_keys_when_enabled() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if urlparse(str(request.url)).path == "/auth/api-keys":
+            return httpx.Response(200, json={"apiKeys": [FAKE_CREDS.key]}, request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    from eth_account import Account
+
+    from polymarket._internal.actions.auth import fetch_api_keys_sync
+
+    signer: Any = Account.from_key(PRIVATE_KEY)
+    probe = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=httpx.MockTransport(handler)),
+        header_resolver=_make_l2_header_resolver_sync(signer, FAKE_CREDS),
+    )
+    keys = fetch_api_keys_sync(probe)
+    probe.close()
+    assert FAKE_CREDS.key in keys
+    assert len(captured) == 1
+    headers = captured[0].headers
+    assert headers.get("POLY_API_KEY") == FAKE_CREDS.key
+    assert headers.get("POLY_SIGNATURE")
+    assert headers.get("POLY_TIMESTAMP")
+
+
+def test_create_rejects_credentials_with_nonzero_nonce() -> None:
+    with pytest.raises(UserInputError, match="nonce cannot be combined"):
+        SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            credentials=FAKE_CREDS,
+            nonce=1,
+        )
+
+
+def test_create_rejects_negative_nonce() -> None:
+    with pytest.raises(UserInputError, match="non-negative integer"):
+        SecureClient.create(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
+
+
+def test_create_rejects_bool_nonce() -> None:
+    with pytest.raises(UserInputError, match="non-negative integer"):
+        SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            nonce=cast(int, True),
+        )
+
+
+def test_create_rejects_missing_wallet() -> None:
+    with pytest.raises(UserInputError, match="wallet is required"):
+        SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet="",
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        )
+
+
+def test_create_rejects_invalid_wallet_address() -> None:
+    with pytest.raises(UserInputError, match="Invalid wallet address"):
+        SecureClient.create(
+            private_key=PRIVATE_KEY,
+            wallet="not-an-address",
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        )
+
+
+def test_create_classifies_eoa_when_wallet_equals_signer() -> None:
+    with _make_client() as client:
+        assert client.wallet_type == "EOA"
+        assert client.wallet == client.signer
+
+
+def test_create_normalizes_wallet_to_checksum() -> None:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS.lower(),
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
+        assert client.wallet == SIGNER_ADDRESS
+
+
+def test_l2_signature_includes_canonical_body_for_authenticated_post() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        transport = SyncTransport(
+            base_url="https://clob.test",
+            client=httpx.Client(
+                base_url="https://clob.test",
+                transport=_capture(captured, 200, "OK"),
+            ),
+            header_resolver=client._ctx.secure_clob._header_resolver,
+        )
+        transport.post_json("/some-endpoint", json={"a": 1, "b": 2})
+        transport.close()
+
+    request = captured[0]
+    assert request.method == "POST"
+    body_str = json.dumps({"a": 1, "b": 2}, separators=(",", ":"))
+    assert request.content == body_str.encode("utf-8")
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.headers["POLY_SIGNATURE"]
+
+
+def test_fetch_api_keys_propagates_401_as_request_rejected() -> None:
+    with _make_client() as client:
+        transport = SyncTransport(
+            base_url="https://clob.test",
+            client=httpx.Client(
+                base_url="https://clob.test",
+                transport=_capture([], 401, {"error": "invalid"}),
+            ),
+            header_resolver=client._ctx.secure_clob._header_resolver,
+        )
+        client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+        with pytest.raises(RequestRejectedError) as info:
+            client.fetch_api_keys()
+        assert info.value.status == 401

--- a/tests/unit/test_secure_orders_sync.py
+++ b/tests/unit/test_secure_orders_sync.py
@@ -1,0 +1,224 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+from decimal import Decimal
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, SecureClient
+from polymarket.clients._transport import SyncTransport
+from polymarket.errors import InsufficientAllowanceError, UserInputError
+from polymarket.models.clob.order_response import AcceptedOrder
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _public_routes() -> dict[str, Any]:
+    return {
+        "/tick-size": {"minimum_tick_size": 0.01},
+        "/neg-risk": {"neg_risk": False},
+    }
+
+
+def _secure_routes(*, has_allowance: bool = True) -> dict[str, Any]:
+    allowance = "100000000000" if has_allowance else "0"
+    return {
+        "/balance-allowance": {
+            "balance": allowance,
+            "allowances": {
+                "0xE111180000d2663C0091e4f400237545B87B996B": allowance,
+                "0xe2222d279d744050d28e00520010520000310F59": allowance,
+            },
+        },
+        "/order": {
+            "errorMsg": "",
+            "makingAmount": "5",
+            "orderID": "ord-1",
+            "status": "live",
+            "success": True,
+            "takingAmount": "10",
+            "tradeIDs": [],
+            "transactionsHashes": [],
+        },
+        "/orders": [
+            {
+                "errorMsg": "",
+                "makingAmount": "5",
+                "orderID": "ord-2",
+                "status": "live",
+                "success": True,
+                "takingAmount": "10",
+                "tradeIDs": [],
+                "transactionsHashes": [],
+            }
+        ],
+        "/cancel-all": {"canceled": ["ord-1", "ord-2"], "not_canceled": {}},
+        "/cancel-market-orders": {"canceled": ["ord-3"], "not_canceled": {}},
+    }
+
+
+def _routed_handler(captured: list[httpx.Request], routes: dict[str, Any]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order" and request.method == "DELETE":
+            return httpx.Response(
+                200, json={"canceled": ["ord-1"], "not_canceled": {}}, request=request
+            )
+        if path == "/orders" and request.method == "DELETE":
+            return httpx.Response(
+                200, json={"canceled": ["a", "b"], "not_canceled": {}}, request=request
+            )
+        if path in routes:
+            return httpx.Response(200, json=routes[path], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_clob(client: SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = dataclasses.replace(client._ctx, clob=transport)
+
+
+def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+
+
+def _make_client() -> SecureClient:
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_create_limit_order_signs_and_returns_signed_order() -> None:
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_clob(client, _routed_handler(public_captured, _public_routes()))
+        _install_secure_clob(client, _routed_handler(secure_captured, _secure_routes()))
+        signed = client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+    assert signed.signature.startswith("0x")
+    assert len(signed.signature) >= 132
+    assert signed.maker_amount == 5_000_000
+    assert signed.taker_amount == 10_000_000
+    assert signed.order_type == "GTC"
+    assert signed.post_only is False
+
+
+def test_create_limit_order_raises_when_allowance_insufficient() -> None:
+    with pytest.raises(InsufficientAllowanceError), _make_client() as client:
+        _install_clob(client, _routed_handler([], _public_routes()))
+        _install_secure_clob(client, _routed_handler([], _secure_routes(has_allowance=False)))
+        client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+
+def test_place_limit_order_posts_after_signing() -> None:
+    secure_captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_clob(client, _routed_handler([], _public_routes()))
+        _install_secure_clob(client, _routed_handler(secure_captured, _secure_routes()))
+        response = client.place_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+    assert isinstance(response, AcceptedOrder)
+    assert response.order_id == "ord-1"
+    post_request = next(
+        r for r in secure_captured if r.method == "POST" and urlparse(str(r.url)).path == "/order"
+    )
+    assert post_request.headers.get("POLY_SIGNATURE")
+
+
+def test_place_market_order_buy_signs_and_posts() -> None:
+    secure_captured: list[httpx.Request] = []
+    public_routes = {
+        **_public_routes(),
+        "/book": {
+            "asset_id": "8501497",
+            "market": "0xMARKET",
+            "bids": [],
+            "asks": [{"price": "0.50", "size": "100"}],
+            "min_order_size": "1",
+            "tick_size": "0.01",
+            "neg_risk": False,
+            "hash": "0xhash",
+            "timestamp": "0",
+        },
+    }
+
+    with _make_client() as client:
+        _install_clob(client, _routed_handler([], public_routes))
+        _install_secure_clob(client, _routed_handler(secure_captured, _secure_routes()))
+        response = client.place_market_order(token_id="8501497", side="BUY", amount=Decimal(2))
+
+    assert isinstance(response, AcceptedOrder)
+
+
+def test_post_order_validation_rejects_post_only_on_market_order() -> None:
+    with pytest.raises(UserInputError, match="post-only"), _make_client() as client:
+        _install_clob(client, _routed_handler([], _public_routes()))
+        _install_secure_clob(client, _routed_handler([], _secure_routes()))
+        signed = client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+        mutated = dataclasses.replace(signed, order_type="FAK", post_only=True)
+        client.post_order(mutated)
+
+
+def test_cancel_order_targets_order_path() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _routed_handler(captured, _secure_routes()))
+        client.cancel_order(order_id="ord-1")
+
+    delete = captured[0]
+    assert delete.method == "DELETE"
+    assert urlparse(str(delete.url)).path == "/order"
+    body = delete.content.decode()
+    assert "orderID" in body
+
+
+def test_cancel_all_targets_cancel_all_path() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _routed_handler(captured, _secure_routes()))
+        response = client.cancel_all()
+
+    assert response.canceled == ("ord-1", "ord-2")
+    assert urlparse(str(captured[0].url)).path == "/cancel-all"
+
+
+def test_cancel_market_orders_sends_filters_in_body() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _routed_handler(captured, _secure_routes()))
+        client.cancel_market_orders(market="0xMARKET", token_id="8501497")
+
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/cancel-market-orders"
+    body = request.content.decode()
+    assert "0xMARKET" in body
+    assert "asset_id" in body
+
+
+def test_cancel_market_orders_requires_market_or_token() -> None:
+    with pytest.raises(UserInputError, match="market or token_id"), _make_client() as client:
+        client.cancel_market_orders()

--- a/tests/unit/test_secure_rewards_sync.py
+++ b/tests/unit/test_secure_rewards_sync.py
@@ -1,0 +1,141 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from polymarket import ApiKeyCreds, SecureClient
+from polymarket._internal.actions.rewards import END_CURSOR
+from polymarket.clients._transport import SyncTransport
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+
+
+def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> None:
+    transport = SyncTransport(
+        base_url="https://clob.test",
+        client=httpx.Client(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+
+
+def _make_client() -> SecureClient:
+    return SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_get_order_scoring_routes_to_order_scoring_endpoint() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, {"scoring": True}))
+        result = client.get_order_scoring(order_id="ord-1")
+
+    assert result is True
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/order-scoring"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("order_id") == ["ord-1"]
+    assert request.headers.get("POLY_SIGNATURE")
+
+
+def test_get_orders_scoring_posts_order_ids_and_parses_map() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, {"ord-1": True, "ord-2": False}))
+        result = client.get_orders_scoring(order_ids=["ord-1", "ord-2"])
+
+    assert result == {"ord-1": True, "ord-2": False}
+    request = captured[0]
+    assert request.method == "POST"
+    assert urlparse(str(request.url)).path == "/orders-scoring"
+    assert b"ord-1" in request.content
+    assert b"ord-2" in request.content
+
+
+def test_list_user_earnings_for_day_passes_signature_type_and_date() -> None:
+    captured: list[httpx.Request] = []
+
+    page_payload: dict[str, Any] = {
+        "data": [
+            {
+                "asset_address": "0xASSET",
+                "asset_rate": "0.001",
+                "condition_id": "0xCONDITION",
+                "date": 1700000000000,
+                "earnings": "1.5",
+                "maker_address": "0xMAKER",
+            }
+        ],
+        "next_cursor": END_CURSOR,
+        "count": 1,
+    }
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, page_payload))
+        earnings = list(client.list_user_earnings_for_day(date="2026-01-01").items())
+
+    assert len(earnings) == 1
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/rewards/user"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("date") == ["2026-01-01"]
+    assert qs.get("signature_type") == ["0"]
+
+
+def test_get_total_earnings_for_user_for_day_routes_to_total_endpoint() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(
+            client,
+            _capture(
+                captured,
+                200,
+                [
+                    {
+                        "asset_address": "0xASSET",
+                        "asset_rate": "0.001",
+                        "date": 1700000000000,
+                        "earnings": "10.0",
+                        "maker_address": "0xMAKER",
+                    }
+                ],
+            ),
+        )
+        totals = client.get_total_earnings_for_user_for_day(date="2026-01-01")
+
+    assert len(totals) == 1
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/rewards/user/total"
+
+
+def test_get_reward_percentages_routes_to_percentages_endpoint() -> None:
+    captured: list[httpx.Request] = []
+
+    with _make_client() as client:
+        _install_secure_clob(client, _capture(captured, 200, {"0xCONDITION": 0.5}))
+        result = client.get_reward_percentages()
+
+    assert "0xCONDITION" in result
+    request = captured[0]
+    assert urlparse(str(request.url)).path == "/rewards/user/percentages"
+    qs = parse_qs(urlparse(str(request.url)).query)
+    assert qs.get("signature_type") == ["0"]

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -53,7 +53,12 @@ def _captured() -> list[httpx.Request]:
 
 
 def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.get_portfolio_values()
 
@@ -63,7 +68,12 @@ def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Req
 def test_secure_get_portfolio_values_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.get_portfolio_values(user=OTHER_WALLET)
 
@@ -76,7 +86,12 @@ def test_secure_get_portfolio_values_respects_explicit_user(
 def test_secure_get_traded_market_count_defaults_to_signer(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(
             client, _capturing_handler(captured, {"user": SIGNER_ADDRESS, "traded": 0})
         )
@@ -88,7 +103,12 @@ def test_secure_get_traded_market_count_defaults_to_signer(
 def test_secure_get_traded_market_count_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(
             client, _capturing_handler(captured, {"user": OTHER_WALLET, "traded": 0})
         )
@@ -107,7 +127,12 @@ def test_secure_download_accounting_snapshot_defaults_to_signer(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, httpx.MockTransport(handler))
         client.download_accounting_snapshot()
 
@@ -121,7 +146,12 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, httpx.MockTransport(handler))
         client.download_accounting_snapshot(user=OTHER_WALLET)
 
@@ -132,7 +162,12 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
 
 
 def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.list_positions().first_page()
 
@@ -140,7 +175,12 @@ def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request])
 
 
 def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.list_positions(user=OTHER_WALLET).first_page()
 
@@ -151,7 +191,12 @@ def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Reque
 
 
 def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.list_closed_positions().first_page()
 
@@ -162,7 +207,12 @@ def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Re
 
 
 def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.list_trades().first_page()
 
@@ -173,7 +223,12 @@ def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) ->
 
 
 def test_secure_list_activity_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         client.list_activity().first_page()
 
@@ -280,7 +335,12 @@ def test_secure_list_positions_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         with pytest.raises(UserInputError, match="user is required"):
             client.list_positions(user="").first_page()
@@ -291,7 +351,12 @@ def test_secure_get_portfolio_values_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient.create(private_key=PRIVATE_KEY) as client:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        wallet=SIGNER_ADDRESS,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
         _install_sync_data(client, _capturing_handler(captured, []))
         with pytest.raises(UserInputError, match="user is required"):
             client.get_portfolio_values(user="")


### PR DESCRIPTION
stacked pr: #26 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new sync authentication/signing flows (L1 API key bootstrap + L2 HMAC headers) and adds many secure trading/account endpoints, which could break request signing or order placement if incorrect.
> 
> **Overview**
> Adds **sync secure CLOB parity** by introducing a signed `secure_clob` transport (L2 HMAC header resolver) and expanding `SyncSecureClientContext`/`SecureClient.create()` to require an explicit `wallet`, manage `ApiKeyCreds`, classify `wallet_type`, and optionally bootstrap/validate API keys (with `end_authentication()` to revoke keys and return a `PublicClient`).
> 
> Extends sync functionality with new `*_sync` action helpers (auth, allowance, market data, limit/market order drafting, market price estimation) and surfaces them on `PublicClient`/`SecureClient`, including CLOB quote endpoints (midpoint/price/book/spread/price history), rewards listing, secure account endpoints (open orders, trades, notifications, balance/allowance), and full sync order lifecycle (create/sign/place, post batch, cancel variants) with allowance checks and typed-data signing.
> 
> Updates `SyncTransport` to support DELETE, per-request headers, and canonical JSON-body signing via a sync `header_resolver`, and adds extensive unit tests covering new sync endpoints, request shapes, and header/signature behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adcbc025828c725732df4739f00aa22f9f429112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->