### PR TITLE
feat: handle beacon deposit wallet factory migration [PRO-326]

### DIFF
--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -194,8 +194,6 @@ async def _estimate_proxy_gas_limit(
     to: str,
     data: str,
 ) -> str:
-    if ctx.rpc is None:
-        return _PROXY_DEFAULT_GAS_LIMIT
     try:
         estimated = await ctx.rpc.eth_estimate_gas({"from": from_address, "to": to, "data": data})
     except Exception:

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -47,7 +47,7 @@ class AsyncSecureClientContext(AsyncClientContext):
     wallet_type: WalletType
     relayer: AsyncTransport
     api_key: ApiKey | None
-    rpc: JsonRpcClient | None
+    rpc: JsonRpcClient
 
 
 __all__ = [

--- a/src/polymarket/_internal/eoa/rpc.py
+++ b/src/polymarket/_internal/eoa/rpc.py
@@ -1,9 +1,42 @@
 from __future__ import annotations
 
+import json as _json
 from typing import Any, cast
 
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError, UserInputError
+
+_JSON_RPC_REVERT_CODES = frozenset({3, -32_000, -32_003, -32_015, -32_603})
+_JSON_RPC_REVERT_TOKENS = ("execution reverted", "revert", "invalid opcode")
+
+
+class JsonRpcCallError(RequestRejectedError):
+    def __init__(self, method: str, code: int, message: str, data: object) -> None:
+        super().__init__(f"JSON-RPC {method} failed: {message}", status=200)
+        self.method = method
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+def is_json_rpc_contract_revert(error: object) -> bool:
+    if not isinstance(error, JsonRpcCallError):
+        return False
+    if error.code not in _JSON_RPC_REVERT_CODES:
+        return False
+    haystack = f"{error.message} {_stringify_error_data(error.data)}".lower()
+    return any(token in haystack for token in _JSON_RPC_REVERT_TOKENS)
+
+
+def _stringify_error_data(data: object) -> str:
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    try:
+        return _json.dumps(data)
+    except (TypeError, ValueError):
+        return ""
 
 
 class JsonRpcClient:
@@ -45,13 +78,19 @@ class JsonRpcClient:
         response = cast(dict[str, Any], raw)
         if "error" in response:
             err: Any = response["error"]
-            message = _extract_error_message(err)
-            raise UnexpectedResponseError(f"JSON-RPC {method} failed: {message}")
+            code, message, data = _extract_error_fields(err)
+            raise JsonRpcCallError(method=method, code=code, message=message, data=data)
         return response.get("result")
 
     async def eth_chain_id(self) -> int:
         result = await self._call("eth_chainId", [])
         return _hex_to_int(result, "eth_chainId")
+
+    async def eth_call(self, *, to: str, data: str, block: str = "latest") -> str:
+        result = await self._call("eth_call", [{"to": to, "data": data}, block])
+        if not isinstance(result, str) or not _is_rpc_hex_string(result):
+            raise UnexpectedResponseError("eth_call did not return a hex string")
+        return result
 
     async def eth_get_transaction_count(self, address: str, block: str = "pending") -> int:
         result = await self._call("eth_getTransactionCount", [address, block])
@@ -80,14 +119,22 @@ class JsonRpcClient:
         return cast(dict[str, Any], result)
 
 
-def _extract_error_message(err: object) -> str:
+def _extract_error_fields(err: object) -> tuple[int, str, object]:
     if isinstance(err, dict):
         err_dict = cast(dict[str, object], err)
-        msg = err_dict.get("message")
-        if isinstance(msg, str):
-            return msg
-        return repr(err_dict)
-    return str(err)
+        raw_code = err_dict.get("code")
+        code = raw_code if isinstance(raw_code, int) and not isinstance(raw_code, bool) else 0
+        raw_message = err_dict.get("message")
+        message = raw_message if isinstance(raw_message, str) else repr(err_dict)
+        return code, message, err_dict.get("data")
+    return 0, str(err), None
+
+
+def _is_rpc_hex_string(value: str) -> bool:
+    if not value.startswith("0x"):
+        return False
+    rest = value[2:]
+    return all(c in "0123456789abcdefABCDEF" for c in rest)
 
 
 def _hex_to_int(value: Any, method: str) -> int:
@@ -99,4 +146,4 @@ def _hex_to_int(value: Any, method: str) -> int:
         raise UnexpectedResponseError(f"{method} returned malformed hex: {error}") from error
 
 
-__all__ = ["JsonRpcClient"]
+__all__ = ["JsonRpcCallError", "JsonRpcClient", "is_json_rpc_contract_revert"]

--- a/src/polymarket/_internal/wallet.py
+++ b/src/polymarket/_internal/wallet.py
@@ -7,6 +7,7 @@ from eth_abi.packed import encode_packed
 from eth_utils.address import to_checksum_address
 from eth_utils.crypto import keccak
 
+from polymarket._internal.eoa.rpc import JsonRpcClient, is_json_rpc_contract_revert
 from polymarket.environments import WalletDerivation
 from polymarket.errors import UserInputError
 
@@ -33,6 +34,18 @@ _ERC1967_CONST1 = bytes.fromhex("cc3735a920a3ca505d382bbc545af43d6000803e6038573
 _ERC1967_CONST2 = bytes.fromhex("5155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076")
 _ERC1967_PREFIX_BASE = 0x61003D3D8160233D3973
 
+_ERC1967_BEACON_CONST1 = bytes.fromhex(
+    "b3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3"
+)
+_ERC1967_BEACON_CONST2 = bytes.fromhex(
+    "1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c"
+)
+_ERC1967_BEACON_CONST3 = bytes.fromhex("60195155f3363d3d373d3d363d602036600436635c60da")
+_ERC1967_BEACON_PREFIX_BASE = 0x6100523D8160233D3973
+
+_FACTORY_BEACON_SELECTOR = "0x49493a4d"
+_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
 
 def signature_type_for(wallet_type: WalletType) -> int:
     return _SIGNATURE_TYPE_BY_WALLET[wallet_type]
@@ -56,13 +69,41 @@ def derive_safe_wallet_address(signer: str, config: WalletDerivation) -> str:
     return _create2(config.safe_factory, salt, bytecode_hash)
 
 
-def derive_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
-    signer_bytes = bytes.fromhex(_strip_0x(signer))
-    wallet_id = signer_bytes.rjust(32, b"\x00")
-    args = abi_encode(["address", "bytes32"], [config.deposit_wallet_factory, wallet_id])
-    bytecode_hash = _deposit_init_code_hash(config.deposit_wallet_implementation, args)
+def derive_uups_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+    args = _deposit_wallet_args(signer, config)
+    bytecode_hash = _uups_deposit_init_code_hash(config.deposit_wallet_implementation, args)
     salt = keccak(args)
     return _create2(config.deposit_wallet_factory, salt, bytecode_hash)
+
+
+def derive_beacon_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+    args = _deposit_wallet_args(signer, config)
+    bytecode_hash = _beacon_deposit_init_code_hash(config.deposit_wallet_beacon, args)
+    salt = keccak(args)
+    return _create2(config.deposit_wallet_factory, salt, bytecode_hash)
+
+
+async def get_deposit_wallet_factory_beacon(rpc: JsonRpcClient, factory: str) -> str:
+    try:
+        data = await rpc.eth_call(to=factory, data=_FACTORY_BEACON_SELECTOR)
+    except Exception as error:
+        if is_json_rpc_contract_revert(error):
+            return _ZERO_ADDRESS
+        raise
+    return _decode_address_return_data(data)
+
+
+async def is_beacon_deposit_wallet_factory(rpc: JsonRpcClient, factory: str) -> bool:
+    beacon = await get_deposit_wallet_factory_beacon(rpc, factory)
+    return beacon.lower() != _ZERO_ADDRESS
+
+
+async def derive_current_deposit_wallet_address(
+    rpc: JsonRpcClient, signer: str, config: WalletDerivation
+) -> str:
+    if await is_beacon_deposit_wallet_factory(rpc, config.deposit_wallet_factory):
+        return derive_beacon_deposit_wallet_address(signer, config)
+    return derive_uups_deposit_wallet_address(signer, config)
 
 
 def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) -> WalletType:
@@ -77,7 +118,9 @@ def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) 
 
     if wallet_checksum == signer_checksum:
         return "EOA"
-    if wallet_checksum == derive_deposit_wallet_address(signer_checksum, config):
+    if wallet_checksum == derive_beacon_deposit_wallet_address(signer_checksum, config):
+        return "DEPOSIT_WALLET"
+    if wallet_checksum == derive_uups_deposit_wallet_address(signer_checksum, config):
         return "DEPOSIT_WALLET"
     if wallet_checksum == derive_proxy_wallet_address(signer_checksum, config):
         return "POLY_PROXY"
@@ -90,13 +133,19 @@ def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) 
     )
 
 
+def _deposit_wallet_args(signer: str, config: WalletDerivation) -> bytes:
+    signer_bytes = bytes.fromhex(_strip_0x(signer))
+    wallet_id = signer_bytes.rjust(32, b"\x00")
+    return abi_encode(["address", "bytes32"], [config.deposit_wallet_factory, wallet_id])
+
+
 def _create2(factory: str, salt: bytes, bytecode_hash: bytes) -> str:
     factory_bytes = bytes.fromhex(_strip_0x(factory))
     raw = b"\xff" + factory_bytes + salt + bytecode_hash
     return to_checksum_address("0x" + keccak(raw)[12:].hex())
 
 
-def _deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
+def _uups_deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
     args_byte_length = len(args)
     prefix = _ERC1967_PREFIX_BASE + (args_byte_length << 56)
     prefix_bytes = prefix.to_bytes(10, "big")
@@ -107,6 +156,31 @@ def _deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
     return keccak(bytecode)
 
 
+def _beacon_deposit_init_code_hash(beacon: str, args: bytes) -> bytes:
+    args_byte_length = len(args)
+    prefix = _ERC1967_BEACON_PREFIX_BASE + (args_byte_length << 56)
+    prefix_bytes = prefix.to_bytes(10, "big")
+    beacon_bytes = bytes.fromhex(_strip_0x(beacon))
+    bytecode = (
+        prefix_bytes
+        + beacon_bytes
+        + _ERC1967_BEACON_CONST3
+        + _ERC1967_BEACON_CONST2
+        + _ERC1967_BEACON_CONST1
+        + args
+    )
+    return keccak(bytecode)
+
+
+def _decode_address_return_data(data: str) -> str:
+    if len(data) < 66:
+        return _ZERO_ADDRESS
+    try:
+        return to_checksum_address("0x" + data[-40:])
+    except ValueError:
+        return _ZERO_ADDRESS
+
+
 def _strip_0x(value: str) -> str:
     return value[2:] if value.startswith(("0x", "0X")) else value
 
@@ -114,8 +188,12 @@ def _strip_0x(value: str) -> str:
 __all__ = [
     "WalletType",
     "classify_wallet_type",
-    "derive_deposit_wallet_address",
+    "derive_beacon_deposit_wallet_address",
+    "derive_current_deposit_wallet_address",
     "derive_proxy_wallet_address",
     "derive_safe_wallet_address",
+    "derive_uups_deposit_wallet_address",
+    "get_deposit_wallet_factory_beacon",
+    "is_beacon_deposit_wallet_factory",
     "signature_type_for",
 ]

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -94,7 +94,7 @@ from polymarket._internal.streams.handle import AsyncSubscriptionHandle, Subscri
 from polymarket._internal.wallet import (
     WalletType,
     classify_wallet_type,
-    derive_deposit_wallet_address,
+    derive_current_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.auth import ApiKey
@@ -321,10 +321,8 @@ class AsyncSecureClient:
             logger=logger,
             header_resolver=_make_l2_header_resolver(signer, credentials),
         )
-        rpc: JsonRpcClient | None = None
-        if environment.rpc_url is not None:
-            rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
-            rpc = JsonRpcClient(rpc_transport)
+        rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
+        rpc = JsonRpcClient(rpc_transport)
 
         ctx = AsyncSecureClientContext(
             environment=environment,
@@ -532,8 +530,7 @@ class AsyncSecureClient:
                                         try:
                                             await ctx.relayer.close()
                                         finally:
-                                            if ctx.rpc is not None:
-                                                await ctx.rpc.close()
+                                            await ctx.rpc.close()
 
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user
@@ -1655,8 +1652,8 @@ class AsyncSecureClient:
             )
         deposit_address = cast(
             EvmAddress,
-            to_checksum_address(
-                derive_deposit_wallet_address(ctx.signer.address, ctx.environment.wallet_derivation)
+            await derive_current_deposit_wallet_address(
+                ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
             ),
         )
         ready = await fetch_deployed(
@@ -1677,25 +1674,23 @@ class AsyncSecureClient:
         )
 
     async def is_gasless_ready(self) -> bool:
-        wallet_type = self._ctx.wallet_type
-        if wallet_type == "EOA":
-            return False
-        type_param = RelayerTransactionType.WALLET if wallet_type == "DEPOSIT_WALLET" else None
+        ctx = self._ctx
+        if ctx.wallet_type != "EOA":
+            type_param = (
+                RelayerTransactionType.WALLET if ctx.wallet_type == "DEPOSIT_WALLET" else None
+            )
+            return await fetch_deployed(ctx.relayer, address=str(ctx.wallet), type=type_param)
+        deposit_address = await derive_current_deposit_wallet_address(
+            ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+        )
         return await fetch_deployed(
-            self._ctx.relayer, address=str(self._ctx.wallet), type=type_param
+            ctx.relayer, address=deposit_address, type=RelayerTransactionType.WALLET
         )
 
     async def _broadcast_eoa_call(self, call: TransactionCall) -> EoaTransactionHandle:
-        rpc = self._ctx.rpc
-        if rpc is None:
-            raise UserInputError(
-                "EOA workflows require rpc_url set on the Environment. "
-                "Pass environment=dataclasses.replace(PRODUCTION, rpc_url='...') "
-                "at create(), or use setup_gasless_wallet() to switch to a Deposit Wallet."
-            )
         env = self._ctx.environment
         return await broadcast_eoa_call(
-            rpc=rpc,
+            rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
             chain_id=env.chain_id,

--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -72,7 +72,7 @@ PRODUCTION = Environment(
     data_url="https://data-api.polymarket.com",
     rtds_ws_url="wss://ws-live-data.polymarket.com",
     sports_ws_url="wss://sports-api.polymarket.com/ws",
-    rpc_url="https://polygon-rpc.com",
+    rpc_url="https://polygon.drpc.org",
 )
 
 __all__ = ["Environment", "PRODUCTION", "WalletDerivation"]

--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -11,6 +11,7 @@ class WalletDerivation:
     safe_init_code_hash: str
     deposit_wallet_factory: str
     deposit_wallet_implementation: str
+    deposit_wallet_beacon: str
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -36,9 +37,9 @@ class Environment:
     data_url: str
     rtds_ws_url: str
     sports_ws_url: str
+    rpc_url: str
     relayer_max_polls: int = 100
     relayer_poll_frequency_ms: int = 2000
-    rpc_url: str | None = None
 
 
 PRODUCTION = Environment(
@@ -51,6 +52,7 @@ PRODUCTION = Environment(
         safe_init_code_hash="0x2bce2127ff07fb632d16c8347c4ebf501f4841168bed00d9e6ef715ddb6fcecf",
         deposit_wallet_factory="0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
         deposit_wallet_implementation="0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB",
+        deposit_wallet_beacon="0x7A18EDfe055488A3128f01F563e5B479D92ffc3a",
     ),
     collateral_token="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
     conditional_tokens="0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
@@ -70,6 +72,7 @@ PRODUCTION = Environment(
     data_url="https://data-api.polymarket.com",
     rtds_ws_url="wss://ws-live-data.polymarket.com",
     sports_ws_url="wss://sports-api.polymarket.com/ws",
+    rpc_url="https://polygon-rpc.com",
 )
 
 __all__ = ["Environment", "PRODUCTION", "WalletDerivation"]

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -26,11 +26,11 @@ SPENDER = "0x000000000000000000000000000000000000dEaD"
 async def make_deposit_client() -> AsyncSecureClient:
     from eth_account import Account
 
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
     return await AsyncSecureClient.create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -207,6 +207,53 @@ def install_relayer_handler(
     client._ctx = dataclasses.replace(client._ctx, relayer=transport)
 
 
+def install_rpc_handler(
+    client: AsyncSecureClient,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    from polymarket._internal.eoa.rpc import JsonRpcClient
+
+    transport = AsyncTransport(
+        base_url="https://rpc.test",
+        client=httpx.AsyncClient(
+            base_url="https://rpc.test", transport=httpx.MockTransport(handler)
+        ),
+    )
+    client._ctx = dataclasses.replace(client._ctx, rpc=JsonRpcClient(transport))
+
+
+def legacy_factory_rpc_handler() -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": 3, "message": "execution reverted"},
+            },
+            request=request,
+        )
+
+    return handler
+
+
+def beacon_factory_rpc_handler(beacon_address: str) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": "0x" + beacon_address[2:].rjust(64, "0").lower(),
+            },
+            request=request,
+        )
+
+    return handler
+
+
 def request_json(request: httpx.Request) -> Any:
     return json.loads(request.content.decode("utf-8"))
 
@@ -220,8 +267,11 @@ __all__ = [
     "RELAY_PAYLOAD_DEFAULT_ADDRESS",
     "SPENDER",
     "TOKEN",
+    "beacon_factory_rpc_handler",
     "install_relayer_handler",
     "install_relayer_routes",
+    "install_rpc_handler",
+    "legacy_factory_rpc_handler",
     "make_deposit_client",
     "make_eoa_client",
     "make_eoa_client_with_rpc",

--- a/tests/unit/test_eoa_broadcast.py
+++ b/tests/unit/test_eoa_broadcast.py
@@ -5,35 +5,17 @@ import dataclasses
 import httpx
 import pytest
 from _relayer_helpers import (
-    BUILDER_AUTH,
-    FAKE_CREDS,
-    PK_DEPLOY_WALLET,
-    make_eoa_client,
     make_eoa_client_with_rpc,
     make_rpc_handler,
 )
 
-from polymarket import AsyncSecureClient, TransactionCall
+from polymarket import TransactionCall
 from polymarket.errors import TimeoutError, TransactionFailedError, UserInputError
 from polymarket.transactions import EoaTransactionHandle
 from polymarket.types import EvmAddress
 
 _TOKEN = EvmAddress("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
 _SPENDER = EvmAddress("0xE111180000d2663C0091e4f400237545B87B996B")
-
-
-def test_eoa_workflow_without_rpc_url_raises_user_input_error() -> None:
-    async def run() -> None:
-        client = await make_eoa_client()
-        try:
-            with pytest.raises(UserInputError, match="rpc_url"):
-                await client.approve_erc20(
-                    token_address=str(_TOKEN), spender_address=str(_SPENDER), amount=1
-                )
-        finally:
-            await client.close()
-
-    asyncio.run(run())
 
 
 def test_eoa_approve_erc20_signs_and_broadcasts() -> None:
@@ -215,26 +197,6 @@ def test_rpc_client_closes_with_client() -> None:
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         assert client._ctx.rpc is not None
         await client.close()
-
-    asyncio.run(run())
-
-
-def test_no_rpc_url_means_ctx_rpc_is_none() -> None:
-    from eth_account import Account
-
-    async def run() -> None:
-        signer = Account.from_key(PK_DEPLOY_WALLET)
-        client = await AsyncSecureClient.create(
-            private_key=PK_DEPLOY_WALLET,
-            wallet=signer.address,
-            credentials=FAKE_CREDS,
-            api_key=BUILDER_AUTH,
-            validate_credentials=False,
-        )
-        try:
-            assert client._ctx.rpc is None
-        finally:
-            await client.close()
 
     asyncio.run(run())
 

--- a/tests/unit/test_factory_beacon_detection.py
+++ b/tests/unit/test_factory_beacon_detection.py
@@ -1,0 +1,189 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from polymarket._internal.eoa.rpc import JsonRpcCallError, JsonRpcClient
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_current_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+    get_deposit_wallet_factory_beacon,
+    is_beacon_deposit_wallet_factory,
+)
+from polymarket.clients._transport import AsyncTransport
+from polymarket.environments import PRODUCTION
+
+_FACTORY = PRODUCTION.wallet_derivation.deposit_wallet_factory
+_BEACON = PRODUCTION.wallet_derivation.deposit_wallet_beacon
+_SIGNER = "0x0000000000000000000000000000000000000001"
+_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+_FACTORY_BEACON_SELECTOR = "0x49493a4d"
+
+
+def _rpc(handler: httpx.MockTransport) -> JsonRpcClient:
+    transport = AsyncTransport(
+        base_url="https://rpc.test",
+        client=httpx.AsyncClient(base_url="https://rpc.test", transport=handler),
+    )
+    return JsonRpcClient(transport)
+
+
+def _capturing_handler(
+    response: dict[str, object],
+    captured: list[dict[str, object]] | None = None,
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if captured is not None:
+            captured.append(body)
+        envelope = {"jsonrpc": "2.0", "id": body["id"], **response}
+        return httpx.Response(200, json=envelope, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def test_get_factory_beacon_parses_address_from_return_data() -> None:
+    captured: list[dict[str, object]] = []
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()}, captured)
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert result.lower() == _BEACON.lower()
+    assert captured[0]["method"] == "eth_call"
+    params = captured[0]["params"]
+    assert isinstance(params, list)
+    assert params[0] == {"to": _FACTORY, "data": _FACTORY_BEACON_SELECTOR}
+
+
+def test_get_factory_beacon_returns_zero_address_on_short_return_data() -> None:
+    handler = _capturing_handler({"result": "0x"})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_returns_zero_address_on_contract_revert() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_returns_zero_address_when_revert_message_nested_in_data() -> None:
+    handler = _capturing_handler(
+        {
+            "error": {
+                "code": -32_603,
+                "message": "VM Exception while processing transaction",
+                "data": {"message": "execution reverted"},
+            }
+        }
+    )
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_propagates_generic_rpc_failures() -> None:
+    handler = _capturing_handler({"error": {"code": -32_603, "message": "upstream unavailable"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
+
+
+def test_is_beacon_deposit_wallet_factory_returns_true_for_beacon_address() -> None:
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()})
+
+    async def run() -> bool:
+        rpc = _rpc(handler)
+        try:
+            return await is_beacon_deposit_wallet_factory(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) is True
+
+
+def test_is_beacon_deposit_wallet_factory_returns_false_when_factory_reverts() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> bool:
+        rpc = _rpc(handler)
+        try:
+            return await is_beacon_deposit_wallet_factory(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) is False
+
+
+def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await derive_current_deposit_wallet_address(
+                rpc, _SIGNER, PRODUCTION.wallet_derivation
+            )
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert (
+        result.lower()
+        == derive_beacon_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+    )
+
+
+def test_derive_current_picks_uups_when_factory_reverts() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await derive_current_deposit_wallet_address(
+                rpc, _SIGNER, PRODUCTION.wallet_derivation
+            )
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert (
+        result.lower()
+        == derive_uups_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+    )

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -14,6 +14,7 @@ from _relayer_helpers import (
     TOKEN,
     install_relayer_handler,
     install_relayer_routes,
+    install_rpc_handler,
     make_deposit_client,
     make_proxy_client,
     make_safe_client,
@@ -128,7 +129,21 @@ def test_approve_erc20_deposit_wallet_payload_shape() -> None:
 
 
 def test_approve_erc20_proxy_payload_shape() -> None:
+    import json as _json
+
     captured: list[httpx.Request] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = _json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32_603, "message": "upstream unavailable"},
+            },
+            request=request,
+        )
 
     async def run() -> None:
         client = await make_proxy_client()
@@ -147,6 +162,7 @@ def test_approve_erc20_proxy_payload_shape() -> None:
                 },
             },
         )
+        install_rpc_handler(client, rpc_handler)
         try:
             await client.approve_erc20(
                 token_address=TOKEN,

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -28,12 +28,12 @@ from polymarket.transactions import TransactionHandle
 def test_approve_erc20_rejects_when_no_api_key() -> None:
     from eth_account import Account
 
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
         client = await AsyncSecureClient.create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
@@ -401,14 +401,14 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
     from eth_account import Account
 
     from polymarket import RelayerApiKey
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     captured: list[httpx.Request] = []
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
         client = await AsyncSecureClient.create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,

--- a/tests/unit/test_relayer_is_gasless_ready.py
+++ b/tests/unit/test_relayer_is_gasless_ready.py
@@ -6,42 +6,129 @@ import httpx
 from _relayer_helpers import (
     FAKE_CREDS,
     PK_DEPLOY_WALLET,
+    beacon_factory_rpc_handler,
     install_relayer_handler,
+    install_rpc_handler,
+    legacy_factory_rpc_handler,
     make_deposit_client,
     make_proxy_client,
     make_safe_client,
 )
 
 from polymarket import AsyncSecureClient
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+)
+from polymarket.environments import PRODUCTION
 
 
-def test_is_gasless_ready_eoa_returns_false_without_network_call() -> None:
+async def _make_eoa_secure_client() -> AsyncSecureClient:
+    from eth_account import Account
+
+    signer = Account.from_key(PK_DEPLOY_WALLET)
+    return await AsyncSecureClient.create(
+        private_key=PK_DEPLOY_WALLET,
+        wallet=signer.address,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_is_gasless_ready_eoa_legacy_factory_queries_uups_deposit_wallet() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> bool:
-        from eth_account import Account
-
-        signer = Account.from_key(PK_DEPLOY_WALLET)
-        client = await AsyncSecureClient.create(
-            private_key=PK_DEPLOY_WALLET,
-            wallet=signer.address,
-            credentials=FAKE_CREDS,
-            validate_credentials=False,
-        )
+    async def run() -> tuple[bool, str]:
+        client = await _make_eoa_secure_client()
+        signer_address = client._ctx.signer.address
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured.append(request)
-            return httpx.Response(500, json={"error": "should not be called"}, request=request)
+            return httpx.Response(200, json={"deployed": True}, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
+        try:
+            result = await client.is_gasless_ready()
+            return result, signer_address
+        finally:
+            await client.close()
+
+    result, signer_address = asyncio.run(run())
+    expected = derive_uups_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    assert result is True
+    assert len(captured) == 1
+    parsed = urlparse(str(captured[0].url))
+    assert parsed.path == "/deployed"
+    qs = parse_qs(parsed.query)
+    assert qs["type"] == ["WALLET"]
+    assert qs["address"] == [expected]
+
+
+def test_is_gasless_ready_eoa_beacon_factory_queries_beacon_deposit_wallet() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> tuple[bool, str]:
+        client = await _make_eoa_secure_client()
+        signer_address = client._ctx.signer.address
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"deployed": False}, request=request)
+
+        install_relayer_handler(client, handler)
+        install_rpc_handler(
+            client, beacon_factory_rpc_handler(PRODUCTION.wallet_derivation.deposit_wallet_beacon)
+        )
+        try:
+            result = await client.is_gasless_ready()
+            return result, signer_address
+        finally:
+            await client.close()
+
+    result, signer_address = asyncio.run(run())
+    expected = derive_beacon_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    assert result is False
+    assert len(captured) == 1
+    parsed = urlparse(str(captured[0].url))
+    qs = parse_qs(parsed.query)
+    assert qs["type"] == ["WALLET"]
+    assert qs["address"] == [expected]
+
+
+def test_is_gasless_ready_eoa_propagates_generic_rpc_failure() -> None:
+    import pytest
+
+    from polymarket._internal.eoa.rpc import JsonRpcCallError
+
+    async def run() -> bool:
+        client = await _make_eoa_secure_client()
+
+        def rpc_handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {"code": -32_603, "message": "upstream unavailable"},
+                },
+                request=request,
+            )
+
+        install_relayer_handler(
+            client, lambda r: httpx.Response(500, json={"error": "unused"}, request=r)
+        )
+        install_rpc_handler(client, rpc_handler)
         try:
             return await client.is_gasless_ready()
         finally:
             await client.close()
 
-    result = asyncio.run(run())
-    assert result is False
-    assert captured == []
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
 
 
 def test_is_gasless_ready_deposit_wallet_sends_type_wallet() -> None:

--- a/tests/unit/test_relayer_proxy_contract.py
+++ b/tests/unit/test_relayer_proxy_contract.py
@@ -10,6 +10,7 @@ from _relayer_helpers import (
     SPENDER,
     TOKEN,
     install_relayer_routes,
+    install_rpc_handler,
     make_proxy_client,
     request_json,
 )
@@ -82,8 +83,20 @@ def test_proxy_signs_relay_address_returned_from_relay_payload() -> None:
     assert body["signatureParams"]["relay"] != "0x" + "00" * 20
 
 
-def test_proxy_signs_default_gas_limit_when_no_rpc_configured() -> None:
+def test_proxy_signs_default_gas_limit_when_rpc_estimate_fails() -> None:
     captured: list[httpx.Request] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32_603, "message": "upstream unavailable"},
+            },
+            request=request,
+        )
 
     async def run() -> None:
         client = await make_proxy_client()
@@ -95,6 +108,7 @@ def test_proxy_signs_default_gas_limit_when_no_rpc_configured() -> None:
                 "/submit": _submit_route(),
             },
         )
+        install_rpc_handler(client, rpc_handler)
         try:
             await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
         finally:

--- a/tests/unit/test_relayer_setup_gasless_wallet.py
+++ b/tests/unit/test_relayer_setup_gasless_wallet.py
@@ -6,7 +6,10 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from _relayer_helpers import (
+    beacon_factory_rpc_handler,
     install_relayer_handler,
+    install_rpc_handler,
+    legacy_factory_rpc_handler,
     make_deposit_client,
     make_eoa_client,
     make_proxy_client,
@@ -14,7 +17,10 @@ from _relayer_helpers import (
     request_json,
 )
 
-from polymarket._internal.wallet import derive_deposit_wallet_address
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+)
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UserInputError
 
@@ -89,7 +95,9 @@ def test_setup_gasless_wallet_eoa_skips_deploy_when_already_deployed() -> None:
     async def run() -> tuple[str, str]:
         client = await make_eoa_client()
         eoa_address = client._ctx.signer.address
-        expected_deposit = derive_deposit_wallet_address(eoa_address, PRODUCTION.wallet_derivation)
+        expected_deposit = derive_uups_deposit_wallet_address(
+            eoa_address, PRODUCTION.wallet_derivation
+        )
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured.append(request)
@@ -99,6 +107,7 @@ def test_setup_gasless_wallet_eoa_skips_deploy_when_already_deployed() -> None:
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         try:
             new_client = await client.setup_gasless_wallet()
             try:
@@ -159,6 +168,7 @@ def test_setup_gasless_wallet_eoa_deploys_when_not_deployed() -> None:
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         client._ctx = dataclasses.replace(
             client._ctx,
             environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
@@ -185,6 +195,79 @@ def test_setup_gasless_wallet_eoa_deploys_when_not_deployed() -> None:
     assert body["metadata"] == "Deploy Deposit Wallet"
 
 
+def test_setup_gasless_wallet_eoa_uses_beacon_factory_when_available() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> tuple[str, str]:
+        client = await make_eoa_client()
+        eoa_address = client._ctx.signer.address
+        expected = derive_beacon_deposit_wallet_address(eoa_address, PRODUCTION.wallet_derivation)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            path = urlparse(str(request.url)).path
+            if path == "/deployed":
+                return httpx.Response(200, json={"deployed": True}, request=request)
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        install_rpc_handler(
+            client,
+            beacon_factory_rpc_handler(PRODUCTION.wallet_derivation.deposit_wallet_beacon),
+        )
+        try:
+            new_client = await client.setup_gasless_wallet()
+            try:
+                return str(new_client.wallet), expected
+            finally:
+                await new_client.close()
+        finally:
+            await client.close()
+
+    actual, expected = asyncio.run(run())
+    assert actual == expected
+    deployed_calls = [r for r in captured if urlparse(str(r.url)).path == "/deployed"]
+    assert len(deployed_calls) == 1
+    qs = parse_qs(urlparse(str(deployed_calls[0].url)).query)
+    assert qs["address"] == [expected]
+
+
+def test_setup_gasless_wallet_eoa_propagates_generic_rpc_failure() -> None:
+    import pytest
+
+    from polymarket._internal.eoa.rpc import JsonRpcCallError
+
+    async def run() -> None:
+        client = await make_eoa_client()
+
+        def rpc_handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {"code": -32_603, "message": "upstream unavailable"},
+                },
+                request=request,
+            )
+
+        install_rpc_handler(client, rpc_handler)
+        install_relayer_handler(
+            client,
+            lambda r: httpx.Response(500, json={"error": "unused"}, request=r),
+        )
+        try:
+            await client.setup_gasless_wallet()
+        finally:
+            await client.close()
+
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
+
+
 def test_setup_gasless_wallet_returns_independent_client_with_fresh_transports() -> None:
     captured: list[httpx.Request] = []
 
@@ -199,6 +282,7 @@ def test_setup_gasless_wallet_returns_independent_client_with_fresh_transports()
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         async with client:
             returned = await client.setup_gasless_wallet()
             async with returned:

--- a/tests/unit/test_streams_subscribe_router.py
+++ b/tests/unit/test_streams_subscribe_router.py
@@ -63,6 +63,7 @@ def _env_with(
             safe_init_code_hash=PRODUCTION.wallet_derivation.safe_init_code_hash,
             deposit_wallet_factory=PRODUCTION.wallet_derivation.deposit_wallet_factory,
             deposit_wallet_implementation=PRODUCTION.wallet_derivation.deposit_wallet_implementation,
+            deposit_wallet_beacon=PRODUCTION.wallet_derivation.deposit_wallet_beacon,
         ),
         collateral_token=PRODUCTION.collateral_token,
         conditional_tokens=PRODUCTION.conditional_tokens,
@@ -82,6 +83,7 @@ def _env_with(
         data_url=PRODUCTION.data_url,
         rtds_ws_url=rtds_ws_url,
         sports_ws_url=sports_ws_url,
+        rpc_url=PRODUCTION.rpc_url,
     )
 
 

--- a/tests/unit/test_wallet_derivations.py
+++ b/tests/unit/test_wallet_derivations.py
@@ -2,9 +2,10 @@ import pytest
 
 from polymarket._internal.wallet import (
     classify_wallet_type,
-    derive_deposit_wallet_address,
+    derive_beacon_deposit_wallet_address,
     derive_proxy_wallet_address,
     derive_safe_wallet_address,
+    derive_uups_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.environments import PRODUCTION
@@ -12,14 +13,20 @@ from polymarket.errors import UserInputError
 
 SIGNER = "0x0000000000000000000000000000000000000001"
 
-EXPECTED_DEPOSIT = "0x57ffbc34de23124faeb8387fcd689d314e57accd"
+EXPECTED_UUPS_DEPOSIT = "0x57ffbc34de23124faeb8387fcd689d314e57accd"
+EXPECTED_BEACON_DEPOSIT = "0x94bf330955a0b957662feaf878de77bf25f76cd9"
 EXPECTED_PROXY = "0x7754536ecd85c00b2e0cf9c1aa679340d8550756"
 EXPECTED_SAFE = "0x766b6851a199bf91ae3fa13b1cfac5187355118f"
 
 
-def test_derive_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
-    assert derived.lower() == EXPECTED_DEPOSIT
+def test_derive_uups_deposit_wallet_address_matches_ts_golden_vector() -> None:
+    derived = derive_uups_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    assert derived.lower() == EXPECTED_UUPS_DEPOSIT
+
+
+def test_derive_beacon_deposit_wallet_address_matches_ts_golden_vector() -> None:
+    derived = derive_beacon_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    assert derived.lower() == EXPECTED_BEACON_DEPOSIT
 
 
 def test_derive_proxy_wallet_address_matches_ts_golden_vector() -> None:
@@ -44,9 +51,16 @@ def test_classify_wallet_type_returns_eoa_when_wallet_equals_signer() -> None:
     assert result == "EOA"
 
 
-def test_classify_wallet_type_returns_deposit_wallet_for_derived_address() -> None:
+def test_classify_wallet_type_returns_deposit_wallet_for_uups_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_DEPOSIT, config=PRODUCTION.wallet_derivation
+        signer=SIGNER, wallet=EXPECTED_UUPS_DEPOSIT, config=PRODUCTION.wallet_derivation
+    )
+    assert result == "DEPOSIT_WALLET"
+
+
+def test_classify_wallet_type_returns_deposit_wallet_for_beacon_address() -> None:
+    result = classify_wallet_type(
+        signer=SIGNER, wallet=EXPECTED_BEACON_DEPOSIT, config=PRODUCTION.wallet_derivation
     )
     assert result == "DEPOSIT_WALLET"
 
@@ -66,7 +80,7 @@ def test_classify_wallet_type_returns_gnosis_safe_for_derived_address() -> None:
 
 
 def test_classify_wallet_type_is_case_insensitive() -> None:
-    upper = EXPECTED_DEPOSIT.upper().replace("0X", "0x")
+    upper = EXPECTED_UUPS_DEPOSIT.upper().replace("0X", "0x")
     result = classify_wallet_type(signer=SIGNER, wallet=upper, config=PRODUCTION.wallet_derivation)
     assert result == "DEPOSIT_WALLET"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deterministic deposit-wallet address derivation and makes `rpc_url`/`ctx.rpc` mandatory, affecting gasless wallet setup/readiness and proxy gas estimation. Risk is moderate because incorrect beacon detection or RPC failures could route users to the wrong wallet address or break workflows.
> 
> **Overview**
> **Adds support for a deposit-wallet factory migration to beacon proxies.** The SDK now detects whether `deposit_wallet_factory` exposes a beacon via an `eth_call`, and derives the deposit wallet address using either the new beacon init-code hash or the legacy UUPS init-code hash (`derive_current_deposit_wallet_address`).
> 
> **Makes RPC a required dependency and improves JSON-RPC error handling.** `Environment.rpc_url` and `AsyncSecureClientContext.rpc` are no longer optional; relayer proxy gas estimation always attempts `eth_estimateGas` and falls back on failure. `JsonRpcClient` now raises structured `JsonRpcCallError`, adds `eth_call`, and includes helpers to treat contract reverts as a non-fatal signal for legacy factory detection.
> 
> Tests are updated and expanded to cover beacon detection, EOA `is_gasless_ready`/`setup_gasless_wallet` behavior under legacy vs beacon factories, and RPC error propagation/fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737126e479b5a3bb7b7203314d31ee097b10d467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->