### PR TITLE
feat: sync parity for SecureClient relayer/wallet workflows

### DIFF
--- a/src/polymarket/__init__.py
+++ b/src/polymarket/__init__.py
@@ -117,6 +117,9 @@ from polymarket.pagination import AsyncPaginator, Page, Paginator
 from polymarket.transactions import (
     EoaTransactionHandle,
     GaslessTransactionHandle,
+    SyncEoaTransactionHandle,
+    SyncGaslessTransactionHandle,
+    SyncTransactionHandle,
     TransactionHandle,
 )
 from polymarket.types import EvmAddress, HexString, TransactionHash
@@ -223,6 +226,9 @@ __all__ = [
     "SplitActivity",
     "SportsMarketTypes",
     "SportsMetadata",
+    "SyncEoaTransactionHandle",
+    "SyncGaslessTransactionHandle",
+    "SyncTransactionHandle",
     "Tag",
     "TagId",
     "TagReference",

--- a/src/polymarket/_internal/actions/relayer/auth.py
+++ b/src/polymarket/_internal/actions/relayer/auth.py
@@ -8,6 +8,7 @@ from polymarket._internal.hmac import build_hmac_signature
 from polymarket.auth import ApiKey, BuilderApiKey, RelayerApiKey
 
 RelayerHeaderResolver = Callable[[str, str, str | None], Awaitable[Mapping[str, str]]]
+SyncRelayerHeaderResolver = Callable[[str, str, str | None], Mapping[str, str]]
 
 
 def make_relayer_header_resolver(api_key: ApiKey) -> RelayerHeaderResolver:
@@ -46,4 +47,45 @@ def make_relayer_header_resolver(api_key: ApiKey) -> RelayerHeaderResolver:
     assert_never(api_key)
 
 
-__all__ = ["RelayerHeaderResolver", "make_relayer_header_resolver"]
+def make_relayer_header_resolver_sync(api_key: ApiKey) -> SyncRelayerHeaderResolver:
+    if isinstance(api_key, BuilderApiKey):
+        creds = api_key
+
+        def builder_resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
+            timestamp = int(time.time())
+            signature = build_hmac_signature(
+                secret=creds.secret,
+                timestamp=timestamp,
+                method=method,
+                path=path,
+                body=body,
+            )
+            return {
+                "POLY_BUILDER_API_KEY": creds.key,
+                "POLY_BUILDER_PASSPHRASE": creds.passphrase,
+                "POLY_BUILDER_SIGNATURE": signature,
+                "POLY_BUILDER_TIMESTAMP": str(timestamp),
+            }
+
+        return builder_resolver
+
+    if isinstance(api_key, RelayerApiKey):  # pyright: ignore[reportUnnecessaryIsInstance]
+        headers: Mapping[str, str] = {
+            "RELAYER_API_KEY": api_key.key,
+            "RELAYER_API_KEY_ADDRESS": str(api_key.address),
+        }
+
+        def relayer_resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
+            return headers
+
+        return relayer_resolver
+
+    assert_never(api_key)
+
+
+__all__ = [
+    "RelayerHeaderResolver",
+    "SyncRelayerHeaderResolver",
+    "make_relayer_header_resolver",
+    "make_relayer_header_resolver_sync",
+]

--- a/src/polymarket/_internal/actions/relayer/deployed.py
+++ b/src/polymarket/_internal/actions/relayer/deployed.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.models.clob.relayer import (
     RelayerDeployedResponse,
     RelayerTransactionType,
@@ -20,4 +20,17 @@ async def fetch_deployed(
     return RelayerDeployedResponse.parse_response(data).deployed
 
 
-__all__ = ["fetch_deployed"]
+def fetch_deployed_sync(
+    relayer: SyncTransport,
+    *,
+    address: str,
+    type: RelayerTransactionType | None = None,
+) -> bool:
+    params: dict[str, str | None] = {"address": address}
+    if type is not None:
+        params["type"] = type.value
+    data = relayer.get_json("/deployed", params=params)
+    return RelayerDeployedResponse.parse_response(data).deployed
+
+
+__all__ = ["fetch_deployed", "fetch_deployed_sync"]

--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -194,8 +194,6 @@ async def _estimate_proxy_gas_limit(
     to: str,
     data: str,
 ) -> str:
-    if ctx.rpc is None:
-        return _PROXY_DEFAULT_GAS_LIMIT
     try:
         estimated = await ctx.rpc.eth_estimate_gas({"from": from_address, "to": to, "data": data})
     except Exception:

--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -11,7 +11,9 @@ from polymarket._internal.actions.relayer.calls import (
 )
 from polymarket._internal.actions.relayer.nonce import (
     fetch_execute_params,
+    fetch_execute_params_sync,
     fetch_relay_payload,
+    fetch_relay_payload_sync,
 )
 from polymarket._internal.actions.relayer.signing.deposit_wallet import (
     sign_deposit_wallet_batch,
@@ -25,14 +27,15 @@ from polymarket._internal.actions.relayer.submit import (
     GASLESS_SUBMIT_RETRY_ATTEMPTS,
     is_retryable_submit_error,
     submit_gasless,
+    submit_gasless_sync,
 )
-from polymarket._internal.context import AsyncSecureClientContext
+from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket.errors import UserInputError
 from polymarket.models.clob.relayer import (
     RelayerExecuteResponse,
     RelayerTransactionType,
 )
-from polymarket.transactions import GaslessTransactionHandle
+from polymarket.transactions import GaslessTransactionHandle, SyncGaslessTransactionHandle
 from polymarket.types import EvmAddress, HexString
 
 _DEPOSIT_WALLET_DEADLINE_S = 600
@@ -124,20 +127,43 @@ async def _submit_deposit_wallet(
         deadline=deadline,
         chain_id=ctx.environment.chain_id,
     )
-    payload = {
+    payload = build_deposit_wallet_payload(
+        signer_address=ctx.signer.address,
+        deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
+        wallet=ctx.wallet,
+        calls=calls,
+        nonce=params.nonce,
+        deadline=deadline,
+        signature=signature,
+        metadata=metadata,
+    )
+    return await submit_gasless(ctx.relayer, payload=payload)
+
+
+def build_deposit_wallet_payload(
+    *,
+    signer_address: str,
+    deposit_wallet_factory: str,
+    wallet: EvmAddress,
+    calls: list[TransactionCall],
+    nonce: str,
+    deadline: str,
+    signature: str,
+    metadata: str,
+) -> dict[str, object]:
+    return {
         "type": RelayerTransactionType.WALLET.value,
-        "from": ctx.signer.address,
-        "to": ctx.environment.wallet_derivation.deposit_wallet_factory,
-        "nonce": params.nonce,
+        "from": signer_address,
+        "to": deposit_wallet_factory,
+        "nonce": nonce,
         "signature": signature,
         "metadata": metadata,
         "depositWalletParams": {
-            "depositWallet": str(ctx.wallet),
+            "depositWallet": str(wallet),
             "deadline": deadline,
             "calls": [{"target": str(c.to), "value": str(c.value), "data": c.data} for c in calls],
         },
     }
-    return await submit_gasless(ctx.relayer, payload=payload)
 
 
 async def _submit_proxy(
@@ -167,24 +193,51 @@ async def _submit_proxy(
         relay=relay,
     )
     signature = sign_proxy_message(ctx.signer, hash_)
-    payload = {
+    payload = build_proxy_payload(
+        signer_address=ctx.signer.address,
+        proxy_factory=to,
+        wallet=ctx.wallet,
+        data=data,
+        nonce=params.nonce,
+        signature=signature,
+        gas_limit=gas_limit,
+        relay=relay,
+        relay_hub=ctx.environment.relay_hub,
+        metadata=metadata,
+    )
+    return await submit_gasless(ctx.relayer, payload=payload)
+
+
+def build_proxy_payload(
+    *,
+    signer_address: str,
+    proxy_factory: str,
+    wallet: EvmAddress,
+    data: HexString,
+    nonce: str,
+    signature: str,
+    gas_limit: str,
+    relay: EvmAddress,
+    relay_hub: str,
+    metadata: str,
+) -> dict[str, object]:
+    return {
         "type": RelayerTransactionType.PROXY.value,
-        "from": ctx.signer.address,
-        "to": to,
-        "proxyWallet": str(ctx.wallet),
+        "from": signer_address,
+        "to": proxy_factory,
+        "proxyWallet": str(wallet),
         "data": data,
-        "nonce": params.nonce,
+        "nonce": nonce,
         "signature": signature,
         "metadata": metadata,
         "signatureParams": {
             "gasLimit": gas_limit,
             "gasPrice": _PROXY_GAS_PRICE,
             "relay": str(relay),
-            "relayHub": ctx.environment.relay_hub,
+            "relayHub": relay_hub,
             "relayerFee": _PROXY_RELAYER_FEE,
         },
     }
-    return await submit_gasless(ctx.relayer, payload=payload)
 
 
 async def _estimate_proxy_gas_limit(
@@ -210,18 +263,7 @@ async def _submit_safe(
     params = await fetch_execute_params(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
     )
-
-    if len(calls) == 1:
-        target = calls[0].to
-        data: HexString = calls[0].data
-        value = calls[0].value
-        operation = _SAFE_OPERATION_CALL
-    else:
-        target = EvmAddress(ctx.environment.safe_multisend)
-        data = encode_safe_multisend_call(calls)
-        value = 0
-        operation = _SAFE_OPERATION_DELEGATECALL
-
+    target, data, value, operation = _resolve_safe_call(ctx.environment.safe_multisend, calls)
     signature = sign_safe_transaction(
         ctx.signer,
         safe_address=ctx.wallet,
@@ -232,13 +274,52 @@ async def _submit_safe(
         nonce=params.nonce,
         chain_id=ctx.environment.chain_id,
     )
+    payload = build_safe_payload(
+        signer_address=ctx.signer.address,
+        wallet=ctx.wallet,
+        target=target,
+        data=data,
+        value=value,
+        operation=operation,
+        nonce=params.nonce,
+        signature=signature,
+        metadata=metadata,
+    )
+    return await submit_gasless(ctx.relayer, payload=payload)
+
+
+def _resolve_safe_call(
+    safe_multisend: str, calls: list[TransactionCall]
+) -> tuple[EvmAddress, HexString, int, int]:
+    if len(calls) == 1:
+        return calls[0].to, calls[0].data, calls[0].value, _SAFE_OPERATION_CALL
+    return (
+        EvmAddress(safe_multisend),
+        encode_safe_multisend_call(calls),
+        0,
+        _SAFE_OPERATION_DELEGATECALL,
+    )
+
+
+def build_safe_payload(
+    *,
+    signer_address: str,
+    wallet: EvmAddress,
+    target: EvmAddress,
+    data: HexString,
+    value: int,
+    operation: int,
+    nonce: str,
+    signature: str,
+    metadata: str,
+) -> dict[str, object]:
     payload: dict[str, object] = {
         "type": RelayerTransactionType.SAFE.value,
-        "from": ctx.signer.address,
+        "from": signer_address,
         "to": str(target),
-        "proxyWallet": str(ctx.wallet),
+        "proxyWallet": str(wallet),
         "data": data,
-        "nonce": params.nonce,
+        "nonce": nonce,
         "signature": signature,
         "metadata": metadata,
         "signatureParams": {
@@ -252,7 +333,7 @@ async def _submit_safe(
     }
     if value > 0:
         payload["value"] = str(value)
-    return await submit_gasless(ctx.relayer, payload=payload)
+    return payload
 
 
 async def submit_deposit_wallet_create(
@@ -284,4 +365,223 @@ async def submit_deposit_wallet_create(
     )
 
 
-__all__ = ["prepare_gasless_transaction", "submit_deposit_wallet_create"]
+def prepare_gasless_transaction_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    calls: list[TransactionCall],
+    metadata: str = "",
+) -> SyncGaslessTransactionHandle:
+    if ctx.api_key is None:
+        raise UserInputError(
+            "Gasless transactions require a Builder API Key or Relayer API Key. "
+            "Pass api_key= when constructing the client."
+        )
+    if ctx.wallet_type == "EOA":
+        raise UserInputError(
+            "EOA wallets do not use the relayer in this SDK version. "
+            "Direct EOA broadcasting is planned but not yet supported."
+        )
+    if not calls:
+        raise UserInputError("prepare_gasless_transaction requires at least one call")
+    if len(metadata) > _METADATA_MAX_LENGTH:
+        raise UserInputError(f"metadata must be at most {_METADATA_MAX_LENGTH} characters")
+
+    env = ctx.environment
+    retry_delay_s = env.relayer_poll_frequency_ms / 1000
+    last_error: BaseException | None = None
+    for attempt in range(GASLESS_SUBMIT_RETRY_ATTEMPTS + 1):
+        try:
+            response = _submit_for_wallet_type_sync(ctx, calls=calls, metadata=metadata)
+            return SyncGaslessTransactionHandle(
+                transaction_id=response.transaction_id,
+                transaction_hash=response.transaction_hash,
+                _relayer=ctx.relayer,
+                _max_polls=env.relayer_max_polls,
+                _poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+            )
+        except Exception as error:
+            last_error = error
+            if attempt == GASLESS_SUBMIT_RETRY_ATTEMPTS or not is_retryable_submit_error(error):
+                raise
+            time.sleep(retry_delay_s)
+    assert last_error is not None
+    raise last_error
+
+
+def _submit_for_wallet_type_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    calls: list[TransactionCall],
+    metadata: str,
+) -> RelayerExecuteResponse:
+    wallet_type = ctx.wallet_type
+    if wallet_type == "DEPOSIT_WALLET":
+        return _submit_deposit_wallet_sync(ctx, calls=calls, metadata=metadata)
+    if wallet_type == "POLY_PROXY":
+        return _submit_proxy_sync(ctx, calls=calls, metadata=metadata)
+    if wallet_type == "GNOSIS_SAFE":
+        return _submit_safe_sync(ctx, calls=calls, metadata=metadata)
+    if wallet_type == "EOA":
+        raise UserInputError("EOA wallets are not supported by the relayer in this SDK version")
+    assert_never(wallet_type)
+
+
+def _submit_deposit_wallet_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    calls: list[TransactionCall],
+    metadata: str,
+) -> RelayerExecuteResponse:
+    params = fetch_execute_params_sync(
+        ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.WALLET
+    )
+    deadline = str(int(time.time()) + _DEPOSIT_WALLET_DEADLINE_S)
+    signature = sign_deposit_wallet_batch(
+        ctx.signer,
+        wallet=ctx.wallet,
+        calls=calls,
+        nonce=params.nonce,
+        deadline=deadline,
+        chain_id=ctx.environment.chain_id,
+    )
+    payload = build_deposit_wallet_payload(
+        signer_address=ctx.signer.address,
+        deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
+        wallet=ctx.wallet,
+        calls=calls,
+        nonce=params.nonce,
+        deadline=deadline,
+        signature=signature,
+        metadata=metadata,
+    )
+    return submit_gasless_sync(ctx.relayer, payload=payload)
+
+
+def _submit_proxy_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    calls: list[TransactionCall],
+    metadata: str,
+) -> RelayerExecuteResponse:
+    params = fetch_relay_payload_sync(
+        ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.PROXY
+    )
+    to = ctx.environment.wallet_derivation.proxy_factory
+    data = encode_proxy_call(calls)
+    relay = EvmAddress(params.address)
+    gas_limit = _estimate_proxy_gas_limit_sync(
+        ctx, from_address=ctx.signer.address, to=to, data=data
+    )
+    hash_ = build_proxy_transaction_hash(
+        from_address=EvmAddress(ctx.signer.address),
+        to=EvmAddress(to),
+        data=data,
+        relayer_fee=_PROXY_RELAYER_FEE,
+        gas_price=_PROXY_GAS_PRICE,
+        gas_limit=gas_limit,
+        nonce=params.nonce,
+        relay_hub=EvmAddress(ctx.environment.relay_hub),
+        relay=relay,
+    )
+    signature = sign_proxy_message(ctx.signer, hash_)
+    payload = build_proxy_payload(
+        signer_address=ctx.signer.address,
+        proxy_factory=to,
+        wallet=ctx.wallet,
+        data=data,
+        nonce=params.nonce,
+        signature=signature,
+        gas_limit=gas_limit,
+        relay=relay,
+        relay_hub=ctx.environment.relay_hub,
+        metadata=metadata,
+    )
+    return submit_gasless_sync(ctx.relayer, payload=payload)
+
+
+def _estimate_proxy_gas_limit_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    from_address: str,
+    to: str,
+    data: str,
+) -> str:
+    try:
+        estimated = ctx.rpc.eth_estimate_gas({"from": from_address, "to": to, "data": data})
+    except Exception:
+        return _PROXY_DEFAULT_GAS_LIMIT
+    return str(estimated)
+
+
+def _submit_safe_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    calls: list[TransactionCall],
+    metadata: str,
+) -> RelayerExecuteResponse:
+    params = fetch_execute_params_sync(
+        ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
+    )
+    target, data, value, operation = _resolve_safe_call(ctx.environment.safe_multisend, calls)
+    signature = sign_safe_transaction(
+        ctx.signer,
+        safe_address=ctx.wallet,
+        to=target,
+        data=data,
+        value=value,
+        operation=operation,
+        nonce=params.nonce,
+        chain_id=ctx.environment.chain_id,
+    )
+    payload = build_safe_payload(
+        signer_address=ctx.signer.address,
+        wallet=ctx.wallet,
+        target=target,
+        data=data,
+        value=value,
+        operation=operation,
+        nonce=params.nonce,
+        signature=signature,
+        metadata=metadata,
+    )
+    return submit_gasless_sync(ctx.relayer, payload=payload)
+
+
+def submit_deposit_wallet_create_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    metadata: str = "",
+) -> SyncGaslessTransactionHandle:
+    if ctx.api_key is None:
+        raise UserInputError(
+            "Gasless transactions require a Builder API Key or Relayer API Key. "
+            "Pass api_key= when constructing the client."
+        )
+    if len(metadata) > _METADATA_MAX_LENGTH:
+        raise UserInputError(f"metadata must be at most {_METADATA_MAX_LENGTH} characters")
+    payload = {
+        "type": RelayerTransactionType.WALLET_CREATE.value,
+        "from": ctx.signer.address,
+        "to": ctx.environment.wallet_derivation.deposit_wallet_factory,
+        "metadata": metadata,
+    }
+    response = submit_gasless_sync(ctx.relayer, payload=payload)
+    env = ctx.environment
+    return SyncGaslessTransactionHandle(
+        transaction_id=response.transaction_id,
+        transaction_hash=response.transaction_hash,
+        _relayer=ctx.relayer,
+        _max_polls=env.relayer_max_polls,
+        _poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+    )
+
+
+__all__ = [
+    "build_deposit_wallet_payload",
+    "build_proxy_payload",
+    "build_safe_payload",
+    "prepare_gasless_transaction",
+    "prepare_gasless_transaction_sync",
+    "submit_deposit_wallet_create",
+    "submit_deposit_wallet_create_sync",
+]

--- a/src/polymarket/_internal/actions/relayer/nonce.py
+++ b/src/polymarket/_internal/actions/relayer/nonce.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.models.clob.relayer import RelayerExecuteParams, RelayerTransactionType
 
 
@@ -11,6 +11,19 @@ async def fetch_execute_params(
     type: RelayerTransactionType,
 ) -> RelayerExecuteParams:
     data = await relayer.get_json(
+        "/v1/account/transactions/params",
+        params={"address": address, "type": type.value},
+    )
+    return RelayerExecuteParams.parse_response(data)
+
+
+def fetch_execute_params_sync(
+    relayer: SyncTransport,
+    *,
+    address: str,
+    type: RelayerTransactionType,
+) -> RelayerExecuteParams:
+    data = relayer.get_json(
         "/v1/account/transactions/params",
         params={"address": address, "type": type.value},
     )
@@ -30,4 +43,22 @@ async def fetch_relay_payload(
     return RelayerExecuteParams.parse_response(data)
 
 
-__all__ = ["fetch_execute_params", "fetch_relay_payload"]
+def fetch_relay_payload_sync(
+    relayer: SyncTransport,
+    *,
+    address: str,
+    type: RelayerTransactionType,
+) -> RelayerExecuteParams:
+    data = relayer.get_json(
+        "/relay-payload",
+        params={"address": address, "type": type.value},
+    )
+    return RelayerExecuteParams.parse_response(data)
+
+
+__all__ = [
+    "fetch_execute_params",
+    "fetch_execute_params_sync",
+    "fetch_relay_payload",
+    "fetch_relay_payload_sync",
+]

--- a/src/polymarket/_internal/actions/relayer/poll.py
+++ b/src/polymarket/_internal/actions/relayer/poll.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import cast
 
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.errors import TimeoutError, TransactionFailedError, UnexpectedResponseError
 from polymarket.models.clob.relayer import (
     GaslessTransaction,
@@ -23,6 +24,13 @@ async def fetch_gasless_transaction(
     return GaslessTransaction.parse_response(data)
 
 
+def fetch_gasless_transaction_sync(
+    relayer: SyncTransport, *, transaction_id: str
+) -> GaslessTransaction:
+    data = relayer.get_json(f"/v1/account/transactions/{transaction_id}")
+    return GaslessTransaction.parse_response(data)
+
+
 async def poll_until_terminal(
     relayer: AsyncTransport,
     *,
@@ -33,20 +41,9 @@ async def poll_until_terminal(
 ) -> TransactionOutcome:
     for _ in range(max_polls):
         tx = await fetch_gasless_transaction(relayer, transaction_id=transaction_id)
-        if tx.state in _TERMINAL_SUCCESS:
-            tx_hash = tx.transaction_hash or fallback_hash
-            if tx_hash is None:
-                raise UnexpectedResponseError(
-                    f"Transaction {transaction_id} settled without a transaction hash"
-                )
-            return TransactionOutcome(
-                transaction_hash=cast(TransactionHash, tx_hash),
-                transaction_id=tx.transaction_id,
-            )
-        if tx.state in _TERMINAL_FAILURE:
-            raise TransactionFailedError(
-                tx.error_msg or f"Transaction {transaction_id} reached terminal state {tx.state}"
-            )
+        outcome = _terminal_outcome(tx, transaction_id=transaction_id, fallback_hash=fallback_hash)
+        if outcome is not None:
+            return outcome
         await asyncio.sleep(poll_delay_s)
     raise TimeoutError(
         f"Timed out waiting for transaction {transaction_id} after "
@@ -54,4 +51,49 @@ async def poll_until_terminal(
     )
 
 
-__all__ = ["fetch_gasless_transaction", "poll_until_terminal"]
+def poll_until_terminal_sync(
+    relayer: SyncTransport,
+    *,
+    transaction_id: str,
+    fallback_hash: str | None,
+    max_polls: int,
+    poll_delay_s: float,
+) -> TransactionOutcome:
+    for _ in range(max_polls):
+        tx = fetch_gasless_transaction_sync(relayer, transaction_id=transaction_id)
+        outcome = _terminal_outcome(tx, transaction_id=transaction_id, fallback_hash=fallback_hash)
+        if outcome is not None:
+            return outcome
+        time.sleep(poll_delay_s)
+    raise TimeoutError(
+        f"Timed out waiting for transaction {transaction_id} after "
+        f"{max_polls} polls ({max_polls * poll_delay_s:.0f}s)"
+    )
+
+
+def _terminal_outcome(
+    tx: GaslessTransaction, *, transaction_id: str, fallback_hash: str | None
+) -> TransactionOutcome | None:
+    if tx.state in _TERMINAL_SUCCESS:
+        tx_hash = tx.transaction_hash or fallback_hash
+        if tx_hash is None:
+            raise UnexpectedResponseError(
+                f"Transaction {transaction_id} settled without a transaction hash"
+            )
+        return TransactionOutcome(
+            transaction_hash=cast(TransactionHash, tx_hash),
+            transaction_id=tx.transaction_id,
+        )
+    if tx.state in _TERMINAL_FAILURE:
+        raise TransactionFailedError(
+            tx.error_msg or f"Transaction {transaction_id} reached terminal state {tx.state}"
+        )
+    return None
+
+
+__all__ = [
+    "fetch_gasless_transaction",
+    "fetch_gasless_transaction_sync",
+    "poll_until_terminal",
+    "poll_until_terminal_sync",
+]

--- a/src/polymarket/_internal/actions/relayer/submit.py
+++ b/src/polymarket/_internal/actions/relayer/submit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.errors import RateLimitError, RequestRejectedError
 from polymarket.models.clob.relayer import RelayerExecuteResponse
 
@@ -20,6 +20,13 @@ async def submit_gasless(
     relayer: AsyncTransport, *, payload: dict[str, Any]
 ) -> RelayerExecuteResponse:
     data = await relayer.post_json("/submit", json=payload)
+    return RelayerExecuteResponse.parse_response(data)
+
+
+def submit_gasless_sync(
+    relayer: SyncTransport, *, payload: dict[str, Any]
+) -> RelayerExecuteResponse:
+    data = relayer.post_json("/submit", json=payload)
     return RelayerExecuteResponse.parse_response(data)
 
 
@@ -43,4 +50,5 @@ __all__ = [
     "GASLESS_SUBMIT_RETRY_ATTEMPTS",
     "is_retryable_submit_error",
     "submit_gasless",
+    "submit_gasless_sync",
 ]

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -47,7 +47,7 @@ class AsyncSecureClientContext(AsyncClientContext):
     wallet_type: WalletType
     relayer: AsyncTransport
     api_key: ApiKey | None
-    rpc: JsonRpcClient | None
+    rpc: JsonRpcClient
 
 
 __all__ = [

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from eth_account.signers.local import LocalAccount
 
-from polymarket._internal.eoa.rpc import JsonRpcClient
+from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
 from polymarket._internal.wallet import WalletType
 from polymarket.auth import ApiKey
 from polymarket.clients._transport import AsyncTransport, SyncTransport
@@ -28,6 +28,9 @@ class SyncSecureClientContext(SyncClientContext):
     secure_clob: SyncTransport
     wallet: EvmAddress
     wallet_type: WalletType
+    relayer: SyncTransport
+    api_key: ApiKey | None
+    rpc: SyncJsonRpcClient
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/polymarket/_internal/eoa/broadcast.py
+++ b/src/polymarket/_internal/eoa/broadcast.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any, cast
 
 from eth_account.signers.local import LocalAccount
 
 from polymarket._internal.actions.relayer.calls import TransactionCall
-from polymarket._internal.eoa.rpc import JsonRpcClient
+from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
 from polymarket.errors import (
     SigningError,
     TimeoutError,
@@ -14,7 +15,7 @@ from polymarket.errors import (
     UnexpectedResponseError,
 )
 from polymarket.models.clob.relayer import TransactionOutcome
-from polymarket.transactions import EoaTransactionHandle
+from polymarket.transactions import EoaTransactionHandle, SyncEoaTransactionHandle
 from polymarket.types import TransactionHash
 
 
@@ -87,4 +88,78 @@ async def wait_for_receipt(
     )
 
 
-__all__ = ["broadcast_eoa_call", "wait_for_receipt"]
+def broadcast_eoa_call_sync(
+    *,
+    rpc: SyncJsonRpcClient,
+    signer: LocalAccount,
+    call: TransactionCall,
+    chain_id: int,
+    max_polls: int,
+    poll_delay_s: float,
+) -> SyncEoaTransactionHandle:
+    rpc.verify_chain_id(chain_id)
+    nonce = rpc.eth_get_transaction_count(signer.address)
+    gas_price = rpc.eth_gas_price()
+    estimate_payload = {
+        "from": signer.address,
+        "to": str(call.to),
+        "value": hex(call.value),
+        "data": call.data,
+    }
+    gas = rpc.eth_estimate_gas(estimate_payload)
+    tx = {
+        "to": str(call.to),
+        "value": call.value,
+        "data": call.data,
+        "gas": gas,
+        "gasPrice": gas_price,
+        "nonce": nonce,
+        "chainId": chain_id,
+    }
+    try:
+        signed = signer.sign_transaction(cast(Any, tx))
+    except Exception as error:
+        raise SigningError(f"Failed to sign EOA transaction: {error}") from error
+    tx_hash = rpc.eth_send_raw_transaction("0x" + signed.raw_transaction.hex())
+    return SyncEoaTransactionHandle(
+        transaction_hash=tx_hash,
+        _rpc=rpc,
+        _max_polls=max_polls,
+        _poll_delay_s=poll_delay_s,
+    )
+
+
+def wait_for_receipt_sync(
+    rpc: SyncJsonRpcClient,
+    *,
+    transaction_hash: str,
+    max_polls: int,
+    poll_delay_s: float,
+) -> TransactionOutcome:
+    for _ in range(max_polls):
+        receipt = rpc.eth_get_transaction_receipt(transaction_hash)
+        if receipt is not None:
+            status = receipt.get("status")
+            if status in ("0x1", 1):
+                return TransactionOutcome(
+                    transaction_hash=cast(TransactionHash, transaction_hash),
+                    transaction_id=None,
+                )
+            if status in ("0x0", 0):
+                raise TransactionFailedError(f"EOA transaction {transaction_hash} reverted")
+            raise UnexpectedResponseError(
+                f"EOA transaction {transaction_hash} has unrecognized status {status!r}"
+            )
+        time.sleep(poll_delay_s)
+    raise TimeoutError(
+        f"Timed out waiting for EOA transaction {transaction_hash} after "
+        f"{max_polls} polls ({max_polls * poll_delay_s:.0f}s)"
+    )
+
+
+__all__ = [
+    "broadcast_eoa_call",
+    "broadcast_eoa_call_sync",
+    "wait_for_receipt",
+    "wait_for_receipt_sync",
+]

--- a/src/polymarket/_internal/eoa/rpc.py
+++ b/src/polymarket/_internal/eoa/rpc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json as _json
 from typing import Any, cast
 
-from polymarket.clients._transport import AsyncTransport
+from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.errors import RequestRejectedError, UnexpectedResponseError, UserInputError
 
 _JSON_RPC_REVERT_CODES = frozenset({3, -32_000, -32_003, -32_015, -32_603})
@@ -119,6 +119,86 @@ class JsonRpcClient:
         return cast(dict[str, Any], result)
 
 
+class SyncJsonRpcClient:
+    def __init__(self, transport: SyncTransport) -> None:
+        self._transport = transport
+        self._id = 0
+        self._verified_chain_id: int | None = None
+
+    def close(self) -> None:
+        self._transport.close()
+
+    def verify_chain_id(self, expected: int) -> None:
+        if self._verified_chain_id is not None:
+            if self._verified_chain_id != expected:
+                raise UserInputError(
+                    f"RPC chain id {self._verified_chain_id} does not match "
+                    f"environment.chain_id {expected}. Configure rpc_url for the correct chain."
+                )
+            return
+        actual = self.eth_chain_id()
+        if actual != expected:
+            raise UserInputError(
+                f"RPC chain id {actual} does not match environment.chain_id {expected}. "
+                "Configure rpc_url for the correct chain."
+            )
+        self._verified_chain_id = actual
+
+    def _call(self, method: str, params: list[Any]) -> Any:
+        self._id += 1
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": self._id,
+            "method": method,
+            "params": params,
+        }
+        raw = self._transport.post_json("", json=envelope)
+        if not isinstance(raw, dict):
+            raise UnexpectedResponseError(f"JSON-RPC {method} returned a non-object response")
+        response = cast(dict[str, Any], raw)
+        if "error" in response:
+            err: Any = response["error"]
+            code, message, data = _extract_error_fields(err)
+            raise JsonRpcCallError(method=method, code=code, message=message, data=data)
+        return response.get("result")
+
+    def eth_chain_id(self) -> int:
+        result = self._call("eth_chainId", [])
+        return _hex_to_int(result, "eth_chainId")
+
+    def eth_call(self, *, to: str, data: str, block: str = "latest") -> str:
+        result = self._call("eth_call", [{"to": to, "data": data}, block])
+        if not isinstance(result, str) or not _is_rpc_hex_string(result):
+            raise UnexpectedResponseError("eth_call did not return a hex string")
+        return result
+
+    def eth_get_transaction_count(self, address: str, block: str = "pending") -> int:
+        result = self._call("eth_getTransactionCount", [address, block])
+        return _hex_to_int(result, "eth_getTransactionCount")
+
+    def eth_gas_price(self) -> int:
+        result = self._call("eth_gasPrice", [])
+        return _hex_to_int(result, "eth_gasPrice")
+
+    def eth_estimate_gas(self, tx: dict[str, Any]) -> int:
+        result = self._call("eth_estimateGas", [tx])
+        return _hex_to_int(result, "eth_estimateGas")
+
+    def eth_send_raw_transaction(self, signed_hex: str) -> str:
+        result = self._call("eth_sendRawTransaction", [signed_hex])
+        if not isinstance(result, str):
+            raise UnexpectedResponseError("eth_sendRawTransaction did not return a hex string")
+        return result
+
+    def eth_get_transaction_receipt(self, tx_hash: str) -> dict[str, Any] | None:
+        result = self._call("eth_getTransactionReceipt", [tx_hash])
+        if result is None:
+            return None
+        if not isinstance(result, dict):
+            raise UnexpectedResponseError("eth_getTransactionReceipt did not return an object")
+        return cast(dict[str, Any], result)
+
+
 def _extract_error_fields(err: object) -> tuple[int, str, object]:
     if isinstance(err, dict):
         err_dict = cast(dict[str, object], err)
@@ -146,4 +226,9 @@ def _hex_to_int(value: Any, method: str) -> int:
         raise UnexpectedResponseError(f"{method} returned malformed hex: {error}") from error
 
 
-__all__ = ["JsonRpcCallError", "JsonRpcClient", "is_json_rpc_contract_revert"]
+__all__ = [
+    "JsonRpcCallError",
+    "JsonRpcClient",
+    "SyncJsonRpcClient",
+    "is_json_rpc_contract_revert",
+]

--- a/src/polymarket/_internal/eoa/rpc.py
+++ b/src/polymarket/_internal/eoa/rpc.py
@@ -1,9 +1,42 @@
 from __future__ import annotations
 
+import json as _json
 from typing import Any, cast
 
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError, UserInputError
+
+_JSON_RPC_REVERT_CODES = frozenset({3, -32_000, -32_003, -32_015, -32_603})
+_JSON_RPC_REVERT_TOKENS = ("execution reverted", "revert", "invalid opcode")
+
+
+class JsonRpcCallError(RequestRejectedError):
+    def __init__(self, method: str, code: int, message: str, data: object) -> None:
+        super().__init__(f"JSON-RPC {method} failed: {message}", status=200)
+        self.method = method
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+def is_json_rpc_contract_revert(error: object) -> bool:
+    if not isinstance(error, JsonRpcCallError):
+        return False
+    if error.code not in _JSON_RPC_REVERT_CODES:
+        return False
+    haystack = f"{error.message} {_stringify_error_data(error.data)}".lower()
+    return any(token in haystack for token in _JSON_RPC_REVERT_TOKENS)
+
+
+def _stringify_error_data(data: object) -> str:
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    try:
+        return _json.dumps(data)
+    except (TypeError, ValueError):
+        return ""
 
 
 class JsonRpcClient:
@@ -45,13 +78,19 @@ class JsonRpcClient:
         response = cast(dict[str, Any], raw)
         if "error" in response:
             err: Any = response["error"]
-            message = _extract_error_message(err)
-            raise UnexpectedResponseError(f"JSON-RPC {method} failed: {message}")
+            code, message, data = _extract_error_fields(err)
+            raise JsonRpcCallError(method=method, code=code, message=message, data=data)
         return response.get("result")
 
     async def eth_chain_id(self) -> int:
         result = await self._call("eth_chainId", [])
         return _hex_to_int(result, "eth_chainId")
+
+    async def eth_call(self, *, to: str, data: str, block: str = "latest") -> str:
+        result = await self._call("eth_call", [{"to": to, "data": data}, block])
+        if not isinstance(result, str) or not _is_rpc_hex_string(result):
+            raise UnexpectedResponseError("eth_call did not return a hex string")
+        return result
 
     async def eth_get_transaction_count(self, address: str, block: str = "pending") -> int:
         result = await self._call("eth_getTransactionCount", [address, block])
@@ -80,14 +119,22 @@ class JsonRpcClient:
         return cast(dict[str, Any], result)
 
 
-def _extract_error_message(err: object) -> str:
+def _extract_error_fields(err: object) -> tuple[int, str, object]:
     if isinstance(err, dict):
         err_dict = cast(dict[str, object], err)
-        msg = err_dict.get("message")
-        if isinstance(msg, str):
-            return msg
-        return repr(err_dict)
-    return str(err)
+        raw_code = err_dict.get("code")
+        code = raw_code if isinstance(raw_code, int) and not isinstance(raw_code, bool) else 0
+        raw_message = err_dict.get("message")
+        message = raw_message if isinstance(raw_message, str) else repr(err_dict)
+        return code, message, err_dict.get("data")
+    return 0, str(err), None
+
+
+def _is_rpc_hex_string(value: str) -> bool:
+    if not value.startswith("0x"):
+        return False
+    rest = value[2:]
+    return all(c in "0123456789abcdefABCDEF" for c in rest)
 
 
 def _hex_to_int(value: Any, method: str) -> int:
@@ -99,4 +146,4 @@ def _hex_to_int(value: Any, method: str) -> int:
         raise UnexpectedResponseError(f"{method} returned malformed hex: {error}") from error
 
 
-__all__ = ["JsonRpcClient"]
+__all__ = ["JsonRpcCallError", "JsonRpcClient", "is_json_rpc_contract_revert"]

--- a/src/polymarket/_internal/wallet.py
+++ b/src/polymarket/_internal/wallet.py
@@ -7,6 +7,7 @@ from eth_abi.packed import encode_packed
 from eth_utils.address import to_checksum_address
 from eth_utils.crypto import keccak
 
+from polymarket._internal.eoa.rpc import JsonRpcClient, is_json_rpc_contract_revert
 from polymarket.environments import WalletDerivation
 from polymarket.errors import UserInputError
 
@@ -33,6 +34,18 @@ _ERC1967_CONST1 = bytes.fromhex("cc3735a920a3ca505d382bbc545af43d6000803e6038573
 _ERC1967_CONST2 = bytes.fromhex("5155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076")
 _ERC1967_PREFIX_BASE = 0x61003D3D8160233D3973
 
+_ERC1967_BEACON_CONST1 = bytes.fromhex(
+    "b3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3"
+)
+_ERC1967_BEACON_CONST2 = bytes.fromhex(
+    "1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c"
+)
+_ERC1967_BEACON_CONST3 = bytes.fromhex("60195155f3363d3d373d3d363d602036600436635c60da")
+_ERC1967_BEACON_PREFIX_BASE = 0x6100523D8160233D3973
+
+_FACTORY_BEACON_SELECTOR = "0x49493a4d"
+_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
 
 def signature_type_for(wallet_type: WalletType) -> int:
     return _SIGNATURE_TYPE_BY_WALLET[wallet_type]
@@ -56,13 +69,41 @@ def derive_safe_wallet_address(signer: str, config: WalletDerivation) -> str:
     return _create2(config.safe_factory, salt, bytecode_hash)
 
 
-def derive_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
-    signer_bytes = bytes.fromhex(_strip_0x(signer))
-    wallet_id = signer_bytes.rjust(32, b"\x00")
-    args = abi_encode(["address", "bytes32"], [config.deposit_wallet_factory, wallet_id])
-    bytecode_hash = _deposit_init_code_hash(config.deposit_wallet_implementation, args)
+def derive_uups_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+    args = _deposit_wallet_args(signer, config)
+    bytecode_hash = _uups_deposit_init_code_hash(config.deposit_wallet_implementation, args)
     salt = keccak(args)
     return _create2(config.deposit_wallet_factory, salt, bytecode_hash)
+
+
+def derive_beacon_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+    args = _deposit_wallet_args(signer, config)
+    bytecode_hash = _beacon_deposit_init_code_hash(config.deposit_wallet_beacon, args)
+    salt = keccak(args)
+    return _create2(config.deposit_wallet_factory, salt, bytecode_hash)
+
+
+async def get_deposit_wallet_factory_beacon(rpc: JsonRpcClient, factory: str) -> str:
+    try:
+        data = await rpc.eth_call(to=factory, data=_FACTORY_BEACON_SELECTOR)
+    except Exception as error:
+        if is_json_rpc_contract_revert(error):
+            return _ZERO_ADDRESS
+        raise
+    return _decode_address_return_data(data)
+
+
+async def is_beacon_deposit_wallet_factory(rpc: JsonRpcClient, factory: str) -> bool:
+    beacon = await get_deposit_wallet_factory_beacon(rpc, factory)
+    return beacon.lower() != _ZERO_ADDRESS
+
+
+async def derive_current_deposit_wallet_address(
+    rpc: JsonRpcClient, signer: str, config: WalletDerivation
+) -> str:
+    if await is_beacon_deposit_wallet_factory(rpc, config.deposit_wallet_factory):
+        return derive_beacon_deposit_wallet_address(signer, config)
+    return derive_uups_deposit_wallet_address(signer, config)
 
 
 def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) -> WalletType:
@@ -77,7 +118,9 @@ def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) 
 
     if wallet_checksum == signer_checksum:
         return "EOA"
-    if wallet_checksum == derive_deposit_wallet_address(signer_checksum, config):
+    if wallet_checksum == derive_beacon_deposit_wallet_address(signer_checksum, config):
+        return "DEPOSIT_WALLET"
+    if wallet_checksum == derive_uups_deposit_wallet_address(signer_checksum, config):
         return "DEPOSIT_WALLET"
     if wallet_checksum == derive_proxy_wallet_address(signer_checksum, config):
         return "POLY_PROXY"
@@ -90,13 +133,19 @@ def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) 
     )
 
 
+def _deposit_wallet_args(signer: str, config: WalletDerivation) -> bytes:
+    signer_bytes = bytes.fromhex(_strip_0x(signer))
+    wallet_id = signer_bytes.rjust(32, b"\x00")
+    return abi_encode(["address", "bytes32"], [config.deposit_wallet_factory, wallet_id])
+
+
 def _create2(factory: str, salt: bytes, bytecode_hash: bytes) -> str:
     factory_bytes = bytes.fromhex(_strip_0x(factory))
     raw = b"\xff" + factory_bytes + salt + bytecode_hash
     return to_checksum_address("0x" + keccak(raw)[12:].hex())
 
 
-def _deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
+def _uups_deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
     args_byte_length = len(args)
     prefix = _ERC1967_PREFIX_BASE + (args_byte_length << 56)
     prefix_bytes = prefix.to_bytes(10, "big")
@@ -107,6 +156,31 @@ def _deposit_init_code_hash(implementation: str, args: bytes) -> bytes:
     return keccak(bytecode)
 
 
+def _beacon_deposit_init_code_hash(beacon: str, args: bytes) -> bytes:
+    args_byte_length = len(args)
+    prefix = _ERC1967_BEACON_PREFIX_BASE + (args_byte_length << 56)
+    prefix_bytes = prefix.to_bytes(10, "big")
+    beacon_bytes = bytes.fromhex(_strip_0x(beacon))
+    bytecode = (
+        prefix_bytes
+        + beacon_bytes
+        + _ERC1967_BEACON_CONST3
+        + _ERC1967_BEACON_CONST2
+        + _ERC1967_BEACON_CONST1
+        + args
+    )
+    return keccak(bytecode)
+
+
+def _decode_address_return_data(data: str) -> str:
+    if len(data) < 66:
+        return _ZERO_ADDRESS
+    try:
+        return to_checksum_address("0x" + data[-40:])
+    except ValueError:
+        return _ZERO_ADDRESS
+
+
 def _strip_0x(value: str) -> str:
     return value[2:] if value.startswith(("0x", "0X")) else value
 
@@ -114,8 +188,12 @@ def _strip_0x(value: str) -> str:
 __all__ = [
     "WalletType",
     "classify_wallet_type",
-    "derive_deposit_wallet_address",
+    "derive_beacon_deposit_wallet_address",
+    "derive_current_deposit_wallet_address",
     "derive_proxy_wallet_address",
     "derive_safe_wallet_address",
+    "derive_uups_deposit_wallet_address",
+    "get_deposit_wallet_factory_beacon",
+    "is_beacon_deposit_wallet_factory",
     "signature_type_for",
 ]

--- a/src/polymarket/_internal/wallet.py
+++ b/src/polymarket/_internal/wallet.py
@@ -7,7 +7,11 @@ from eth_abi.packed import encode_packed
 from eth_utils.address import to_checksum_address
 from eth_utils.crypto import keccak
 
-from polymarket._internal.eoa.rpc import JsonRpcClient, is_json_rpc_contract_revert
+from polymarket._internal.eoa.rpc import (
+    JsonRpcClient,
+    SyncJsonRpcClient,
+    is_json_rpc_contract_revert,
+)
 from polymarket.environments import WalletDerivation
 from polymarket.errors import UserInputError
 
@@ -106,6 +110,29 @@ async def derive_current_deposit_wallet_address(
     return derive_uups_deposit_wallet_address(signer, config)
 
 
+def get_deposit_wallet_factory_beacon_sync(rpc: SyncJsonRpcClient, factory: str) -> str:
+    try:
+        data = rpc.eth_call(to=factory, data=_FACTORY_BEACON_SELECTOR)
+    except Exception as error:
+        if is_json_rpc_contract_revert(error):
+            return _ZERO_ADDRESS
+        raise
+    return _decode_address_return_data(data)
+
+
+def is_beacon_deposit_wallet_factory_sync(rpc: SyncJsonRpcClient, factory: str) -> bool:
+    beacon = get_deposit_wallet_factory_beacon_sync(rpc, factory)
+    return beacon.lower() != _ZERO_ADDRESS
+
+
+def derive_current_deposit_wallet_address_sync(
+    rpc: SyncJsonRpcClient, signer: str, config: WalletDerivation
+) -> str:
+    if is_beacon_deposit_wallet_factory_sync(rpc, config.deposit_wallet_factory):
+        return derive_beacon_deposit_wallet_address(signer, config)
+    return derive_uups_deposit_wallet_address(signer, config)
+
+
 def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) -> WalletType:
     try:
         signer_checksum = to_checksum_address(signer)
@@ -190,10 +217,13 @@ __all__ = [
     "classify_wallet_type",
     "derive_beacon_deposit_wallet_address",
     "derive_current_deposit_wallet_address",
+    "derive_current_deposit_wallet_address_sync",
     "derive_proxy_wallet_address",
     "derive_safe_wallet_address",
     "derive_uups_deposit_wallet_address",
     "get_deposit_wallet_factory_beacon",
+    "get_deposit_wallet_factory_beacon_sync",
     "is_beacon_deposit_wallet_factory",
+    "is_beacon_deposit_wallet_factory_sync",
     "signature_type_for",
 ]

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -94,7 +94,7 @@ from polymarket._internal.streams.handle import AsyncSubscriptionHandle, Subscri
 from polymarket._internal.wallet import (
     WalletType,
     classify_wallet_type,
-    derive_deposit_wallet_address,
+    derive_current_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.auth import ApiKey
@@ -321,10 +321,8 @@ class AsyncSecureClient:
             logger=logger,
             header_resolver=_make_l2_header_resolver(signer, credentials),
         )
-        rpc: JsonRpcClient | None = None
-        if environment.rpc_url is not None:
-            rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
-            rpc = JsonRpcClient(rpc_transport)
+        rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
+        rpc = JsonRpcClient(rpc_transport)
 
         ctx = AsyncSecureClientContext(
             environment=environment,
@@ -532,8 +530,7 @@ class AsyncSecureClient:
                                         try:
                                             await ctx.relayer.close()
                                         finally:
-                                            if ctx.rpc is not None:
-                                                await ctx.rpc.close()
+                                            await ctx.rpc.close()
 
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user
@@ -1655,8 +1652,8 @@ class AsyncSecureClient:
             )
         deposit_address = cast(
             EvmAddress,
-            to_checksum_address(
-                derive_deposit_wallet_address(ctx.signer.address, ctx.environment.wallet_derivation)
+            await derive_current_deposit_wallet_address(
+                ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
             ),
         )
         ready = await fetch_deployed(
@@ -1677,25 +1674,23 @@ class AsyncSecureClient:
         )
 
     async def is_gasless_ready(self) -> bool:
-        wallet_type = self._ctx.wallet_type
-        if wallet_type == "EOA":
-            return False
-        type_param = RelayerTransactionType.WALLET if wallet_type == "DEPOSIT_WALLET" else None
+        ctx = self._ctx
+        if ctx.wallet_type != "EOA":
+            type_param = (
+                RelayerTransactionType.WALLET if ctx.wallet_type == "DEPOSIT_WALLET" else None
+            )
+            return await fetch_deployed(ctx.relayer, address=str(ctx.wallet), type=type_param)
+        deposit_address = await derive_current_deposit_wallet_address(
+            ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+        )
         return await fetch_deployed(
-            self._ctx.relayer, address=str(self._ctx.wallet), type=type_param
+            ctx.relayer, address=deposit_address, type=RelayerTransactionType.WALLET
         )
 
     async def _broadcast_eoa_call(self, call: TransactionCall) -> EoaTransactionHandle:
-        rpc = self._ctx.rpc
-        if rpc is None:
-            raise UserInputError(
-                "EOA workflows require rpc_url set on the Environment. "
-                "Pass environment=dataclasses.replace(PRODUCTION, rpc_url='...') "
-                "at create(), or use setup_gasless_wallet() to switch to a Deposit Wallet."
-            )
         env = self._ctx.environment
         return await broadcast_eoa_call(
-            rpc=rpc,
+            rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
             chain_id=env.chain_id,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Self, cast
+from typing import TYPE_CHECKING, Literal, Self, cast
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -58,6 +58,28 @@ from polymarket._internal.actions.orders.typed_data import (
     build_order_typed_data,
 )
 from polymarket._internal.actions.orders.types import OrderDraft
+from polymarket._internal.actions.relayer.auth import make_relayer_header_resolver_sync
+from polymarket._internal.actions.relayer.calls import (
+    MAX_UINT256,
+    TransactionCall,
+    ctf_redeem_positions_call,
+    erc20_approval_call,
+    erc20_transfer_call,
+    erc1155_set_approval_for_all_call,
+    merge_positions_call,
+    split_position_call,
+)
+from polymarket._internal.actions.relayer.deployed import fetch_deployed_sync
+from polymarket._internal.actions.relayer.gasless import (
+    prepare_gasless_transaction_sync,
+    submit_deposit_wallet_create_sync,
+)
+from polymarket._internal.actions.relayer.positions import (
+    expect_binary_positions,
+    expect_negative_risk_flag,
+    resolve_binary_positions_condition_id,
+    resolve_merge_amount,
+)
 from polymarket._internal.context import SyncSecureClientContext
 from polymarket._internal.dispatch import (
     sync_dispatch,
@@ -65,12 +87,25 @@ from polymarket._internal.dispatch import (
     sync_paginate_offset,
     sync_paginate_page_based,
 )
+from polymarket._internal.eoa.broadcast import broadcast_eoa_call_sync
+from polymarket._internal.eoa.rpc import SyncJsonRpcClient
 from polymarket._internal.hmac import build_hmac_signature
 from polymarket._internal.l1_auth import sign_api_key_auth
-from polymarket._internal.wallet import WalletType, classify_wallet_type, signature_type_for
+from polymarket._internal.wallet import (
+    WalletType,
+    classify_wallet_type,
+    derive_current_deposit_wallet_address_sync,
+    signature_type_for,
+)
+from polymarket.auth import ApiKey
 from polymarket.clients._transport import SyncHeaderResolver, SyncTransport
 from polymarket.environments import PRODUCTION, Environment
-from polymarket.errors import RequestRejectedError, SigningError, UserInputError
+from polymarket.errors import (
+    RequestRejectedError,
+    SigningError,
+    UnexpectedResponseError,
+    UserInputError,
+)
 from polymarket.models import (
     ApiKeyCreds,
     AssetType,
@@ -102,6 +137,7 @@ from polymarket.models import (
 from polymarket.models.clob.cancel import CancelOrdersResponse
 from polymarket.models.clob.order_response import OrderResponse
 from polymarket.models.clob.orders import MarketOrderType, SignedOrder
+from polymarket.models.clob.relayer import RelayerTransactionType
 from polymarket.models.clob.rewards import (
     CurrentReward,
     MarketReward,
@@ -131,6 +167,7 @@ from polymarket.models.data import (
 )
 from polymarket.models.types import ConditionId
 from polymarket.pagination import Page, Paginator
+from polymarket.transactions import SyncEoaTransactionHandle, SyncTransactionHandle
 from polymarket.types import EvmAddress, HexString
 
 if TYPE_CHECKING:
@@ -181,6 +218,7 @@ class SecureClient:
         wallet: str,
         environment: Environment = PRODUCTION,
         credentials: ApiKeyCreds | None = None,
+        api_key: ApiKey | None = None,
         nonce: int = 0,
         validate_credentials: bool = True,
         logger: logging.Logger | None = None,
@@ -199,6 +237,40 @@ class SecureClient:
         except (ValueError, TypeError) as error:
             raise UserInputError(f"Invalid private_key: {error}") from error
 
+        bootstrap_clob = SyncTransport(base_url=environment.clob_url, logger=logger)
+        try:
+            resolved_credentials = _bootstrap_credentials_sync(
+                environment=environment,
+                signer=signer,
+                clob=bootstrap_clob,
+                provided=credentials,
+                nonce=nonce,
+                validate=validate_credentials,
+                logger=logger,
+            )
+        finally:
+            bootstrap_clob.close()
+
+        return cls._construct_for_wallet(
+            signer=signer,
+            wallet=wallet,
+            environment=environment,
+            credentials=resolved_credentials,
+            api_key=api_key,
+            logger=logger,
+        )
+
+    @classmethod
+    def _construct_for_wallet(
+        cls,
+        *,
+        signer: LocalAccount,
+        wallet: str,
+        environment: Environment,
+        credentials: ApiKeyCreds,
+        api_key: ApiKey | None,
+        logger: logging.Logger | None,
+    ) -> Self:
         try:
             wallet_checksum = to_checksum_address(wallet)
         except ValueError as error:
@@ -213,26 +285,27 @@ class SecureClient:
         gamma = SyncTransport(base_url=environment.gamma_url, logger=logger)
         data = SyncTransport(base_url=environment.data_url, logger=logger)
         clob = SyncTransport(base_url=environment.clob_url, logger=logger)
-
+        relayer_resolver = (
+            make_relayer_header_resolver_sync(api_key) if api_key is not None else None
+        )
+        relayer = SyncTransport(
+            base_url=environment.relayer_url,
+            logger=logger,
+            header_resolver=relayer_resolver,
+        )
         try:
-            resolved_credentials = _bootstrap_credentials_sync(
-                environment=environment,
-                signer=signer,
-                clob=clob,
-                provided=credentials,
-                nonce=nonce,
-                validate=validate_credentials,
-                logger=logger,
-            )
             secure_clob = SyncTransport(
                 base_url=environment.clob_url,
                 logger=logger,
-                header_resolver=_make_l2_header_resolver_sync(signer, resolved_credentials),
+                header_resolver=_make_l2_header_resolver_sync(signer, credentials),
             )
+            rpc_transport = SyncTransport(base_url=environment.rpc_url, logger=logger)
+            rpc = SyncJsonRpcClient(rpc_transport)
         except BaseException:
             gamma.close()
             data.close()
             clob.close()
+            relayer.close()
             raise
 
         ctx = SyncSecureClientContext(
@@ -241,10 +314,13 @@ class SecureClient:
             data=data,
             clob=clob,
             signer=signer,
-            credentials=resolved_credentials,
+            credentials=credentials,
             secure_clob=secure_clob,
             wallet=branded_wallet,
             wallet_type=wallet_type,
+            relayer=relayer,
+            api_key=api_key,
+            rpc=rpc,
         )
         return cls(ctx=ctx, _create_token=_CREATE_TOKEN, logger=logger)
 
@@ -291,7 +367,13 @@ class SecureClient:
                 try:
                     ctx.clob.close()
                 finally:
-                    ctx.secure_clob.close()
+                    try:
+                        ctx.secure_clob.close()
+                    finally:
+                        try:
+                            ctx.relayer.close()
+                        finally:
+                            ctx.rpc.close()
 
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user
@@ -1382,6 +1464,315 @@ class SecureClient:
         return _rewards_actions.parse_reward_percentages(
             self._ctx.secure_clob.get_json(path, params=params)
         )
+
+    def approve_erc20(
+        self,
+        *,
+        token_address: str,
+        spender_address: str,
+        amount: int | Literal["max"],
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        try:
+            token = cast(EvmAddress, to_checksum_address(token_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid token_address: {error}") from error
+        try:
+            spender = cast(EvmAddress, to_checksum_address(spender_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid spender_address: {error}") from error
+        resolved_amount = MAX_UINT256 if amount == "max" else amount
+        call = erc20_approval_call(token_address=token, spender=spender, amount=resolved_amount)
+        resolved_metadata = (
+            metadata if metadata is not None else f"Approve {amount} of {token} to {spender}"
+        )
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def approve_erc1155_for_all(
+        self,
+        *,
+        token_address: str,
+        operator_address: str,
+        approved: bool = True,
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        try:
+            token = cast(EvmAddress, to_checksum_address(token_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid token_address: {error}") from error
+        try:
+            operator = cast(EvmAddress, to_checksum_address(operator_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid operator_address: {error}") from error
+        call = erc1155_set_approval_for_all_call(
+            token_address=token, operator=operator, approved=approved
+        )
+        verb = "Approve" if approved else "Revoke"
+        resolved_metadata = metadata if metadata is not None else f"{verb} {operator} on {token}"
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def transfer_erc20(
+        self,
+        *,
+        token_address: str,
+        recipient_address: str,
+        amount: int,
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        try:
+            token = cast(EvmAddress, to_checksum_address(token_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid token_address: {error}") from error
+        try:
+            recipient = cast(EvmAddress, to_checksum_address(recipient_address))
+        except ValueError as error:
+            raise UserInputError(f"Invalid recipient_address: {error}") from error
+        call = erc20_transfer_call(token_address=token, recipient=recipient, amount=amount)
+        resolved_metadata = (
+            metadata if metadata is not None else f"Transfer {amount} of {token} to {recipient}"
+        )
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def setup_trading_approvals(self) -> SyncTransactionHandle:
+        env = self._ctx.environment
+        collateral = cast(EvmAddress, env.collateral_token)
+        conditional = cast(EvmAddress, env.conditional_tokens)
+        calls = [
+            erc20_approval_call(
+                token_address=collateral,
+                spender=cast(EvmAddress, env.standard_exchange),
+                amount=MAX_UINT256,
+            ),
+            erc20_approval_call(
+                token_address=collateral,
+                spender=cast(EvmAddress, env.neg_risk_exchange),
+                amount=MAX_UINT256,
+            ),
+            erc20_approval_call(
+                token_address=collateral,
+                spender=cast(EvmAddress, env.neg_risk_adapter),
+                amount=MAX_UINT256,
+            ),
+            erc20_approval_call(
+                token_address=collateral,
+                spender=cast(EvmAddress, env.collateral_adapter),
+                amount=MAX_UINT256,
+            ),
+            erc20_approval_call(
+                token_address=collateral,
+                spender=cast(EvmAddress, env.neg_risk_collateral_adapter),
+                amount=MAX_UINT256,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.standard_exchange),
+                approved=True,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.neg_risk_exchange),
+                approved=True,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.neg_risk_adapter),
+                approved=True,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.collateral_adapter),
+                approved=True,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.neg_risk_collateral_adapter),
+                approved=True,
+            ),
+            erc1155_set_approval_for_all_call(
+                token_address=conditional,
+                operator=cast(EvmAddress, env.auto_redeem_operator),
+                approved=True,
+            ),
+        ]
+        if self._ctx.wallet_type == "EOA":
+            for call in calls[:-1]:
+                handle = self._broadcast_eoa_call(call)
+                handle.wait()
+            return self._broadcast_eoa_call(calls[-1])
+        return prepare_gasless_transaction_sync(
+            self._ctx, calls=calls, metadata="Trading setup approvals"
+        )
+
+    def setup_gasless_wallet(self) -> Self:
+        ctx = self._ctx
+        if ctx.api_key is None:
+            raise UserInputError(
+                "setup_gasless_wallet requires a Builder API Key or Relayer API Key. "
+                "Pass api_key= when constructing the client."
+            )
+        if ctx.wallet_type != "EOA":
+            return type(self)._construct_for_wallet(
+                signer=ctx.signer,
+                wallet=str(ctx.wallet),
+                environment=ctx.environment,
+                credentials=ctx.credentials,
+                api_key=ctx.api_key,
+                logger=self._logger,
+            )
+        deposit_address = cast(
+            EvmAddress,
+            derive_current_deposit_wallet_address_sync(
+                ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+            ),
+        )
+        ready = fetch_deployed_sync(
+            ctx.relayer,
+            address=str(deposit_address),
+            type=RelayerTransactionType.WALLET,
+        )
+        if not ready:
+            handle = submit_deposit_wallet_create_sync(ctx, metadata="Deploy Deposit Wallet")
+            handle.wait()
+        return type(self)._construct_for_wallet(
+            signer=ctx.signer,
+            wallet=str(deposit_address),
+            environment=ctx.environment,
+            credentials=ctx.credentials,
+            api_key=ctx.api_key,
+            logger=self._logger,
+        )
+
+    def is_gasless_ready(self) -> bool:
+        ctx = self._ctx
+        if ctx.wallet_type != "EOA":
+            type_param = (
+                RelayerTransactionType.WALLET if ctx.wallet_type == "DEPOSIT_WALLET" else None
+            )
+            return fetch_deployed_sync(ctx.relayer, address=str(ctx.wallet), type=type_param)
+        deposit_address = derive_current_deposit_wallet_address_sync(
+            ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+        )
+        return fetch_deployed_sync(
+            ctx.relayer, address=deposit_address, type=RelayerTransactionType.WALLET
+        )
+
+    def split_position(
+        self,
+        *,
+        condition_id: str,
+        amount: int,
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        env = self._ctx.environment
+        neg_risk = self._resolve_market_neg_risk(condition_id)
+        call = split_position_call(
+            target=self._lifecycle_target_address(neg_risk),
+            collateral=cast(EvmAddress, env.collateral_token),
+            condition_id=condition_id,
+            amount=amount,
+        )
+        resolved_metadata = (
+            metadata
+            if metadata is not None
+            else f"Split {amount} positions for condition {condition_id}"
+        )
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def merge_positions(
+        self,
+        *,
+        condition_id: str,
+        amount: int | Literal["max"],
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        env = self._ctx.environment
+        binary = self._fetch_binary_positions(condition_id)
+        neg_risk = expect_negative_risk_flag(binary)
+        resolved_amount = resolve_merge_amount(binary, amount)
+        call = merge_positions_call(
+            target=self._lifecycle_target_address(neg_risk),
+            collateral=cast(EvmAddress, env.collateral_token),
+            condition_id=condition_id,
+            amount=resolved_amount,
+        )
+        resolved_metadata = (
+            metadata
+            if metadata is not None
+            else f"Merge {resolved_amount} positions for condition {condition_id}"
+        )
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def redeem_positions(
+        self,
+        *,
+        condition_id: str | None = None,
+        market_id: str | None = None,
+        metadata: str | None = None,
+    ) -> SyncTransactionHandle:
+        if (condition_id is None) == (market_id is None):
+            raise UserInputError("Provide exactly one of condition_id or market_id")
+        env = self._ctx.environment
+        lookup_id = condition_id if condition_id is not None else market_id
+        assert lookup_id is not None
+        binary = self._fetch_binary_positions(lookup_id)
+        neg_risk = expect_negative_risk_flag(binary)
+        resolved_condition_id = resolve_binary_positions_condition_id(binary)
+        call = ctf_redeem_positions_call(
+            ctf=self._lifecycle_target_address(neg_risk),
+            collateral=cast(EvmAddress, env.collateral_token),
+            condition_id=resolved_condition_id,
+        )
+        resolved_metadata = (
+            metadata
+            if metadata is not None
+            else f"Redeem positions for condition {resolved_condition_id}"
+        )
+        return self._dispatch_single_call(call, metadata=resolved_metadata)
+
+    def _lifecycle_target_address(self, neg_risk: bool) -> EvmAddress:
+        env = self._ctx.environment
+        return cast(
+            EvmAddress,
+            env.neg_risk_collateral_adapter if neg_risk else env.collateral_adapter,
+        )
+
+    def _broadcast_eoa_call(self, call: TransactionCall) -> SyncEoaTransactionHandle:
+        env = self._ctx.environment
+        return broadcast_eoa_call_sync(
+            rpc=self._ctx.rpc,
+            signer=self._ctx.signer,
+            call=call,
+            chain_id=env.chain_id,
+            max_polls=env.relayer_max_polls,
+            poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+        )
+
+    def _dispatch_single_call(
+        self, call: TransactionCall, *, metadata: str
+    ) -> SyncTransactionHandle:
+        if self._ctx.wallet_type == "EOA":
+            return self._broadcast_eoa_call(call)
+        return prepare_gasless_transaction_sync(self._ctx, calls=[call], metadata=metadata)
+
+    def _resolve_market_neg_risk(self, condition_id: str) -> bool:
+        page = self.list_markets(condition_ids=[condition_id], page_size=2).first_page()
+        markets = page.items
+        if len(markets) != 1:
+            raise UserInputError(
+                f"Expected exactly one market for condition {condition_id}, got {len(markets)}"
+            )
+        market = markets[0]
+        if market.state.neg_risk is None:
+            raise UnexpectedResponseError(f"Missing negRisk flag for condition {condition_id}")
+        return market.state.neg_risk
+
+    def _fetch_binary_positions(self, market_id_or_condition_id: str):  # type: ignore[no-untyped-def]
+        page = self.list_positions(
+            user=str(self._ctx.wallet),
+            market=[market_id_or_condition_id],
+            size_threshold=0,
+        ).first_page()
+        return expect_binary_positions(page.items)
 
 
 def _bootstrap_credentials_sync(

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Literal, Self, cast
+from typing import TYPE_CHECKING, Literal, Self, cast, overload
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -215,7 +215,7 @@ class SecureClient:
         cls,
         *,
         private_key: str,
-        wallet: str,
+        wallet: str | None = None,
         environment: Environment = PRODUCTION,
         credentials: ApiKeyCreds | None = None,
         api_key: ApiKey | None = None,
@@ -225,10 +225,6 @@ class SecureClient:
     ) -> Self:
         if not private_key:
             raise UserInputError("private_key is required")
-        if not wallet:
-            raise UserInputError(
-                "wallet is required. Pass the signer address itself to authenticate as an EOA."
-            )
         _validate_nonce(nonce)
         if credentials is not None and nonce != 0:
             raise UserInputError("nonce cannot be combined with credentials.")
@@ -236,6 +232,8 @@ class SecureClient:
             signer = cast(LocalAccount, Account.from_key(private_key))
         except (ValueError, TypeError) as error:
             raise UserInputError(f"Invalid private_key: {error}") from error
+
+        resolved_wallet = wallet if wallet else signer.address
 
         bootstrap_clob = SyncTransport(base_url=environment.clob_url, logger=logger)
         try:
@@ -253,7 +251,7 @@ class SecureClient:
 
         return cls._construct_for_wallet(
             signer=signer,
-            wallet=wallet,
+            wallet=resolved_wallet,
             environment=environment,
             credentials=resolved_credentials,
             api_key=api_key,
@@ -1224,6 +1222,27 @@ class SecureClient:
             builder_code=builder_code,
         )
 
+    @overload
+    def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder: ...
+    @overload
+    def create_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> SignedOrder: ...
     def create_market_order(
         self,
         *,
@@ -1267,6 +1286,27 @@ class SecureClient:
         )
         return self.post_order(signed)
 
+    @overload
+    def place_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        max_spend: Decimal | int | float | str | None = None,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> OrderResponse: ...
+    @overload
+    def place_market_order(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FAK",
+        builder_code: str | None = None,
+    ) -> OrderResponse: ...
     def place_market_order(
         self,
         *,

--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -72,7 +72,7 @@ PRODUCTION = Environment(
     data_url="https://data-api.polymarket.com",
     rtds_ws_url="wss://ws-live-data.polymarket.com",
     sports_ws_url="wss://sports-api.polymarket.com/ws",
-    rpc_url="https://polygon-rpc.com",
+    rpc_url="https://polygon.drpc.org",
 )
 
 __all__ = ["Environment", "PRODUCTION", "WalletDerivation"]

--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -11,6 +11,7 @@ class WalletDerivation:
     safe_init_code_hash: str
     deposit_wallet_factory: str
     deposit_wallet_implementation: str
+    deposit_wallet_beacon: str
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -36,9 +37,9 @@ class Environment:
     data_url: str
     rtds_ws_url: str
     sports_ws_url: str
+    rpc_url: str
     relayer_max_polls: int = 100
     relayer_poll_frequency_ms: int = 2000
-    rpc_url: str | None = None
 
 
 PRODUCTION = Environment(
@@ -51,6 +52,7 @@ PRODUCTION = Environment(
         safe_init_code_hash="0x2bce2127ff07fb632d16c8347c4ebf501f4841168bed00d9e6ef715ddb6fcecf",
         deposit_wallet_factory="0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
         deposit_wallet_implementation="0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB",
+        deposit_wallet_beacon="0x7A18EDfe055488A3128f01F563e5B479D92ffc3a",
     ),
     collateral_token="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
     conditional_tokens="0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
@@ -70,6 +72,7 @@ PRODUCTION = Environment(
     data_url="https://data-api.polymarket.com",
     rtds_ws_url="wss://ws-live-data.polymarket.com",
     sports_ws_url="wss://sports-api.polymarket.com/ws",
+    rpc_url="https://polygon-rpc.com",
 )
 
 __all__ = ["Environment", "PRODUCTION", "WalletDerivation"]

--- a/src/polymarket/transactions.py
+++ b/src/polymarket/transactions.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, TypeAlias
 from polymarket.models.clob.relayer import TransactionOutcome
 
 if TYPE_CHECKING:
-    from polymarket._internal.eoa.rpc import JsonRpcClient
-    from polymarket.clients._transport import AsyncTransport
+    from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
+    from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,7 +52,57 @@ class EoaTransactionHandle:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class SyncGaslessTransactionHandle:
+    transaction_id: str
+    transaction_hash: str | None
+    _relayer: SyncTransport = field(repr=False)
+    _max_polls: int
+    _poll_delay_s: float
+
+    def wait(self) -> TransactionOutcome:
+        from polymarket._internal.actions.relayer.poll import poll_until_terminal_sync
+
+        return poll_until_terminal_sync(
+            self._relayer,
+            transaction_id=self.transaction_id,
+            fallback_hash=self.transaction_hash,
+            max_polls=self._max_polls,
+            poll_delay_s=self._poll_delay_s,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SyncEoaTransactionHandle:
+    transaction_hash: str
+    _rpc: SyncJsonRpcClient = field(repr=False)
+    _max_polls: int
+    _poll_delay_s: float
+
+    @property
+    def transaction_id(self) -> None:
+        return None
+
+    def wait(self) -> TransactionOutcome:
+        from polymarket._internal.eoa.broadcast import wait_for_receipt_sync
+
+        return wait_for_receipt_sync(
+            self._rpc,
+            transaction_hash=self.transaction_hash,
+            max_polls=self._max_polls,
+            poll_delay_s=self._poll_delay_s,
+        )
+
+
 TransactionHandle: TypeAlias = GaslessTransactionHandle | EoaTransactionHandle
+SyncTransactionHandle: TypeAlias = SyncGaslessTransactionHandle | SyncEoaTransactionHandle
 
 
-__all__ = ["EoaTransactionHandle", "GaslessTransactionHandle", "TransactionHandle"]
+__all__ = [
+    "EoaTransactionHandle",
+    "GaslessTransactionHandle",
+    "SyncEoaTransactionHandle",
+    "SyncGaslessTransactionHandle",
+    "SyncTransactionHandle",
+    "TransactionHandle",
+]

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey
+from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey, SecureClient
 from polymarket.clients._transport import AsyncTransport
 
 PK_DEPLOY_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -222,6 +222,100 @@ def install_rpc_handler(
     client._ctx = dataclasses.replace(client._ctx, rpc=JsonRpcClient(transport))
 
 
+def make_sync_eoa_client(*, with_api_key: bool = True) -> SecureClient:
+    from eth_account import Account
+
+    signer = Account.from_key(PK_DEPLOY_WALLET)
+    return SecureClient.create(
+        private_key=PK_DEPLOY_WALLET,
+        wallet=signer.address,
+        credentials=FAKE_CREDS,
+        api_key=BUILDER_AUTH if with_api_key else None,
+        validate_credentials=False,
+    )
+
+
+def make_sync_deposit_client() -> SecureClient:
+    from eth_account import Account
+
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
+    from polymarket.environments import PRODUCTION
+
+    signer = Account.from_key(PK_DEPLOY_WALLET)
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    return SecureClient.create(
+        private_key=PK_DEPLOY_WALLET,
+        wallet=wallet,
+        credentials=FAKE_CREDS,
+        api_key=BUILDER_AUTH,
+        validate_credentials=False,
+    )
+
+
+def make_sync_proxy_client() -> SecureClient:
+    from eth_account import Account
+
+    from polymarket._internal.wallet import derive_proxy_wallet_address
+    from polymarket.environments import PRODUCTION
+
+    signer = Account.from_key(PK_PROXY_WALLET)
+    wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    return SecureClient.create(
+        private_key=PK_PROXY_WALLET,
+        wallet=wallet,
+        credentials=FAKE_CREDS,
+        api_key=BUILDER_AUTH,
+        validate_credentials=False,
+    )
+
+
+def make_sync_safe_client() -> SecureClient:
+    from eth_account import Account
+
+    from polymarket._internal.wallet import derive_safe_wallet_address
+    from polymarket.environments import PRODUCTION
+
+    signer = Account.from_key(PK_SAFE_WALLET)
+    wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    return SecureClient.create(
+        private_key=PK_SAFE_WALLET,
+        wallet=wallet,
+        credentials=FAKE_CREDS,
+        api_key=BUILDER_AUTH,
+        validate_credentials=False,
+    )
+
+
+def install_sync_relayer_handler(
+    client: SecureClient,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    from polymarket.clients._transport import SyncTransport
+
+    transport = SyncTransport(
+        base_url="https://relayer.test",
+        client=httpx.Client(
+            base_url="https://relayer.test", transport=httpx.MockTransport(handler)
+        ),
+        header_resolver=client._ctx.relayer._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, relayer=transport)
+
+
+def install_sync_rpc_handler(
+    client: SecureClient,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    from polymarket._internal.eoa.rpc import SyncJsonRpcClient
+    from polymarket.clients._transport import SyncTransport
+
+    transport = SyncTransport(
+        base_url="https://rpc.test",
+        client=httpx.Client(base_url="https://rpc.test", transport=httpx.MockTransport(handler)),
+    )
+    client._ctx = dataclasses.replace(client._ctx, rpc=SyncJsonRpcClient(transport))
+
+
 def legacy_factory_rpc_handler() -> Callable[[httpx.Request], httpx.Response]:
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content.decode("utf-8"))
@@ -271,6 +365,8 @@ __all__ = [
     "install_relayer_handler",
     "install_relayer_routes",
     "install_rpc_handler",
+    "install_sync_relayer_handler",
+    "install_sync_rpc_handler",
     "legacy_factory_rpc_handler",
     "make_deposit_client",
     "make_eoa_client",
@@ -278,5 +374,9 @@ __all__ = [
     "make_proxy_client",
     "make_rpc_handler",
     "make_safe_client",
+    "make_sync_deposit_client",
+    "make_sync_eoa_client",
+    "make_sync_proxy_client",
+    "make_sync_safe_client",
     "request_json",
 ]

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -26,11 +26,11 @@ SPENDER = "0x000000000000000000000000000000000000dEaD"
 async def make_deposit_client() -> AsyncSecureClient:
     from eth_account import Account
 
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
     return await AsyncSecureClient.create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -207,6 +207,53 @@ def install_relayer_handler(
     client._ctx = dataclasses.replace(client._ctx, relayer=transport)
 
 
+def install_rpc_handler(
+    client: AsyncSecureClient,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    from polymarket._internal.eoa.rpc import JsonRpcClient
+
+    transport = AsyncTransport(
+        base_url="https://rpc.test",
+        client=httpx.AsyncClient(
+            base_url="https://rpc.test", transport=httpx.MockTransport(handler)
+        ),
+    )
+    client._ctx = dataclasses.replace(client._ctx, rpc=JsonRpcClient(transport))
+
+
+def legacy_factory_rpc_handler() -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": 3, "message": "execution reverted"},
+            },
+            request=request,
+        )
+
+    return handler
+
+
+def beacon_factory_rpc_handler(beacon_address: str) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": "0x" + beacon_address[2:].rjust(64, "0").lower(),
+            },
+            request=request,
+        )
+
+    return handler
+
+
 def request_json(request: httpx.Request) -> Any:
     return json.loads(request.content.decode("utf-8"))
 
@@ -220,8 +267,11 @@ __all__ = [
     "RELAY_PAYLOAD_DEFAULT_ADDRESS",
     "SPENDER",
     "TOKEN",
+    "beacon_factory_rpc_handler",
     "install_relayer_handler",
     "install_relayer_routes",
+    "install_rpc_handler",
+    "legacy_factory_rpc_handler",
     "make_deposit_client",
     "make_eoa_client",
     "make_eoa_client_with_rpc",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -140,9 +140,19 @@ def test_secure_client_invalid_key_raises_user_input_error() -> None:
         SecureClient.create(private_key="not-a-valid-key", wallet=SIGNER_ADDRESS)
 
 
-def test_secure_client_requires_wallet() -> None:
-    with pytest.raises(UserInputError, match="wallet is required"):
-        SecureClient.create(private_key=PRIVATE_KEY, wallet="")
+def test_secure_client_wallet_defaults_to_signer_when_omitted() -> None:
+    from eth_account import Account
+    from eth_utils.address import to_checksum_address
+
+    expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
+
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
+        assert client.wallet_type == "EOA"
+        assert str(client.wallet) == expected
 
 
 def test_async_secure_client_invalid_key_raises_user_input_error() -> None:

--- a/tests/unit/test_eoa_broadcast.py
+++ b/tests/unit/test_eoa_broadcast.py
@@ -5,35 +5,17 @@ import dataclasses
 import httpx
 import pytest
 from _relayer_helpers import (
-    BUILDER_AUTH,
-    FAKE_CREDS,
-    PK_DEPLOY_WALLET,
-    make_eoa_client,
     make_eoa_client_with_rpc,
     make_rpc_handler,
 )
 
-from polymarket import AsyncSecureClient, TransactionCall
+from polymarket import TransactionCall
 from polymarket.errors import TimeoutError, TransactionFailedError, UserInputError
 from polymarket.transactions import EoaTransactionHandle
 from polymarket.types import EvmAddress
 
 _TOKEN = EvmAddress("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB")
 _SPENDER = EvmAddress("0xE111180000d2663C0091e4f400237545B87B996B")
-
-
-def test_eoa_workflow_without_rpc_url_raises_user_input_error() -> None:
-    async def run() -> None:
-        client = await make_eoa_client()
-        try:
-            with pytest.raises(UserInputError, match="rpc_url"):
-                await client.approve_erc20(
-                    token_address=str(_TOKEN), spender_address=str(_SPENDER), amount=1
-                )
-        finally:
-            await client.close()
-
-    asyncio.run(run())
 
 
 def test_eoa_approve_erc20_signs_and_broadcasts() -> None:
@@ -215,26 +197,6 @@ def test_rpc_client_closes_with_client() -> None:
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         assert client._ctx.rpc is not None
         await client.close()
-
-    asyncio.run(run())
-
-
-def test_no_rpc_url_means_ctx_rpc_is_none() -> None:
-    from eth_account import Account
-
-    async def run() -> None:
-        signer = Account.from_key(PK_DEPLOY_WALLET)
-        client = await AsyncSecureClient.create(
-            private_key=PK_DEPLOY_WALLET,
-            wallet=signer.address,
-            credentials=FAKE_CREDS,
-            api_key=BUILDER_AUTH,
-            validate_credentials=False,
-        )
-        try:
-            assert client._ctx.rpc is None
-        finally:
-            await client.close()
 
     asyncio.run(run())
 

--- a/tests/unit/test_factory_beacon_detection.py
+++ b/tests/unit/test_factory_beacon_detection.py
@@ -1,0 +1,189 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from polymarket._internal.eoa.rpc import JsonRpcCallError, JsonRpcClient
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_current_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+    get_deposit_wallet_factory_beacon,
+    is_beacon_deposit_wallet_factory,
+)
+from polymarket.clients._transport import AsyncTransport
+from polymarket.environments import PRODUCTION
+
+_FACTORY = PRODUCTION.wallet_derivation.deposit_wallet_factory
+_BEACON = PRODUCTION.wallet_derivation.deposit_wallet_beacon
+_SIGNER = "0x0000000000000000000000000000000000000001"
+_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+_FACTORY_BEACON_SELECTOR = "0x49493a4d"
+
+
+def _rpc(handler: httpx.MockTransport) -> JsonRpcClient:
+    transport = AsyncTransport(
+        base_url="https://rpc.test",
+        client=httpx.AsyncClient(base_url="https://rpc.test", transport=handler),
+    )
+    return JsonRpcClient(transport)
+
+
+def _capturing_handler(
+    response: dict[str, object],
+    captured: list[dict[str, object]] | None = None,
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if captured is not None:
+            captured.append(body)
+        envelope = {"jsonrpc": "2.0", "id": body["id"], **response}
+        return httpx.Response(200, json=envelope, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def test_get_factory_beacon_parses_address_from_return_data() -> None:
+    captured: list[dict[str, object]] = []
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()}, captured)
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert result.lower() == _BEACON.lower()
+    assert captured[0]["method"] == "eth_call"
+    params = captured[0]["params"]
+    assert isinstance(params, list)
+    assert params[0] == {"to": _FACTORY, "data": _FACTORY_BEACON_SELECTOR}
+
+
+def test_get_factory_beacon_returns_zero_address_on_short_return_data() -> None:
+    handler = _capturing_handler({"result": "0x"})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_returns_zero_address_on_contract_revert() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_returns_zero_address_when_revert_message_nested_in_data() -> None:
+    handler = _capturing_handler(
+        {
+            "error": {
+                "code": -32_603,
+                "message": "VM Exception while processing transaction",
+                "data": {"message": "execution reverted"},
+            }
+        }
+    )
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) == _ZERO_ADDRESS
+
+
+def test_get_factory_beacon_propagates_generic_rpc_failures() -> None:
+    handler = _capturing_handler({"error": {"code": -32_603, "message": "upstream unavailable"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await get_deposit_wallet_factory_beacon(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
+
+
+def test_is_beacon_deposit_wallet_factory_returns_true_for_beacon_address() -> None:
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()})
+
+    async def run() -> bool:
+        rpc = _rpc(handler)
+        try:
+            return await is_beacon_deposit_wallet_factory(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) is True
+
+
+def test_is_beacon_deposit_wallet_factory_returns_false_when_factory_reverts() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> bool:
+        rpc = _rpc(handler)
+        try:
+            return await is_beacon_deposit_wallet_factory(rpc, _FACTORY)
+        finally:
+            await rpc.close()
+
+    assert asyncio.run(run()) is False
+
+
+def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
+    handler = _capturing_handler({"result": "0x" + _BEACON[2:].rjust(64, "0").lower()})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await derive_current_deposit_wallet_address(
+                rpc, _SIGNER, PRODUCTION.wallet_derivation
+            )
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert (
+        result.lower()
+        == derive_beacon_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+    )
+
+
+def test_derive_current_picks_uups_when_factory_reverts() -> None:
+    handler = _capturing_handler({"error": {"code": 3, "message": "execution reverted"}})
+
+    async def run() -> str:
+        rpc = _rpc(handler)
+        try:
+            return await derive_current_deposit_wallet_address(
+                rpc, _SIGNER, PRODUCTION.wallet_derivation
+            )
+        finally:
+            await rpc.close()
+
+    result = asyncio.run(run())
+    assert (
+        result.lower()
+        == derive_uups_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+    )

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -14,6 +14,7 @@ from _relayer_helpers import (
     TOKEN,
     install_relayer_handler,
     install_relayer_routes,
+    install_rpc_handler,
     make_deposit_client,
     make_proxy_client,
     make_safe_client,
@@ -128,7 +129,21 @@ def test_approve_erc20_deposit_wallet_payload_shape() -> None:
 
 
 def test_approve_erc20_proxy_payload_shape() -> None:
+    import json as _json
+
     captured: list[httpx.Request] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = _json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32_603, "message": "upstream unavailable"},
+            },
+            request=request,
+        )
 
     async def run() -> None:
         client = await make_proxy_client()
@@ -147,6 +162,7 @@ def test_approve_erc20_proxy_payload_shape() -> None:
                 },
             },
         )
+        install_rpc_handler(client, rpc_handler)
         try:
             await client.approve_erc20(
                 token_address=TOKEN,

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -28,12 +28,12 @@ from polymarket.transactions import TransactionHandle
 def test_approve_erc20_rejects_when_no_api_key() -> None:
     from eth_account import Account
 
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
         client = await AsyncSecureClient.create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
@@ -401,14 +401,14 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
     from eth_account import Account
 
     from polymarket import RelayerApiKey
-    from polymarket._internal.wallet import derive_deposit_wallet_address
+    from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
 
     captured: list[httpx.Request] = []
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
         client = await AsyncSecureClient.create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,

--- a/tests/unit/test_relayer_is_gasless_ready.py
+++ b/tests/unit/test_relayer_is_gasless_ready.py
@@ -6,42 +6,129 @@ import httpx
 from _relayer_helpers import (
     FAKE_CREDS,
     PK_DEPLOY_WALLET,
+    beacon_factory_rpc_handler,
     install_relayer_handler,
+    install_rpc_handler,
+    legacy_factory_rpc_handler,
     make_deposit_client,
     make_proxy_client,
     make_safe_client,
 )
 
 from polymarket import AsyncSecureClient
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+)
+from polymarket.environments import PRODUCTION
 
 
-def test_is_gasless_ready_eoa_returns_false_without_network_call() -> None:
+async def _make_eoa_secure_client() -> AsyncSecureClient:
+    from eth_account import Account
+
+    signer = Account.from_key(PK_DEPLOY_WALLET)
+    return await AsyncSecureClient.create(
+        private_key=PK_DEPLOY_WALLET,
+        wallet=signer.address,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    )
+
+
+def test_is_gasless_ready_eoa_legacy_factory_queries_uups_deposit_wallet() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> bool:
-        from eth_account import Account
-
-        signer = Account.from_key(PK_DEPLOY_WALLET)
-        client = await AsyncSecureClient.create(
-            private_key=PK_DEPLOY_WALLET,
-            wallet=signer.address,
-            credentials=FAKE_CREDS,
-            validate_credentials=False,
-        )
+    async def run() -> tuple[bool, str]:
+        client = await _make_eoa_secure_client()
+        signer_address = client._ctx.signer.address
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured.append(request)
-            return httpx.Response(500, json={"error": "should not be called"}, request=request)
+            return httpx.Response(200, json={"deployed": True}, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
+        try:
+            result = await client.is_gasless_ready()
+            return result, signer_address
+        finally:
+            await client.close()
+
+    result, signer_address = asyncio.run(run())
+    expected = derive_uups_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    assert result is True
+    assert len(captured) == 1
+    parsed = urlparse(str(captured[0].url))
+    assert parsed.path == "/deployed"
+    qs = parse_qs(parsed.query)
+    assert qs["type"] == ["WALLET"]
+    assert qs["address"] == [expected]
+
+
+def test_is_gasless_ready_eoa_beacon_factory_queries_beacon_deposit_wallet() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> tuple[bool, str]:
+        client = await _make_eoa_secure_client()
+        signer_address = client._ctx.signer.address
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"deployed": False}, request=request)
+
+        install_relayer_handler(client, handler)
+        install_rpc_handler(
+            client, beacon_factory_rpc_handler(PRODUCTION.wallet_derivation.deposit_wallet_beacon)
+        )
+        try:
+            result = await client.is_gasless_ready()
+            return result, signer_address
+        finally:
+            await client.close()
+
+    result, signer_address = asyncio.run(run())
+    expected = derive_beacon_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    assert result is False
+    assert len(captured) == 1
+    parsed = urlparse(str(captured[0].url))
+    qs = parse_qs(parsed.query)
+    assert qs["type"] == ["WALLET"]
+    assert qs["address"] == [expected]
+
+
+def test_is_gasless_ready_eoa_propagates_generic_rpc_failure() -> None:
+    import pytest
+
+    from polymarket._internal.eoa.rpc import JsonRpcCallError
+
+    async def run() -> bool:
+        client = await _make_eoa_secure_client()
+
+        def rpc_handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {"code": -32_603, "message": "upstream unavailable"},
+                },
+                request=request,
+            )
+
+        install_relayer_handler(
+            client, lambda r: httpx.Response(500, json={"error": "unused"}, request=r)
+        )
+        install_rpc_handler(client, rpc_handler)
         try:
             return await client.is_gasless_ready()
         finally:
             await client.close()
 
-    result = asyncio.run(run())
-    assert result is False
-    assert captured == []
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
 
 
 def test_is_gasless_ready_deposit_wallet_sends_type_wallet() -> None:

--- a/tests/unit/test_relayer_proxy_contract.py
+++ b/tests/unit/test_relayer_proxy_contract.py
@@ -10,6 +10,7 @@ from _relayer_helpers import (
     SPENDER,
     TOKEN,
     install_relayer_routes,
+    install_rpc_handler,
     make_proxy_client,
     request_json,
 )
@@ -82,8 +83,20 @@ def test_proxy_signs_relay_address_returned_from_relay_payload() -> None:
     assert body["signatureParams"]["relay"] != "0x" + "00" * 20
 
 
-def test_proxy_signs_default_gas_limit_when_no_rpc_configured() -> None:
+def test_proxy_signs_default_gas_limit_when_rpc_estimate_fails() -> None:
     captured: list[httpx.Request] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32_603, "message": "upstream unavailable"},
+            },
+            request=request,
+        )
 
     async def run() -> None:
         client = await make_proxy_client()
@@ -95,6 +108,7 @@ def test_proxy_signs_default_gas_limit_when_no_rpc_configured() -> None:
                 "/submit": _submit_route(),
             },
         )
+        install_rpc_handler(client, rpc_handler)
         try:
             await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
         finally:

--- a/tests/unit/test_relayer_setup_gasless_wallet.py
+++ b/tests/unit/test_relayer_setup_gasless_wallet.py
@@ -6,7 +6,10 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from _relayer_helpers import (
+    beacon_factory_rpc_handler,
     install_relayer_handler,
+    install_rpc_handler,
+    legacy_factory_rpc_handler,
     make_deposit_client,
     make_eoa_client,
     make_proxy_client,
@@ -14,7 +17,10 @@ from _relayer_helpers import (
     request_json,
 )
 
-from polymarket._internal.wallet import derive_deposit_wallet_address
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+)
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UserInputError
 
@@ -89,7 +95,9 @@ def test_setup_gasless_wallet_eoa_skips_deploy_when_already_deployed() -> None:
     async def run() -> tuple[str, str]:
         client = await make_eoa_client()
         eoa_address = client._ctx.signer.address
-        expected_deposit = derive_deposit_wallet_address(eoa_address, PRODUCTION.wallet_derivation)
+        expected_deposit = derive_uups_deposit_wallet_address(
+            eoa_address, PRODUCTION.wallet_derivation
+        )
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured.append(request)
@@ -99,6 +107,7 @@ def test_setup_gasless_wallet_eoa_skips_deploy_when_already_deployed() -> None:
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         try:
             new_client = await client.setup_gasless_wallet()
             try:
@@ -159,6 +168,7 @@ def test_setup_gasless_wallet_eoa_deploys_when_not_deployed() -> None:
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         client._ctx = dataclasses.replace(
             client._ctx,
             environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
@@ -185,6 +195,79 @@ def test_setup_gasless_wallet_eoa_deploys_when_not_deployed() -> None:
     assert body["metadata"] == "Deploy Deposit Wallet"
 
 
+def test_setup_gasless_wallet_eoa_uses_beacon_factory_when_available() -> None:
+    captured: list[httpx.Request] = []
+
+    async def run() -> tuple[str, str]:
+        client = await make_eoa_client()
+        eoa_address = client._ctx.signer.address
+        expected = derive_beacon_deposit_wallet_address(eoa_address, PRODUCTION.wallet_derivation)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            path = urlparse(str(request.url)).path
+            if path == "/deployed":
+                return httpx.Response(200, json={"deployed": True}, request=request)
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        install_rpc_handler(
+            client,
+            beacon_factory_rpc_handler(PRODUCTION.wallet_derivation.deposit_wallet_beacon),
+        )
+        try:
+            new_client = await client.setup_gasless_wallet()
+            try:
+                return str(new_client.wallet), expected
+            finally:
+                await new_client.close()
+        finally:
+            await client.close()
+
+    actual, expected = asyncio.run(run())
+    assert actual == expected
+    deployed_calls = [r for r in captured if urlparse(str(r.url)).path == "/deployed"]
+    assert len(deployed_calls) == 1
+    qs = parse_qs(urlparse(str(deployed_calls[0].url)).query)
+    assert qs["address"] == [expected]
+
+
+def test_setup_gasless_wallet_eoa_propagates_generic_rpc_failure() -> None:
+    import pytest
+
+    from polymarket._internal.eoa.rpc import JsonRpcCallError
+
+    async def run() -> None:
+        client = await make_eoa_client()
+
+        def rpc_handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {"code": -32_603, "message": "upstream unavailable"},
+                },
+                request=request,
+            )
+
+        install_rpc_handler(client, rpc_handler)
+        install_relayer_handler(
+            client,
+            lambda r: httpx.Response(500, json={"error": "unused"}, request=r),
+        )
+        try:
+            await client.setup_gasless_wallet()
+        finally:
+            await client.close()
+
+    with pytest.raises(JsonRpcCallError, match="upstream unavailable"):
+        asyncio.run(run())
+
+
 def test_setup_gasless_wallet_returns_independent_client_with_fresh_transports() -> None:
     captured: list[httpx.Request] = []
 
@@ -199,6 +282,7 @@ def test_setup_gasless_wallet_returns_independent_client_with_fresh_transports()
             return httpx.Response(404, request=request)
 
         install_relayer_handler(client, handler)
+        install_rpc_handler(client, legacy_factory_rpc_handler())
         async with client:
             returned = await client.setup_gasless_wallet()
             async with returned:

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -169,14 +169,14 @@ def test_create_rejects_bool_nonce() -> None:
         )
 
 
-def test_create_rejects_missing_wallet() -> None:
-    with pytest.raises(UserInputError, match="wallet is required"):
-        SecureClient.create(
-            private_key=PRIVATE_KEY,
-            wallet="",
-            credentials=FAKE_CREDS,
-            validate_credentials=False,
-        )
+def test_create_defaults_wallet_to_signer_when_omitted() -> None:
+    with SecureClient.create(
+        private_key=PRIVATE_KEY,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
+        assert client.wallet_type == "EOA"
+        assert str(client.wallet) == SIGNER_ADDRESS
 
 
 def test_create_rejects_invalid_wallet_address() -> None:

--- a/tests/unit/test_streams_subscribe_router.py
+++ b/tests/unit/test_streams_subscribe_router.py
@@ -63,6 +63,7 @@ def _env_with(
             safe_init_code_hash=PRODUCTION.wallet_derivation.safe_init_code_hash,
             deposit_wallet_factory=PRODUCTION.wallet_derivation.deposit_wallet_factory,
             deposit_wallet_implementation=PRODUCTION.wallet_derivation.deposit_wallet_implementation,
+            deposit_wallet_beacon=PRODUCTION.wallet_derivation.deposit_wallet_beacon,
         ),
         collateral_token=PRODUCTION.collateral_token,
         conditional_tokens=PRODUCTION.conditional_tokens,
@@ -82,6 +83,7 @@ def _env_with(
         data_url=PRODUCTION.data_url,
         rtds_ws_url=rtds_ws_url,
         sports_ws_url=sports_ws_url,
+        rpc_url=PRODUCTION.rpc_url,
     )
 
 

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -1,0 +1,624 @@
+# pyright: reportPrivateUsage=false
+import dataclasses
+import json
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from _relayer_helpers import (
+    SPENDER,
+    TOKEN,
+    beacon_factory_rpc_handler,
+    install_sync_relayer_handler,
+    install_sync_rpc_handler,
+    legacy_factory_rpc_handler,
+    make_sync_deposit_client,
+    make_sync_eoa_client,
+    make_sync_proxy_client,
+    make_sync_safe_client,
+    request_json,
+)
+
+from polymarket._internal.wallet import (
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
+)
+from polymarket.environments import PRODUCTION
+from polymarket.errors import (
+    TimeoutError as PolyTimeoutError,
+)
+from polymarket.errors import (
+    TransactionFailedError,
+    UnexpectedResponseError,
+    UserInputError,
+)
+from polymarket.transactions import SyncEoaTransactionHandle, SyncGaslessTransactionHandle
+
+
+def _deposit_relayer_handler(captured: list[httpx.Request]):  # type: ignore[no-untyped-def]
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-sync",
+                },
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return handler
+
+
+def test_approve_erc20_gasless_returns_sync_handle() -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_deposit_client() as client:
+        install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    assert isinstance(handle, SyncGaslessTransactionHandle)
+    assert handle.transaction_id == "tx-sync"
+    submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert len(submit_calls) == 1
+    body = request_json(submit_calls[0])
+    assert body["type"] == "WALLET"
+
+
+def test_approve_erc20_eoa_uses_direct_broadcast() -> None:
+    rpc_calls: list[dict[str, object]] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        rpc_calls.append(body)
+        method = body["method"]
+        if method == "eth_chainId":
+            result: object = hex(137)
+        elif method == "eth_getTransactionCount":
+            result = hex(7)
+        elif method == "eth_gasPrice":
+            result = hex(30_000_000_000)
+        elif method == "eth_estimateGas":
+            result = hex(100_000)
+        elif method == "eth_sendRawTransaction":
+            result = "0x" + "aa" * 32
+        else:
+            return httpx.Response(
+                404, json={"jsonrpc": "2.0", "id": body["id"], "error": "?"}, request=request
+            )
+        return httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": body["id"], "result": result}, request=request
+        )
+
+    with make_sync_eoa_client() as client:
+        install_sync_rpc_handler(client, rpc_handler)
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    assert isinstance(handle, SyncEoaTransactionHandle)
+    assert handle.transaction_hash == "0x" + "aa" * 32
+    methods = [c["method"] for c in rpc_calls]
+    assert "eth_sendRawTransaction" in methods
+
+
+def test_is_gasless_ready_deposit_wallet_returns_true() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"deployed": True}, request=request)
+
+    with make_sync_deposit_client() as client:
+        install_sync_relayer_handler(client, handler)
+        result = client.is_gasless_ready()
+
+    assert result is True
+    qs = parse_qs(urlparse(str(captured[0].url)).query)
+    assert qs["type"] == ["WALLET"]
+
+
+def test_is_gasless_ready_eoa_legacy_factory_queries_uups_address() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"deployed": True}, request=request)
+
+    with make_sync_eoa_client() as client:
+        signer_address = client._ctx.signer.address
+        install_sync_relayer_handler(client, handler)
+        install_sync_rpc_handler(client, legacy_factory_rpc_handler())
+        assert client.is_gasless_ready() is True
+
+    expected = derive_uups_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    qs = parse_qs(urlparse(str(captured[0].url)).query)
+    assert qs["address"] == [expected]
+    assert qs["type"] == ["WALLET"]
+
+
+def test_is_gasless_ready_eoa_beacon_factory_queries_beacon_address() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"deployed": False}, request=request)
+
+    with make_sync_eoa_client() as client:
+        signer_address = client._ctx.signer.address
+        install_sync_relayer_handler(client, handler)
+        install_sync_rpc_handler(
+            client,
+            beacon_factory_rpc_handler(PRODUCTION.wallet_derivation.deposit_wallet_beacon),
+        )
+        assert client.is_gasless_ready() is False
+
+    expected = derive_beacon_deposit_wallet_address(signer_address, PRODUCTION.wallet_derivation)
+    qs = parse_qs(urlparse(str(captured[0].url)).query)
+    assert qs["address"] == [expected]
+    assert qs["type"] == ["WALLET"]
+
+
+def test_setup_gasless_wallet_rejects_without_api_key() -> None:
+    with (
+        pytest.raises(UserInputError, match="Builder API Key or Relayer API Key"),
+        make_sync_eoa_client(with_api_key=False) as client,
+    ):
+        client.setup_gasless_wallet()
+
+
+def test_setup_gasless_wallet_eoa_skips_deploy_when_already_deployed() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/deployed":
+            return httpx.Response(200, json={"deployed": True}, request=request)
+        return httpx.Response(404, request=request)
+
+    with make_sync_eoa_client() as client:
+        signer_address = client._ctx.signer.address
+        install_sync_relayer_handler(client, handler)
+        install_sync_rpc_handler(client, legacy_factory_rpc_handler())
+        gasless = client.setup_gasless_wallet()
+        try:
+            assert gasless.wallet_type == "DEPOSIT_WALLET"
+            expected = derive_uups_deposit_wallet_address(
+                signer_address, PRODUCTION.wallet_derivation
+            )
+            assert str(gasless.wallet) == expected
+        finally:
+            gasless.close()
+
+    submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert submit_calls == []
+
+
+def test_setup_gasless_wallet_eoa_deploys_when_not_deployed_and_returns_fresh_client() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/deployed":
+            return httpx.Response(200, json={"deployed": False}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-deploy",
+                },
+                request=request,
+            )
+        if path.startswith("/v1/account/transactions/"):
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transaction_hash": "0x" + "ab" * 32,
+                    "transaction_id": "tx-deploy",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    with make_sync_eoa_client() as client:
+        install_sync_relayer_handler(client, handler)
+        install_sync_rpc_handler(client, legacy_factory_rpc_handler())
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        gasless = client.setup_gasless_wallet()
+        try:
+            assert gasless is not client
+            assert gasless.wallet_type == "DEPOSIT_WALLET"
+        finally:
+            gasless.close()
+
+    submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert len(submit_calls) == 1
+    body = request_json(submit_calls[0])
+    assert body["type"] == "WALLET-CREATE"
+
+
+def test_split_position_routes_through_collateral_adapter() -> None:
+    captured: list[httpx.Request] = []
+    _CONDITION_ID = "0x" + "11" * 32
+
+    class _StubPaginator:
+        def __init__(self, items: tuple[object, ...]) -> None:
+            self._items = items
+
+        def first_page(self):  # type: ignore[no-untyped-def]
+            from polymarket.pagination import Page
+
+            return Page(items=self._items, has_more=False, next_cursor=None, total_count=1)
+
+    def _market_stub(neg_risk: bool):  # type: ignore[no-untyped-def]
+        class _MarketState:
+            def __init__(self) -> None:
+                self.neg_risk = neg_risk
+
+        class _Market:
+            def __init__(self) -> None:
+                self.state = _MarketState()
+
+        return _Market()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-split",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    with make_sync_deposit_client() as client:
+        client.list_markets = lambda **_: _StubPaginator((_market_stub(neg_risk=False),))  # type: ignore[method-assign]
+        install_sync_relayer_handler(client, handler)
+        client.split_position(condition_id=_CONDITION_ID, amount=1_000_000)
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    inner = body["depositWalletParams"]["calls"][0]
+    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+
+
+def test_setup_trading_approvals_bundles_eleven_calls_for_deposit_wallet() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-setup",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    with make_sync_deposit_client() as client:
+        install_sync_relayer_handler(client, handler)
+        client.setup_trading_approvals()
+
+    submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
+    body = request_json(submit_calls[0])
+    inner_calls = body["depositWalletParams"]["calls"]
+    assert len(inner_calls) == 11
+
+
+def test_close_closes_relayer_and_rpc_transports() -> None:
+    client = make_sync_proxy_client()
+    client.close()
+
+
+def _proxy_relayer_handler(captured: list[httpx.Request]):  # type: ignore[no-untyped-def]
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/relay-payload":
+            return httpx.Response(
+                200,
+                json={"address": "0xe679d14b2fe0bdee4a54f25bcec2978e372de566", "nonce": "0"},
+                request=request,
+            )
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-proxy",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    return handler
+
+
+def _safe_relayer_handler(captured: list[httpx.Request]):  # type: ignore[no-untyped-def]
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-safe",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    return handler
+
+
+def test_approve_erc20_proxy_uses_default_gas_limit_when_rpc_estimate_fails() -> None:
+    captured: list[httpx.Request] = []
+
+    def rpc_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "error": {"code": -32_603, "message": "upstream unavailable"},
+            },
+            request=request,
+        )
+
+    with make_sync_proxy_client() as client:
+        install_sync_relayer_handler(client, _proxy_relayer_handler(captured))
+        install_sync_rpc_handler(client, rpc_handler)
+        client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    assert body["type"] == "PROXY"
+    assert body["signatureParams"]["gasLimit"] == "200000"
+    assert body["signatureParams"]["relay"].lower() == "0xe679d14b2fe0bdee4a54f25bcec2978e372de566"
+
+
+def test_approve_erc20_safe_single_call_uses_call_operation() -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_safe_client() as client:
+        install_sync_relayer_handler(client, _safe_relayer_handler(captured))
+        client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    assert body["type"] == "SAFE"
+    assert body["signatureParams"]["operation"] == "0"
+    assert body["to"].lower() == TOKEN.lower()
+
+
+def test_setup_trading_approvals_safe_uses_multisend_delegatecall() -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_safe_client() as client:
+        install_sync_relayer_handler(client, _safe_relayer_handler(captured))
+        client.setup_trading_approvals()
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    assert body["type"] == "SAFE"
+    assert body["signatureParams"]["operation"] == "1"
+    assert body["to"].lower() == PRODUCTION.safe_multisend.lower()
+
+
+def _stub_binary_positions(client, *, neg_risk: bool, yes_size: str, no_size: str):  # type: ignore[no-untyped-def]
+    from polymarket.models.data.portfolio import Position
+    from polymarket.pagination import Page
+
+    yes = Position.parse_response(
+        {
+            "conditionId": "0x" + "11" * 32,
+            "outcomeIndex": 0,
+            "size": yes_size,
+            "negativeRisk": neg_risk,
+        }
+    )
+    no = Position.parse_response(
+        {
+            "conditionId": "0x" + "11" * 32,
+            "outcomeIndex": 1,
+            "size": no_size,
+            "negativeRisk": neg_risk,
+        }
+    )
+
+    class _StubPaginator:
+        def first_page(self):  # type: ignore[no-untyped-def]
+            return Page(items=(yes, no), has_more=False, next_cursor=None, total_count=2)
+
+    client.list_positions = lambda **_: _StubPaginator()  # type: ignore[method-assign]
+
+
+def test_merge_positions_routes_through_collateral_adapter() -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_deposit_client() as client:
+        _stub_binary_positions(client, neg_risk=False, yes_size="100.0", no_size="60.0")
+        install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
+        client.merge_positions(condition_id="0x" + "11" * 32, amount="max")
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    inner = body["depositWalletParams"]["calls"][0]
+    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+
+
+def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_deposit_client() as client:
+        _stub_binary_positions(client, neg_risk=True, yes_size="111.0", no_size="0")
+        install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
+        client.redeem_positions(condition_id="0x" + "11" * 32)
+
+    submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
+    body = request_json(submit)
+    inner = body["depositWalletParams"]["calls"][0]
+    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+
+
+def test_split_position_raises_unexpected_response_when_neg_risk_flag_missing() -> None:
+    class _StubMarket:
+        class _State:
+            neg_risk: bool | None = None
+
+        state = _State()
+
+    class _StubPaginator:
+        def first_page(self):  # type: ignore[no-untyped-def]
+            from polymarket.pagination import Page
+
+            return Page(items=(_StubMarket(),), has_more=False, next_cursor=None, total_count=1)
+
+    with (
+        pytest.raises(UnexpectedResponseError, match="Missing negRisk"),
+        make_sync_deposit_client() as client,
+    ):
+        client.list_markets = lambda **_: _StubPaginator()  # type: ignore[method-assign]
+        client.split_position(condition_id="0x" + "11" * 32, amount=1)
+
+
+def _wait_relayer_handler(state: str, *, error_msg: str | None = None):  # type: ignore[no-untyped-def]
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={"state": "STATE_NEW", "transactionHash": None, "transactionID": "tx-w"},
+                request=request,
+            )
+        if path.startswith("/v1/account/transactions/"):
+            body: dict[str, object] = {
+                "state": state,
+                "transaction_hash": "0x" + "aa" * 32,
+                "transaction_id": "tx-w",
+            }
+            if error_msg is not None:
+                body["error_msg"] = error_msg
+            return httpx.Response(200, json=body, request=request)
+        return httpx.Response(404, request=request)
+
+    return handler
+
+
+def test_gasless_wait_returns_outcome_on_terminal_success() -> None:
+    with make_sync_deposit_client() as client:
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        install_sync_relayer_handler(client, _wait_relayer_handler("STATE_MINED"))
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        outcome = handle.wait()
+
+    assert outcome.transaction_id == "tx-w"
+    assert outcome.transaction_hash == "0x" + "aa" * 32
+
+
+def test_gasless_wait_raises_transaction_failed_on_terminal_failure() -> None:
+    with make_sync_deposit_client() as client:
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        install_sync_relayer_handler(
+            client, _wait_relayer_handler("STATE_FAILED", error_msg="reverted on chain")
+        )
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        with pytest.raises(TransactionFailedError, match="reverted on chain"):
+            handle.wait()
+
+
+def test_gasless_wait_times_out_when_terminal_state_never_reached() -> None:
+    with make_sync_deposit_client() as client:
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(
+                client._ctx.environment,
+                relayer_poll_frequency_ms=1,
+                relayer_max_polls=3,
+            ),
+        )
+        install_sync_relayer_handler(client, _wait_relayer_handler("STATE_NEW"))
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        with pytest.raises(PolyTimeoutError):
+            handle.wait()
+
+
+def test_gasless_submit_retries_on_retryable_400_then_succeeds() -> None:
+    captured: list[httpx.Request] = []
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(
+                    400,
+                    json={"error": "wallet busy with active action"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-retry",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    with make_sync_deposit_client() as client:
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        install_sync_relayer_handler(client, handler)
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    assert handle.transaction_id == "tx-retry"
+    submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert len(submit_calls) == 2

--- a/tests/unit/test_wallet_derivations.py
+++ b/tests/unit/test_wallet_derivations.py
@@ -2,9 +2,10 @@ import pytest
 
 from polymarket._internal.wallet import (
     classify_wallet_type,
-    derive_deposit_wallet_address,
+    derive_beacon_deposit_wallet_address,
     derive_proxy_wallet_address,
     derive_safe_wallet_address,
+    derive_uups_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.environments import PRODUCTION
@@ -12,14 +13,20 @@ from polymarket.errors import UserInputError
 
 SIGNER = "0x0000000000000000000000000000000000000001"
 
-EXPECTED_DEPOSIT = "0x57ffbc34de23124faeb8387fcd689d314e57accd"
+EXPECTED_UUPS_DEPOSIT = "0x57ffbc34de23124faeb8387fcd689d314e57accd"
+EXPECTED_BEACON_DEPOSIT = "0x94bf330955a0b957662feaf878de77bf25f76cd9"
 EXPECTED_PROXY = "0x7754536ecd85c00b2e0cf9c1aa679340d8550756"
 EXPECTED_SAFE = "0x766b6851a199bf91ae3fa13b1cfac5187355118f"
 
 
-def test_derive_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
-    assert derived.lower() == EXPECTED_DEPOSIT
+def test_derive_uups_deposit_wallet_address_matches_ts_golden_vector() -> None:
+    derived = derive_uups_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    assert derived.lower() == EXPECTED_UUPS_DEPOSIT
+
+
+def test_derive_beacon_deposit_wallet_address_matches_ts_golden_vector() -> None:
+    derived = derive_beacon_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    assert derived.lower() == EXPECTED_BEACON_DEPOSIT
 
 
 def test_derive_proxy_wallet_address_matches_ts_golden_vector() -> None:
@@ -44,9 +51,16 @@ def test_classify_wallet_type_returns_eoa_when_wallet_equals_signer() -> None:
     assert result == "EOA"
 
 
-def test_classify_wallet_type_returns_deposit_wallet_for_derived_address() -> None:
+def test_classify_wallet_type_returns_deposit_wallet_for_uups_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_DEPOSIT, config=PRODUCTION.wallet_derivation
+        signer=SIGNER, wallet=EXPECTED_UUPS_DEPOSIT, config=PRODUCTION.wallet_derivation
+    )
+    assert result == "DEPOSIT_WALLET"
+
+
+def test_classify_wallet_type_returns_deposit_wallet_for_beacon_address() -> None:
+    result = classify_wallet_type(
+        signer=SIGNER, wallet=EXPECTED_BEACON_DEPOSIT, config=PRODUCTION.wallet_derivation
     )
     assert result == "DEPOSIT_WALLET"
 
@@ -66,7 +80,7 @@ def test_classify_wallet_type_returns_gnosis_safe_for_derived_address() -> None:
 
 
 def test_classify_wallet_type_is_case_insensitive() -> None:
-    upper = EXPECTED_DEPOSIT.upper().replace("0X", "0x")
+    upper = EXPECTED_UUPS_DEPOSIT.upper().replace("0X", "0x")
     result = classify_wallet_type(signer=SIGNER, wallet=upper, config=PRODUCTION.wallet_derivation)
     assert result == "DEPOSIT_WALLET"
 


### PR DESCRIPTION
stacked pr: #28 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands transaction/broadcast and wallet-derivation logic (relayer payloads, JSON-RPC error handling, and environment defaults), which can affect how funds-moving transactions are created and submitted.
> 
> **Overview**
> Adds **sync parity** for relayer-based and EOA transaction workflows: introduces sync relayer helpers (`*_sync` variants for header resolution, deployed checks, nonce fetching, submit, polling) and new sync transaction handles (`SyncGaslessTransactionHandle`, `SyncEoaTransactionHandle`, `SyncTransactionHandle`).
> 
> Updates `SecureClient` to support gasless workflows end-to-end (relayer transport + `api_key`, EOA direct broadcast via RPC, `setup_gasless_wallet`, `is_gasless_ready`, and new convenience methods like `approve_erc20`, `transfer_erc20`, `setup_trading_approvals`, `split_position`/`merge_positions`/`redeem_positions`), while making `wallet` optional (defaults to signer) and ensuring `rpc_url` is always configured.
> 
> Changes deposit-wallet derivation to be **beacon-aware**: adds `deposit_wallet_beacon` to `WalletDerivation`, detects whether the factory exposes a beacon via `eth_call`, and derives the correct address (beacon vs UUPS) for both async and sync clients; tests are expanded accordingly, plus JSON-RPC now surfaces structured `JsonRpcCallError` for better revert/failure classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e709442b79a3950d81ed385c1cebff8f9a89ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->