### PR TITLE
feat: type-level BUY/SELL guidance on estimate_market_price DEV-114

### DIFF
--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Self, assert_never, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Self, assert_never, cast, overload
 
 from polymarket._internal.actions import builders as _builders_actions
 from polymarket._internal.actions import clob as _clob_actions
@@ -985,6 +985,24 @@ class AsyncPublicClient:
         )
         return _clob_actions.parse_price_history(await self._ctx.clob.get_json(path, params=params))
 
+    @overload
+    async def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
+    @overload
+    async def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
     async def estimate_market_price(
         self,
         *,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1347,6 +1347,24 @@ class AsyncSecureClient:
             await self._ctx.secure_clob.get_json(path, params=params)
         )
 
+    @overload
+    async def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
+    @overload
+    async def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
     async def estimate_market_price(
         self,
         *,

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Sequence
 from decimal import Decimal
 from types import TracebackType
-from typing import Self
+from typing import Literal, Self, overload
 
 from polymarket._internal.actions import builders as _builders_actions
 from polymarket._internal.actions import clob as _clob_actions
@@ -845,6 +845,24 @@ class PublicClient:
         )
         return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
 
+    @overload
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
+    @overload
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
     def estimate_market_price(
         self,
         *,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1087,6 +1087,24 @@ class SecureClient:
         )
         return _clob_actions.parse_price_history(self._ctx.clob.get_json(path, params=params))
 
+    @overload
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["BUY"],
+        amount: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
+    @overload
+    def estimate_market_price(
+        self,
+        *,
+        token_id: str,
+        side: Literal["SELL"],
+        shares: Decimal | int | float | str,
+        order_type: MarketOrderType = "FOK",
+    ) -> Decimal: ...
     def estimate_market_price(
         self,
         *,

--- a/tests/integration/test_clob_orders.py
+++ b/tests/integration/test_clob_orders.py
@@ -108,10 +108,12 @@ async def test_estimate_market_price_for_buy_returns_decimal_in_unit_range(
     public_client: AsyncPublicClient,
     tradable_market: Market,
 ) -> None:
+    amount = tradable_market.trading.minimum_order_size
+    assert amount is not None
     price = await public_client.estimate_market_price(
         token_id=_yes_token_id(tradable_market),
         side="BUY",
-        amount=tradable_market.trading.minimum_order_size,
+        amount=amount,
     )
 
     assert isinstance(price, Decimal)

--- a/tests/unit/test_order_estimate.py
+++ b/tests/unit/test_order_estimate.py
@@ -194,7 +194,7 @@ def test_client_estimate_market_price_validates_input() -> None:
     async def run() -> Decimal:
         client = await _make_client()
         try:
-            return await client.estimate_market_price(
+            return await client.estimate_market_price(  # type: ignore[call-overload]
                 token_id="8501497", side="BUY", amount=Decimal(1), shares=Decimal(1)
             )
         finally:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a type-hint/API ergonomics change (new `@overload` signatures) with no behavioral changes to pricing/HTTP logic; minor risk is only around static type-checking expectations in downstream users.
> 
> **Overview**
> Adds **type-level guidance** for `estimate_market_price` across sync/async `PublicClient` and `SecureClient` variants by introducing `@overload` signatures that tie `side="BUY"` to requiring `amount` and `side="SELL"` to requiring `shares`.
> 
> Updates related imports and adjusts tests to accommodate stricter overload typing (e.g., explicit local `amount` variable in integration test and a `# type: ignore[call-overload]` where intentionally passing invalid params to validate runtime errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb958aade641f716e3a31914e3d5808bf2538d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->