### PR TITLE
fix(place-orders): two-call refresh + SELL recovery test

### DIFF
--- a/src/polymarket/_internal/actions/account.py
+++ b/src/polymarket/_internal/actions/account.py
@@ -204,6 +204,22 @@ def parse_balance_allowance(data: object) -> BalanceAllowance:
     return BalanceAllowance.parse_response(data)
 
 
+def build_update_balance_allowance_request(
+    *,
+    asset_type: AssetType,
+    token_id: str | None,
+    signature_type: int,
+) -> tuple[str, dict[str, QueryParamValue]]:
+    _validate_asset_type(asset_type)
+    params: dict[str, QueryParamValue] = {
+        "asset_type": asset_type,
+        "signature_type": signature_type,
+    }
+    if token_id is not None:
+        params["token_id"] = require_nonempty("token_id", token_id)
+    return "/balance-allowance/update", params
+
+
 __all__ = [
     "END_CURSOR",
     "build_balance_allowance_request",
@@ -213,6 +229,7 @@ __all__ = [
     "build_list_account_trades_request",
     "build_list_open_orders_request",
     "build_notifications_request",
+    "build_update_balance_allowance_request",
     "parse_account_trades_page",
     "parse_balance_allowance",
     "parse_closed_only_mode",

--- a/src/polymarket/_internal/actions/orders/allowance.py
+++ b/src/polymarket/_internal/actions/orders/allowance.py
@@ -3,36 +3,11 @@ from polymarket._internal.actions.orders.types import OrderDraft
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket._internal.request import QueryParamValue
 from polymarket._internal.wallet import WalletType, signature_type_for
-from polymarket.errors import InsufficientAllowanceError
+from polymarket.models.types import OrderSide, TokenId
 from polymarket.types import EvmAddress
 
 
-def _insufficient_allowance_error(spender: EvmAddress, draft: OrderDraft, current: int) -> str:
-    return (
-        f"Insufficient on-chain allowance for spender {spender}: "
-        f"have {current} base units, need {draft.offered_amount}. "
-        "Run an ERC20/ERC1155 approval transaction and try again. "
-        "Automatic approval will be available in a future SDK release."
-    )
-
-
-async def ensure_order_allowance(ctx: AsyncSecureClientContext, draft: OrderDraft) -> None:
-    spender = draft.exchange_address
-    current = await _fetch_current_allowance(ctx, draft=draft, spender=spender)
-    if current >= draft.offered_amount:
-        return
-    raise InsufficientAllowanceError(_insufficient_allowance_error(spender, draft, current))
-
-
-def ensure_order_allowance_sync(ctx: SyncSecureClientContext, draft: OrderDraft) -> None:
-    spender = draft.exchange_address
-    current = _fetch_current_allowance_sync(ctx, draft=draft, spender=spender)
-    if current >= draft.offered_amount:
-        return
-    raise InsufficientAllowanceError(_insufficient_allowance_error(spender, draft, current))
-
-
-async def _fetch_current_allowance(
+async def fetch_current_allowance(
     ctx: AsyncSecureClientContext, *, draft: OrderDraft, spender: EvmAddress
 ) -> int:
     path, params = _balance_allowance_request_for_draft(ctx.wallet_type, draft=draft)
@@ -42,7 +17,7 @@ async def _fetch_current_allowance(
     return _allowance_for_spender(balance.allowances, spender)
 
 
-def _fetch_current_allowance_sync(
+def fetch_current_allowance_sync(
     ctx: SyncSecureClientContext, *, draft: OrderDraft, spender: EvmAddress
 ) -> int:
     path, params = _balance_allowance_request_for_draft(ctx.wallet_type, draft=draft)
@@ -52,17 +27,49 @@ def _fetch_current_allowance_sync(
     return _allowance_for_spender(balance.allowances, spender)
 
 
+async def fetch_current_order_allowance(
+    ctx: AsyncSecureClientContext, *, side: OrderSide, token_id: TokenId, spender: EvmAddress
+) -> int:
+    path, params = _balance_allowance_request_for_side(
+        ctx.wallet_type, side=side, token_id=token_id
+    )
+    balance = _account_actions.parse_balance_allowance(
+        await ctx.secure_clob.get_json(path, params=params)
+    )
+    return _allowance_for_spender(balance.allowances, spender)
+
+
+def fetch_current_order_allowance_sync(
+    ctx: SyncSecureClientContext, *, side: OrderSide, token_id: TokenId, spender: EvmAddress
+) -> int:
+    path, params = _balance_allowance_request_for_side(
+        ctx.wallet_type, side=side, token_id=token_id
+    )
+    balance = _account_actions.parse_balance_allowance(
+        ctx.secure_clob.get_json(path, params=params)
+    )
+    return _allowance_for_spender(balance.allowances, spender)
+
+
 def _balance_allowance_request_for_draft(
     wallet_type: WalletType, *, draft: OrderDraft
 ) -> tuple[str, dict[str, QueryParamValue]]:
+    return _balance_allowance_request_for_side(
+        wallet_type, side=draft.side, token_id=draft.token_id
+    )
+
+
+def _balance_allowance_request_for_side(
+    wallet_type: WalletType, *, side: OrderSide, token_id: TokenId
+) -> tuple[str, dict[str, QueryParamValue]]:
     signature_type = signature_type_for(wallet_type)
-    if draft.side == "BUY":
+    if side == "BUY":
         return _account_actions.build_balance_allowance_request(
             asset_type="COLLATERAL", token_id=None, signature_type=signature_type
         )
     return _account_actions.build_balance_allowance_request(
         asset_type="CONDITIONAL",
-        token_id=draft.token_id,
+        token_id=token_id,
         signature_type=signature_type,
     )
 
@@ -75,4 +82,9 @@ def _allowance_for_spender(allowances: dict[str, int], spender: str) -> int:
     return 0
 
 
-__all__ = ["ensure_order_allowance", "ensure_order_allowance_sync"]
+__all__ = [
+    "fetch_current_allowance",
+    "fetch_current_allowance_sync",
+    "fetch_current_order_allowance",
+    "fetch_current_order_allowance_sync",
+]

--- a/src/polymarket/_internal/actions/orders/place.py
+++ b/src/polymarket/_internal/actions/orders/place.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polymarket._internal.actions import account as _account_actions
+from polymarket._internal.actions.orders import post as _post_actions
+from polymarket._internal.actions.orders.allowance import (
+    fetch_current_order_allowance,
+    fetch_current_order_allowance_sync,
+)
+from polymarket._internal.actions.orders.context import resolve_exchange_address
+from polymarket._internal.actions.orders.market_data import (
+    fetch_neg_risk,
+    fetch_neg_risk_sync,
+)
+from polymarket._internal.wallet import signature_type_for
+from polymarket.errors import RequestRejectedError
+from polymarket.models.clob import AssetType
+from polymarket.models.clob.order_response import OrderResponse
+from polymarket.models.clob.orders import SignedOrder
+
+if TYPE_CHECKING:
+    from polymarket.clients.async_secure import AsyncSecureClient
+    from polymarket.clients.secure import SecureClient
+
+_ALLOWANCE_REJECTION_TOKEN = "allowance is not enough"
+
+
+def is_balance_or_allowance_rejection(error: BaseException) -> bool:
+    return (
+        isinstance(error, RequestRejectedError)
+        and error.status == 400
+        and _ALLOWANCE_REJECTION_TOKEN in str(error)
+    )
+
+
+async def post_order_with_allowance_recovery(
+    client: AsyncSecureClient, signed_order: SignedOrder
+) -> OrderResponse:
+    try:
+        return await _post_order(client, signed_order)
+    except Exception as error:
+        if not is_balance_or_allowance_rejection(error):
+            raise
+        approved = await _approve_order_if_under_allowance(client, signed_order)
+        if not approved:
+            raise
+        return await _post_order(client, signed_order)
+
+
+def post_order_with_allowance_recovery_sync(
+    client: SecureClient, signed_order: SignedOrder
+) -> OrderResponse:
+    try:
+        return _post_order_sync(client, signed_order)
+    except Exception as error:
+        if not is_balance_or_allowance_rejection(error):
+            raise
+        approved = _approve_order_if_under_allowance_sync(client, signed_order)
+        if not approved:
+            raise
+        return _post_order_sync(client, signed_order)
+
+
+async def _post_order(client: AsyncSecureClient, signed_order: SignedOrder) -> OrderResponse:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    path, payload = _post_actions.build_post_order_request(
+        signed_order, owner_api_key=ctx.credentials.key
+    )
+    return _post_actions.parse_order_response(await ctx.secure_clob.post_json(path, json=payload))
+
+
+def _post_order_sync(client: SecureClient, signed_order: SignedOrder) -> OrderResponse:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    path, payload = _post_actions.build_post_order_request(
+        signed_order, owner_api_key=ctx.credentials.key
+    )
+    return _post_actions.parse_order_response(ctx.secure_clob.post_json(path, json=payload))
+
+
+async def _approve_order_if_under_allowance(
+    client: AsyncSecureClient, signed_order: SignedOrder
+) -> bool:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    env = ctx.environment
+    neg_risk = await fetch_neg_risk(ctx, token_id=signed_order.token_id)
+    spender = resolve_exchange_address(env, neg_risk)
+    current = await fetch_current_order_allowance(
+        ctx, side=signed_order.side, token_id=signed_order.token_id, spender=spender
+    )
+    required = signed_order.maker_amount
+    if current >= required:
+        return False
+
+    if signed_order.side == "BUY":
+        handle = await client.approve_erc20(
+            token_address=env.collateral_token,
+            spender_address=str(spender),
+            amount="max",
+        )
+    else:
+        handle = await client.approve_erc1155_for_all(
+            token_address=env.conditional_tokens,
+            operator_address=str(spender),
+        )
+    await handle.wait()
+    await _refresh_balance_allowance(client, signed_order)
+    return True
+
+
+def _approve_order_if_under_allowance_sync(client: SecureClient, signed_order: SignedOrder) -> bool:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    env = ctx.environment
+    neg_risk = fetch_neg_risk_sync(ctx, token_id=signed_order.token_id)
+    spender = resolve_exchange_address(env, neg_risk)
+    current = fetch_current_order_allowance_sync(
+        ctx, side=signed_order.side, token_id=signed_order.token_id, spender=spender
+    )
+    required = signed_order.maker_amount
+    if current >= required:
+        return False
+
+    if signed_order.side == "BUY":
+        handle = client.approve_erc20(
+            token_address=env.collateral_token,
+            spender_address=str(spender),
+            amount="max",
+        )
+    else:
+        handle = client.approve_erc1155_for_all(
+            token_address=env.conditional_tokens,
+            operator_address=str(spender),
+        )
+    handle.wait()
+    _refresh_balance_allowance_sync(client, signed_order)
+    return True
+
+
+async def _refresh_balance_allowance(client: AsyncSecureClient, signed_order: SignedOrder) -> None:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    asset_type, token_id = _refresh_target(signed_order)
+    signature_type = signature_type_for(ctx.wallet_type)
+    update_path, update_params = _account_actions.build_update_balance_allowance_request(
+        asset_type=asset_type,
+        token_id=token_id,
+        signature_type=signature_type,
+    )
+    # /balance-allowance/update is a side-effect endpoint; body is not consumed.
+    await ctx.secure_clob.get_bytes(update_path, params=update_params)
+    fetch_path, fetch_params = _account_actions.build_balance_allowance_request(
+        asset_type=asset_type,
+        token_id=token_id,
+        signature_type=signature_type,
+    )
+    _account_actions.parse_balance_allowance(
+        await ctx.secure_clob.get_json(fetch_path, params=fetch_params)
+    )
+
+
+def _refresh_balance_allowance_sync(client: SecureClient, signed_order: SignedOrder) -> None:
+    ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
+    asset_type, token_id = _refresh_target(signed_order)
+    signature_type = signature_type_for(ctx.wallet_type)
+    update_path, update_params = _account_actions.build_update_balance_allowance_request(
+        asset_type=asset_type,
+        token_id=token_id,
+        signature_type=signature_type,
+    )
+    ctx.secure_clob.get_bytes(update_path, params=update_params)
+    fetch_path, fetch_params = _account_actions.build_balance_allowance_request(
+        asset_type=asset_type,
+        token_id=token_id,
+        signature_type=signature_type,
+    )
+    _account_actions.parse_balance_allowance(
+        ctx.secure_clob.get_json(fetch_path, params=fetch_params)
+    )
+
+
+def _refresh_target(signed_order: SignedOrder) -> tuple[AssetType, str | None]:
+    if signed_order.side == "BUY":
+        return "COLLATERAL", None
+    return "CONDITIONAL", signed_order.token_id
+
+
+__all__ = [
+    "is_balance_or_allowance_rejection",
+    "post_order_with_allowance_recovery",
+    "post_order_with_allowance_recovery_sync",
+]

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -37,7 +37,6 @@ from polymarket._internal.actions.gamma import (
 )
 from polymarket._internal.actions.orders import cancel as _cancel_actions
 from polymarket._internal.actions.orders import post as _post_actions
-from polymarket._internal.actions.orders.allowance import ensure_order_allowance
 from polymarket._internal.actions.orders.estimate import (
     estimate_market_price as _estimate_market_price,
 )
@@ -52,6 +51,9 @@ from polymarket._internal.actions.orders.market import (
 from polymarket._internal.actions.orders.orders import (
     create_signed_order,
     create_unsigned_order,
+)
+from polymarket._internal.actions.orders.place import (
+    post_order_with_allowance_recovery,
 )
 from polymarket._internal.actions.orders.typed_data import (
     build_order_signature,
@@ -1473,7 +1475,7 @@ class AsyncSecureClient:
             expiration=expiration,
             builder_code=builder_code,
         )
-        return await self.post_order(signed)
+        return await post_order_with_allowance_recovery(self, signed)
 
     @overload
     async def place_market_order(
@@ -1516,7 +1518,7 @@ class AsyncSecureClient:
             order_type=order_type,
             builder_code=builder_code,
         )
-        return await self.post_order(signed)
+        return await post_order_with_allowance_recovery(self, signed)
 
     async def get_builder_fee_rates(self, builder_code: str) -> BuilderFeeRates:
         from polymarket._internal.actions.orders.market_data import fetch_builder_fee_rates
@@ -1877,7 +1879,6 @@ class AsyncSecureClient:
         )
 
     async def _sign_order(self, draft: OrderDraft, *, post_only: bool) -> SignedOrder:
-        await ensure_order_allowance(self._ctx, draft)
         unsigned = create_unsigned_order(
             draft, wallet=self._ctx.wallet, wallet_type=self._ctx.wallet_type
         )

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -38,7 +38,6 @@ from polymarket._internal.actions.gamma import (
 )
 from polymarket._internal.actions.orders import cancel as _cancel_actions
 from polymarket._internal.actions.orders import post as _post_actions
-from polymarket._internal.actions.orders.allowance import ensure_order_allowance_sync
 from polymarket._internal.actions.orders.estimate import (
     estimate_market_price_sync as _estimate_market_price_sync,
 )
@@ -53,6 +52,9 @@ from polymarket._internal.actions.orders.market import (
 from polymarket._internal.actions.orders.orders import (
     create_signed_order,
     create_unsigned_order,
+)
+from polymarket._internal.actions.orders.place import (
+    post_order_with_allowance_recovery_sync,
 )
 from polymarket._internal.actions.orders.typed_data import (
     build_order_signature,
@@ -1311,7 +1313,7 @@ class SecureClient:
             expiration=expiration,
             builder_code=builder_code,
         )
-        return self.post_order(signed)
+        return post_order_with_allowance_recovery_sync(self, signed)
 
     @overload
     def place_market_order(
@@ -1354,7 +1356,7 @@ class SecureClient:
             order_type=order_type,
             builder_code=builder_code,
         )
-        return self.post_order(signed)
+        return post_order_with_allowance_recovery_sync(self, signed)
 
     def get_builder_fee_rates(self, builder_code: str) -> BuilderFeeRates:
         from polymarket._internal.actions.orders.market_data import fetch_builder_fee_rates_sync
@@ -1452,7 +1454,6 @@ class SecureClient:
         return self._sign_order(draft, post_only=False)
 
     def _sign_order(self, draft: OrderDraft, *, post_only: bool) -> SignedOrder:
-        ensure_order_allowance_sync(self._ctx, draft)
         unsigned = create_unsigned_order(
             draft, wallet=self._ctx.wallet, wallet_type=self._ctx.wallet_type
         )

--- a/tests/unit/test_order_allowance.py
+++ b/tests/unit/test_order_allowance.py
@@ -4,13 +4,10 @@ import dataclasses
 from typing import Any
 
 import httpx
-import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient
-from polymarket._internal.actions.orders.allowance import ensure_order_allowance
-from polymarket._internal.actions.orders.types import OrderDraft
+from polymarket._internal.actions.orders.allowance import fetch_current_order_allowance
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import InsufficientAllowanceError
 from polymarket.models.types import TokenId
 from polymarket.types import EvmAddress
 
@@ -18,21 +15,6 @@ PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff8
 SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
 EXCHANGE = EvmAddress("0xE111180000d2663C0091e4f400237545B87B996B")
-
-
-def _draft(*, side: str, offered: int) -> OrderDraft:
-    return OrderDraft(
-        chain_id=137,
-        exchange_address=EXCHANGE,
-        expiration=0,
-        funder_address=EvmAddress(SIGNER_ADDRESS),
-        offered_amount=offered,
-        order_type="GTC",
-        side=side,  # type: ignore[arg-type]
-        signer=EvmAddress(SIGNER_ADDRESS),
-        requested_amount=1_000_000,
-        token_id=TokenId("8501497"),
-    )
 
 
 def _install_secure_clob(client: AsyncSecureClient, payload: dict[str, Any]) -> None:
@@ -58,65 +40,78 @@ async def _make_client() -> AsyncSecureClient:
     )
 
 
-def test_ensure_order_allowance_passes_when_collateral_sufficient_for_buy() -> None:
-    async def run() -> None:
+def test_fetch_current_order_allowance_returns_buy_spender_balance() -> None:
+    async def run() -> int:
         client = await _make_client()
         try:
             _install_secure_clob(
                 client,
-                {"balance": "100000000", "allowances": {EXCHANGE: "100000000"}},
+                {"balance": "0", "allowances": {EXCHANGE: "5000000"}},
             )
-            await ensure_order_allowance(client._ctx, _draft(side="BUY", offered=1_000_000))
+            return await fetch_current_order_allowance(
+                client._ctx,
+                side="BUY",
+                token_id=TokenId("8501497"),
+                spender=EXCHANGE,
+            )
         finally:
             await client.close()
 
-    asyncio.run(run())
+    assert asyncio.run(run()) == 5_000_000
 
 
-def test_ensure_order_allowance_raises_when_collateral_short_for_buy() -> None:
-    async def run() -> None:
+def test_fetch_current_order_allowance_returns_sell_spender_balance() -> None:
+    async def run() -> int:
         client = await _make_client()
         try:
             _install_secure_clob(
                 client,
-                {"balance": "100", "allowances": {EXCHANGE: "100"}},
+                {"balance": "0", "allowances": {EXCHANGE: "777"}},
             )
-            await ensure_order_allowance(client._ctx, _draft(side="BUY", offered=1_000_000))
+            return await fetch_current_order_allowance(
+                client._ctx,
+                side="SELL",
+                token_id=TokenId("8501497"),
+                spender=EXCHANGE,
+            )
         finally:
             await client.close()
 
-    with pytest.raises(InsufficientAllowanceError, match="Insufficient"):
-        asyncio.run(run())
+    assert asyncio.run(run()) == 777
 
 
-def test_ensure_order_allowance_passes_when_conditional_sufficient_for_sell() -> None:
-    async def run() -> None:
+def test_fetch_current_order_allowance_returns_zero_when_spender_absent() -> None:
+    async def run() -> int:
+        client = await _make_client()
+        try:
+            _install_secure_clob(client, {"balance": "0", "allowances": {}})
+            return await fetch_current_order_allowance(
+                client._ctx,
+                side="BUY",
+                token_id=TokenId("8501497"),
+                spender=EXCHANGE,
+            )
+        finally:
+            await client.close()
+
+    assert asyncio.run(run()) == 0
+
+
+def test_fetch_current_order_allowance_spender_lookup_is_case_insensitive() -> None:
+    async def run() -> int:
         client = await _make_client()
         try:
             _install_secure_clob(
                 client,
-                {"balance": "100000000", "allowances": {EXCHANGE: "100000000"}},
+                {"balance": "0", "allowances": {EXCHANGE.lower(): "42"}},
             )
-            await ensure_order_allowance(client._ctx, _draft(side="SELL", offered=1_000_000))
+            return await fetch_current_order_allowance(
+                client._ctx,
+                side="BUY",
+                token_id=TokenId("8501497"),
+                spender=EXCHANGE,
+            )
         finally:
             await client.close()
 
-    asyncio.run(run())
-
-
-def test_ensure_order_allowance_spender_lookup_is_case_insensitive() -> None:
-    async def run() -> None:
-        client = await _make_client()
-        try:
-            _install_secure_clob(
-                client,
-                {
-                    "balance": "100000000",
-                    "allowances": {EXCHANGE.lower(): "100000000"},
-                },
-            )
-            await ensure_order_allowance(client._ctx, _draft(side="BUY", offered=1_000_000))
-        finally:
-            await client.close()
-
-    asyncio.run(run())
+    assert asyncio.run(run()) == 42

--- a/tests/unit/test_order_client.py
+++ b/tests/unit/test_order_client.py
@@ -10,7 +10,7 @@ import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import InsufficientAllowanceError, UserInputError
+from polymarket.errors import UserInputError
 from polymarket.models.clob.order_response import AcceptedOrder
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -136,18 +136,24 @@ def test_create_limit_order_signs_and_returns_signed_order() -> None:
     asyncio.run(run())
 
 
-def test_create_limit_order_raises_when_allowance_insufficient() -> None:
+def test_create_limit_order_does_not_preflight_allowance() -> None:
+    secure_captured: list[httpx.Request] = []
+
     async def run() -> None:
         client = await _make_client()
         try:
             _install_clob(client, _routed_handler([], _public_routes()))
-            _install_secure_clob(client, _routed_handler([], _secure_routes(has_allowance=False)))
+            _install_secure_clob(
+                client, _routed_handler(secure_captured, _secure_routes(has_allowance=False))
+            )
             await client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
         finally:
             await client.close()
 
-    with pytest.raises(InsufficientAllowanceError):
-        asyncio.run(run())
+    asyncio.run(run())
+    paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert "/balance-allowance" not in paths
+    assert "/balance-allowance/update" not in paths
 
 
 def test_place_limit_order_posts_after_signing() -> None:

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -1,0 +1,500 @@
+# pyright: reportPrivateUsage=false
+import asyncio
+import dataclasses
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from polymarket import ApiKeyCreds, AsyncSecureClient
+from polymarket._internal.actions.orders.place import (
+    is_balance_or_allowance_rejection,
+    post_order_with_allowance_recovery,
+)
+from polymarket._internal.wallet import derive_uups_deposit_wallet_address
+from polymarket.clients._transport import AsyncTransport
+from polymarket.environments import PRODUCTION
+from polymarket.errors import RequestRejectedError
+
+_PRIVATE_KEY = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
+_STANDARD_EXCHANGE = PRODUCTION.standard_exchange
+
+
+def _builder_auth() -> Any:
+    from polymarket import BuilderApiKey
+
+    return BuilderApiKey(key="bk", secret="dGVzdA==", passphrase="bp")
+
+
+async def _make_deposit_client() -> AsyncSecureClient:
+    from eth_account import Account
+
+    signer = Account.from_key(_PRIVATE_KEY)
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    return await AsyncSecureClient.create(
+        private_key=_PRIVATE_KEY,
+        wallet=wallet,
+        credentials=_CREDS,
+        api_key=_builder_auth(),
+        validate_credentials=False,
+    )
+
+
+def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport) -> None:
+    transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+        header_resolver=client._ctx.secure_clob._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
+
+
+def _install_clob(client: AsyncSecureClient, handler: httpx.MockTransport) -> None:
+    transport = AsyncTransport(
+        base_url="https://clob.test",
+        client=httpx.AsyncClient(base_url="https://clob.test", transport=handler),
+    )
+    client._ctx = dataclasses.replace(client._ctx, clob=transport)
+
+
+def _install_relayer(client: AsyncSecureClient, handler: httpx.MockTransport) -> None:
+    transport = AsyncTransport(
+        base_url="https://relayer.test",
+        client=httpx.AsyncClient(base_url="https://relayer.test", transport=handler),
+        header_resolver=client._ctx.relayer._header_resolver,
+    )
+    client._ctx = dataclasses.replace(client._ctx, relayer=transport)
+
+
+def _accepted_order_payload() -> dict[str, Any]:
+    return {
+        "errorMsg": "",
+        "makingAmount": "5",
+        "orderID": "ord-1",
+        "status": "live",
+        "success": True,
+        "takingAmount": "10",
+        "tradeIDs": [],
+        "transactionsHashes": [],
+    }
+
+
+_LIMIT_PUBLIC_ROUTES: dict[str, Any] = {
+    "/tick-size": {"minimum_tick_size": 0.01},
+    "/neg-risk": {"neg_risk": False},
+}
+
+
+def _public_handler(captured: list[httpx.Request]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path in _LIMIT_PUBLIC_ROUTES:
+            return httpx.Response(200, json=_LIMIT_PUBLIC_ROUTES[path], request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    return httpx.MockTransport(handler)
+
+
+async def _make_signed_buy_order(client: AsyncSecureClient) -> Any:
+    return await client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+
+def test_is_balance_or_allowance_rejection_matches_ts_signal() -> None:
+    err = RequestRejectedError("not enough balance / allowance is not enough", status=400)
+    assert is_balance_or_allowance_rejection(err) is True
+
+
+def test_is_balance_or_allowance_rejection_rejects_other_400() -> None:
+    err = RequestRejectedError("invalid order", status=400)
+    assert is_balance_or_allowance_rejection(err) is False
+
+
+def test_is_balance_or_allowance_rejection_rejects_non_400() -> None:
+    err = RequestRejectedError("allowance is not enough", status=500)
+    assert is_balance_or_allowance_rejection(err) is False
+
+
+def test_is_balance_or_allowance_rejection_rejects_other_exceptions() -> None:
+    assert is_balance_or_allowance_rejection(ValueError("nope")) is False
+
+
+def test_place_limit_order_first_post_success_no_recovery_calls() -> None:
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            return httpx.Response(200, json=_accepted_order_payload(), request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    async def run() -> None:
+        client = await _make_deposit_client()
+        try:
+            _install_clob(client, _public_handler(public_captured))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            await client.place_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    secure_paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert secure_paths == ["/order"]
+
+
+def test_place_limit_order_skips_approve_when_allowance_already_sufficient() -> None:
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            return httpx.Response(400, json={"error": "allowance is not enough"}, request=request)
+        if path == "/balance-allowance":
+            return httpx.Response(
+                200,
+                json={"balance": "0", "allowances": {_STANDARD_EXCHANGE: "99999999999"}},
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    async def run() -> None:
+        client = await _make_deposit_client()
+        try:
+            _install_clob(client, _public_handler(public_captured))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            with pytest.raises(RequestRejectedError, match="allowance is not enough"):
+                await client.place_limit_order(
+                    token_id="8501497", price="0.5", size="10", side="BUY"
+                )
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert paths.count("/order") == 1  # no retry
+    assert "/balance-allowance" in paths
+    assert "/balance-allowance/update" not in paths  # no approve, no refresh
+
+
+def test_place_limit_order_does_not_recover_on_non_allowance_400() -> None:
+    secure_captured: list[httpx.Request] = []
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            return httpx.Response(400, json={"error": "invalid signature"}, request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    async def run() -> None:
+        client = await _make_deposit_client()
+        try:
+            _install_clob(client, _public_handler([]))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            with pytest.raises(RequestRejectedError, match="invalid signature"):
+                await client.place_limit_order(
+                    token_id="8501497", price="0.5", size="10", side="BUY"
+                )
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert paths == ["/order"]
+
+
+def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+    relayer_captured: list[httpx.Request] = []
+    order_post_count = {"n": 0}
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            order_post_count["n"] += 1
+            if order_post_count["n"] == 1:
+                return httpx.Response(
+                    400, json={"error": "allowance is not enough"}, request=request
+                )
+            return httpx.Response(200, json=_accepted_order_payload(), request=request)
+        if path == "/balance-allowance":
+            return httpx.Response(
+                200,
+                json={"balance": "0", "allowances": {_STANDARD_EXCHANGE: "0"}},
+                request=request,
+            )
+        if path == "/balance-allowance/update":
+            return httpx.Response(
+                200,
+                json={"balance": "100000000", "allowances": {_STANDARD_EXCHANGE: "99999999999"}},
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    def relayer_handler(request: httpx.Request) -> httpx.Response:
+        relayer_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transactionHash": "0x" + "ab" * 32,
+                    "transactionID": "tx-approve",
+                },
+                request=request,
+            )
+        if path.startswith("/v1/account/transactions/"):
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transaction_hash": "0x" + "ab" * 32,
+                    "transaction_id": "tx-approve",
+                },
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    async def run() -> Any:
+        client = await _make_deposit_client()
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        try:
+            _install_clob(client, _public_handler(public_captured))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            _install_relayer(client, httpx.MockTransport(relayer_handler))
+            return await client.place_limit_order(
+                token_id="8501497", price="0.5", size="10", side="BUY"
+            )
+        finally:
+            await client.close()
+
+    response = asyncio.run(run())
+    assert response.order_id == "ord-1"
+
+    secure_paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert secure_paths.count("/order") == 2  # exactly one retry
+    # Refresh after approve = two-call (update + balance-allowance), matching TS.
+    assert secure_paths.count("/balance-allowance/update") == 1
+    # /balance-allowance called twice: once pre-approve, once post-refresh.
+    assert secure_paths.count("/balance-allowance") == 2
+
+    relayer_paths = [urlparse(str(r.url)).path for r in relayer_captured]
+    assert "/submit" in relayer_paths  # approve was submitted
+
+    # ERC20 approve on collateral_token to standard_exchange
+    approve_submit = next(r for r in relayer_captured if urlparse(str(r.url)).path == "/submit")
+    import json as _json
+
+    body = _json.loads(approve_submit.content.decode("utf-8"))
+    inner = body["depositWalletParams"]["calls"][0]
+    assert inner["target"].lower() == PRODUCTION.collateral_token.lower()
+
+
+def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retries() -> None:
+    import json as _json
+
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+    relayer_captured: list[httpx.Request] = []
+    order_post_count = {"n": 0}
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            order_post_count["n"] += 1
+            if order_post_count["n"] == 1:
+                return httpx.Response(
+                    400, json={"error": "allowance is not enough"}, request=request
+                )
+            return httpx.Response(200, json=_accepted_order_payload(), request=request)
+        if path == "/balance-allowance":
+            return httpx.Response(
+                200,
+                json={"balance": "0", "allowances": {_STANDARD_EXCHANGE: "0"}},
+                request=request,
+            )
+        if path == "/balance-allowance/update":
+            return httpx.Response(200, json={}, request=request)
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    def relayer_handler(request: httpx.Request) -> httpx.Response:
+        relayer_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transactionHash": "0x" + "cd" * 32,
+                    "transactionID": "tx-erc1155",
+                },
+                request=request,
+            )
+        if path.startswith("/v1/account/transactions/"):
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transaction_hash": "0x" + "cd" * 32,
+                    "transaction_id": "tx-erc1155",
+                },
+                request=request,
+            )
+        return httpx.Response(404, json={"error": "not mocked"}, request=request)
+
+    async def run() -> Any:
+        client = await _make_deposit_client()
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        try:
+            _install_clob(client, _public_handler(public_captured))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            _install_relayer(client, httpx.MockTransport(relayer_handler))
+            return await client.place_limit_order(
+                token_id="8501497", price="0.5", size="10", side="SELL"
+            )
+        finally:
+            await client.close()
+
+    response = asyncio.run(run())
+    assert response.order_id == "ord-1"
+
+    secure_paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert secure_paths.count("/order") == 2
+
+    # The pre-approve allowance fetch must query the CONDITIONAL asset path with the token_id.
+    pre_approve_check = next(
+        r for r in secure_captured if urlparse(str(r.url)).path == "/balance-allowance"
+    )
+    from urllib.parse import parse_qs
+
+    qs = parse_qs(urlparse(str(pre_approve_check.url)).query)
+    assert qs["asset_type"] == ["CONDITIONAL"]
+    assert qs["token_id"] == ["8501497"]
+
+    # Approve was sent: setApprovalForAll on the conditional_tokens contract.
+    approve_submit = next(r for r in relayer_captured if urlparse(str(r.url)).path == "/submit")
+    body = _json.loads(approve_submit.content.decode("utf-8"))
+    inner = body["depositWalletParams"]["calls"][0]
+    set_approval_selector = "0xa22cb465"  # setApprovalForAll(address,bool)
+    assert inner["target"].lower() == PRODUCTION.conditional_tokens.lower()
+    assert inner["data"].startswith(set_approval_selector)
+
+
+def test_place_limit_order_retry_failure_surfaces_directly() -> None:
+    public_captured: list[httpx.Request] = []
+    secure_captured: list[httpx.Request] = []
+    order_post_count = {"n": 0}
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/order":
+            order_post_count["n"] += 1
+            if order_post_count["n"] == 1:
+                return httpx.Response(
+                    400, json={"error": "allowance is not enough"}, request=request
+                )
+            return httpx.Response(400, json={"error": "second-attempt rejection"}, request=request)
+        if path == "/balance-allowance":
+            return httpx.Response(
+                200,
+                json={"balance": "0", "allowances": {_STANDARD_EXCHANGE: "0"}},
+                request=request,
+            )
+        if path == "/balance-allowance/update":
+            return httpx.Response(
+                200,
+                json={"balance": "100000000", "allowances": {_STANDARD_EXCHANGE: "99999999999"}},
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    def relayer_handler(request: httpx.Request) -> httpx.Response:
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "0"}, request=request)
+        if path == "/submit":
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transactionHash": "0x" + "ab" * 32,
+                    "transactionID": "tx-a",
+                },
+                request=request,
+            )
+        if path.startswith("/v1/account/transactions/"):
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_MINED",
+                    "transaction_hash": "0x" + "ab" * 32,
+                    "transaction_id": "tx-a",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    async def run() -> None:
+        client = await _make_deposit_client()
+        client._ctx = dataclasses.replace(
+            client._ctx,
+            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+        )
+        try:
+            _install_clob(client, _public_handler(public_captured))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            _install_relayer(client, httpx.MockTransport(relayer_handler))
+            with pytest.raises(RequestRejectedError, match="second-attempt rejection"):
+                await client.place_limit_order(
+                    token_id="8501497", price="0.5", size="10", side="BUY"
+                )
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    # exactly two /order attempts; no third
+    posts = [r for r in secure_captured if urlparse(str(r.url)).path == "/order"]
+    assert len(posts) == 2
+
+
+def test_post_order_with_allowance_recovery_helper_is_idempotent_on_success() -> None:
+    secure_captured: list[httpx.Request] = []
+
+    def secure_handler(request: httpx.Request) -> httpx.Response:
+        secure_captured.append(request)
+        return httpx.Response(200, json=_accepted_order_payload(), request=request)
+
+    async def run() -> None:
+        client = await _make_deposit_client()
+        try:
+            _install_clob(client, _public_handler([]))
+            _install_secure_clob(client, httpx.MockTransport(secure_handler))
+            signed = await _make_signed_buy_order(client)
+            await post_order_with_allowance_recovery(client, signed)
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert paths == ["/order"]

--- a/tests/unit/test_secure_orders_sync.py
+++ b/tests/unit/test_secure_orders_sync.py
@@ -9,7 +9,7 @@ import pytest
 
 from polymarket import ApiKeyCreds, SecureClient
 from polymarket.clients._transport import SyncTransport
-from polymarket.errors import InsufficientAllowanceError, UserInputError
+from polymarket.errors import UserInputError
 from polymarket.models.clob.order_response import AcceptedOrder
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -123,11 +123,19 @@ def test_create_limit_order_signs_and_returns_signed_order() -> None:
     assert signed.post_only is False
 
 
-def test_create_limit_order_raises_when_allowance_insufficient() -> None:
-    with pytest.raises(InsufficientAllowanceError), _make_client() as client:
+def test_create_limit_order_does_not_preflight_allowance() -> None:
+    secure_captured: list[httpx.Request] = []
+
+    with _make_client() as client:
         _install_clob(client, _routed_handler([], _public_routes()))
-        _install_secure_clob(client, _routed_handler([], _secure_routes(has_allowance=False)))
+        _install_secure_clob(
+            client, _routed_handler(secure_captured, _secure_routes(has_allowance=False))
+        )
         client.create_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+    paths = [urlparse(str(r.url)).path for r in secure_captured]
+    assert "/balance-allowance" not in paths
+    assert "/balance-allowance/update" not in paths
 
 
 def test_place_limit_order_posts_after_signing() -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the order placement flow to conditionally submit on-chain approval transactions and retry the order on specific 400 rejections, which can affect trading behavior and trigger side effects (approvals/relayer calls). Test coverage is added, but the logic depends on matching a backend error string and new side-effect endpoints.
> 
> **Overview**
> Adds `post_order_with_allowance_recovery` (async + sync) to retry `POST /order` when the API rejects with an *allowance/balance* 400 error: it checks current spender allowance, submits the appropriate approval (`approve_erc20` for BUY, `approve_erc1155_for_all` for SELL), performs a two-call allowance refresh (`/balance-allowance/update` then `/balance-allowance`), and retries once.
> 
> Removes the previous preflight `ensure_order_allowance` check during signing, refactors allowance helpers to expose `fetch_current_*_allowance` utilities (including side/token-specific queries), and updates/expands unit tests to cover BUY/SELL recovery behavior and confirm `create_*_order` no longer hits allowance endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb59ae80fc20cc6e60c837a02ebaf22856853f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->