### PR TITLE
ci: pin third-party workflow actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -32,4 +32,4 @@ jobs:
         run: uv build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release PR
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to full commit SHAs to resolve CodeQL actions/unpinned-tag alerts
- keep comments with the original tag/channel for maintainability

## Alerts addressed
- #1 integration setup-uv
- #3 publish setup-uv
- #4 PyPI publish action
- #5 release-please action
- #6 verify setup-uv static checks
- #7 verify setup-uv tests

## Verification
- make lint
- make format-check
- make typecheck
- actionlint -ignore 'label "arc-runner-set-euw1" is unknown'

Note: the ignored actionlint warning is for the existing custom self-hosted runner label used by the integration workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that pin existing third-party actions to immutable commit SHAs, reducing supply-chain risk without altering build/test logic.
> 
> **Overview**
> Pins third-party GitHub Actions used in CI/CD workflows to full commit SHAs (keeping the original tag/channel in comments) to address unpinned-action alerts.
> 
> This updates `setup-uv` across integration and verify workflows, pins `gh-action-pypi-publish` in the publish workflow, and pins `release-please-action` in the release workflow, with no functional changes expected beyond using the exact referenced action revisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119ca2aebe85bd1f3f95c1a396d37ea914a7ce4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->