### PR TITLE
fix: update idna lockfile dependency

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -607,11 +607,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update transitive `idna` lockfile resolution from 3.13 to 3.16
- address Dependabot alert GHSA-65pc-fj4g-8rjx / CVE-2026-45409

## Dependency path
- `idna` is transitive through `httpx` and `anyio`
- no direct dependency constraint change was needed

## Verification
- `uv tree --package idna --invert`
- `make lint`
- `make format-check`
- `make typecheck`
- `make test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a lockfile-only transitive dependency bump, with no application code changes. Runtime behavior could change slightly for URL/IDNA handling in `httpx`-related paths.
> 
> **Overview**
> Bumps the resolved `idna` package in `uv.lock` from **3.13** to **3.16** (updating the recorded sdist/wheel URLs and hashes) to address the associated vulnerability advisory.
> 
> No direct dependency constraints or application code are modified; only the lockfile resolution changes for this transitive dependency (used via `httpx`/`anyio`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ca1db9d6654bec32ab03266dcf2a430a8221f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->