### PR TITLE
fix: hide credential validation test switch

### DIFF
--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -284,30 +284,6 @@ class AsyncSecureClient:
         )
 
     @classmethod
-    async def _create_for_testing(
-        cls,
-        *,
-        private_key: str,
-        wallet: str | None = None,
-        environment: Environment = PRODUCTION,
-        credentials: ApiKeyCreds | None = None,
-        api_key: ApiKey | None = None,
-        nonce: int = 0,
-        validate_credentials: bool = True,
-        logger: logging.Logger | None = None,
-    ) -> Self:
-        return await cls._create(
-            private_key=private_key,
-            wallet=wallet,
-            environment=environment,
-            credentials=credentials,
-            api_key=api_key,
-            nonce=nonce,
-            validate_credentials=validate_credentials,
-            logger=logger,
-        )
-
-    @classmethod
     async def _create(
         cls,
         *,
@@ -317,7 +293,7 @@ class AsyncSecureClient:
         credentials: ApiKeyCreds | None = None,
         api_key: ApiKey | None = None,
         nonce: int = 0,
-        validate_credentials: bool,
+        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
         if not private_key:

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -256,7 +256,6 @@ class AsyncSecureClient:
         credentials: ApiKeyCreds | None = None,
         api_key: ApiKey | None = None,
         nonce: int = 0,
-        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
         """Create an authenticated async client.
@@ -268,12 +267,59 @@ class AsyncSecureClient:
                 derived during client creation.
             api_key: Optional key for gasless wallet and relayed transaction workflows.
             nonce: Credential derivation nonce. Cannot be combined with ``credentials``.
-            validate_credentials: Whether provided credentials should be validated.
 
         Raises:
             UserInputError: If key material, wallet, nonce, or credentials are invalid.
             RequestRejectedError: If credential derivation or validation is rejected.
         """
+        return await cls._create(
+            private_key=private_key,
+            wallet=wallet,
+            environment=environment,
+            credentials=credentials,
+            api_key=api_key,
+            nonce=nonce,
+            validate_credentials=True,
+            logger=logger,
+        )
+
+    @classmethod
+    async def _create_for_testing(
+        cls,
+        *,
+        private_key: str,
+        wallet: str | None = None,
+        environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        api_key: ApiKey | None = None,
+        nonce: int = 0,
+        validate_credentials: bool = True,
+        logger: logging.Logger | None = None,
+    ) -> Self:
+        return await cls._create(
+            private_key=private_key,
+            wallet=wallet,
+            environment=environment,
+            credentials=credentials,
+            api_key=api_key,
+            nonce=nonce,
+            validate_credentials=validate_credentials,
+            logger=logger,
+        )
+
+    @classmethod
+    async def _create(
+        cls,
+        *,
+        private_key: str,
+        wallet: str | None = None,
+        environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        api_key: ApiKey | None = None,
+        nonce: int = 0,
+        validate_credentials: bool,
+        logger: logging.Logger | None = None,
+    ) -> Self:
         if not private_key:
             raise UserInputError("private_key is required")
         _validate_nonce(nonce)

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -230,7 +230,6 @@ class SecureClient:
         credentials: ApiKeyCreds | None = None,
         api_key: ApiKey | None = None,
         nonce: int = 0,
-        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
         """Create an authenticated synchronous client.
@@ -242,12 +241,59 @@ class SecureClient:
                 derived during client creation.
             api_key: Optional key for gasless wallet and relayed transaction workflows.
             nonce: Credential derivation nonce. Cannot be combined with ``credentials``.
-            validate_credentials: Whether provided credentials should be validated.
 
         Raises:
             UserInputError: If key material, wallet, nonce, or credentials are invalid.
             RequestRejectedError: If credential derivation or validation is rejected.
         """
+        return cls._create(
+            private_key=private_key,
+            wallet=wallet,
+            environment=environment,
+            credentials=credentials,
+            api_key=api_key,
+            nonce=nonce,
+            validate_credentials=True,
+            logger=logger,
+        )
+
+    @classmethod
+    def _create_for_testing(
+        cls,
+        *,
+        private_key: str,
+        wallet: str | None = None,
+        environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        api_key: ApiKey | None = None,
+        nonce: int = 0,
+        validate_credentials: bool = True,
+        logger: logging.Logger | None = None,
+    ) -> Self:
+        return cls._create(
+            private_key=private_key,
+            wallet=wallet,
+            environment=environment,
+            credentials=credentials,
+            api_key=api_key,
+            nonce=nonce,
+            validate_credentials=validate_credentials,
+            logger=logger,
+        )
+
+    @classmethod
+    def _create(
+        cls,
+        *,
+        private_key: str,
+        wallet: str | None = None,
+        environment: Environment = PRODUCTION,
+        credentials: ApiKeyCreds | None = None,
+        api_key: ApiKey | None = None,
+        nonce: int = 0,
+        validate_credentials: bool,
+        logger: logging.Logger | None = None,
+    ) -> Self:
         if not private_key:
             raise UserInputError("private_key is required")
         _validate_nonce(nonce)

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -258,30 +258,6 @@ class SecureClient:
         )
 
     @classmethod
-    def _create_for_testing(
-        cls,
-        *,
-        private_key: str,
-        wallet: str | None = None,
-        environment: Environment = PRODUCTION,
-        credentials: ApiKeyCreds | None = None,
-        api_key: ApiKey | None = None,
-        nonce: int = 0,
-        validate_credentials: bool = True,
-        logger: logging.Logger | None = None,
-    ) -> Self:
-        return cls._create(
-            private_key=private_key,
-            wallet=wallet,
-            environment=environment,
-            credentials=credentials,
-            api_key=api_key,
-            nonce=nonce,
-            validate_credentials=validate_credentials,
-            logger=logger,
-        )
-
-    @classmethod
     def _create(
         cls,
         *,
@@ -291,7 +267,7 @@ class SecureClient:
         credentials: ApiKeyCreds | None = None,
         api_key: ApiKey | None = None,
         nonce: int = 0,
-        validate_credentials: bool,
+        validate_credentials: bool = True,
         logger: logging.Logger | None = None,
     ) -> Self:
         if not private_key:

--- a/tests/integration/test_clob_reads.py
+++ b/tests/integration/test_clob_reads.py
@@ -41,7 +41,7 @@ def test_async_secure_get_midpoint_returns_decimal_in_unit_range(
     active_clob_token: TokenId,
 ) -> None:
     async def run() -> Decimal:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/integration/test_clob_reads.py
+++ b/tests/integration/test_clob_reads.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 import asyncio
 from decimal import Decimal
 
@@ -40,7 +41,7 @@ def test_async_secure_get_midpoint_returns_decimal_in_unit_range(
     active_clob_token: TokenId,
 ) -> None:
     async def run() -> Decimal:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -31,7 +31,7 @@ async def make_deposit_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -48,7 +48,7 @@ async def make_proxy_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_PROXY_WALLET)
     wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -61,7 +61,7 @@ async def make_eoa_client(*, with_api_key: bool = True) -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -80,7 +80,7 @@ async def make_eoa_client_with_rpc(
 
     env = dataclasses.replace(PRODUCTION, rpc_url="https://rpc.test")
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    client = await AsyncSecureClient.create(
+    client = await AsyncSecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -153,7 +153,7 @@ async def make_safe_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_SAFE_WALLET)
     wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -226,7 +226,7 @@ def make_sync_eoa_client(*, with_api_key: bool = True) -> SecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -243,7 +243,7 @@ def make_sync_deposit_client() -> SecureClient:
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -260,7 +260,7 @@ def make_sync_proxy_client() -> SecureClient:
 
     signer = Account.from_key(PK_PROXY_WALLET)
     wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -277,7 +277,7 @@ def make_sync_safe_client() -> SecureClient:
 
     signer = Account.from_key(PK_SAFE_WALLET)
     wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -31,7 +31,7 @@ async def make_deposit_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -48,7 +48,7 @@ async def make_proxy_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_PROXY_WALLET)
     wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -61,7 +61,7 @@ async def make_eoa_client(*, with_api_key: bool = True) -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -80,7 +80,7 @@ async def make_eoa_client_with_rpc(
 
     env = dataclasses.replace(PRODUCTION, rpc_url="https://rpc.test")
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    client = await AsyncSecureClient._create_for_testing(
+    client = await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -153,7 +153,7 @@ async def make_safe_client() -> AsyncSecureClient:
 
     signer = Account.from_key(PK_SAFE_WALLET)
     wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -226,7 +226,7 @@ def make_sync_eoa_client(*, with_api_key: bool = True) -> SecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,
@@ -243,7 +243,7 @@ def make_sync_deposit_client() -> SecureClient:
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -260,7 +260,7 @@ def make_sync_proxy_client() -> SecureClient:
 
     signer = Account.from_key(PK_PROXY_WALLET)
     wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,
@@ -277,7 +277,7 @@ def make_sync_safe_client() -> SecureClient:
 
     signer = Account.from_key(PK_SAFE_WALLET)
     wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -96,7 +96,7 @@ def _assert_l2_headers(request: httpx.Request) -> None:
 
 def _make_client() -> AsyncSecureClient:
     return asyncio.run(
-        AsyncSecureClient._create_for_testing(
+        AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -109,7 +109,7 @@ def test_get_closed_only_mode_returns_bool_and_uses_l2_headers() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> bool:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -147,7 +147,7 @@ def test_list_open_orders_paginates_until_end_cursor() -> None:
         return httpx.Response(200, json=next(responses), request=request)
 
     async def run() -> list[str]:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -177,7 +177,7 @@ def test_get_order_targets_data_order_path() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> str:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -209,7 +209,7 @@ def test_list_account_trades_paginates_and_passes_filters() -> None:
         return httpx.Response(200, json=next(responses), request=request)
 
     async def run() -> list[str]:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -239,7 +239,7 @@ def test_get_notifications_includes_signature_type_for_eoa_wallet() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -263,7 +263,7 @@ def test_drop_notifications_uses_delete_with_comma_separated_ids() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -286,7 +286,7 @@ def test_drop_notifications_uses_delete_with_comma_separated_ids() -> None:
 
 def test_drop_notifications_rejects_empty_id_list() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -305,7 +305,7 @@ def test_get_balance_allowance_for_collateral_omits_token_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> int:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -334,7 +334,7 @@ def test_get_balance_allowance_for_conditional_includes_token_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -366,7 +366,7 @@ def test_secure_client_classifies_eoa_when_wallet_equals_signer() -> None:
 
 def test_secure_client_normalizes_wallet_to_checksum() -> None:
     async def run() -> str:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS.lower(),
             credentials=FAKE_CREDS,
@@ -382,7 +382,7 @@ def test_secure_client_normalizes_wallet_to_checksum() -> None:
 
 def test_secure_client_rejects_invalid_wallet_address() -> None:
     async def run() -> None:
-        await AsyncSecureClient._create_for_testing(
+        await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet="not-an-address",
             credentials=FAKE_CREDS,
@@ -400,7 +400,7 @@ def test_secure_client_defaults_wallet_to_signer_address() -> None:
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
     async def run() -> str:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             credentials=FAKE_CREDS,
             validate_credentials=False,
@@ -416,7 +416,7 @@ def test_secure_client_defaults_wallet_to_signer_address() -> None:
 
 def test_secure_client_rejects_unrelated_wallet_address() -> None:
     async def run() -> None:
-        await AsyncSecureClient._create_for_testing(
+        await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet="0x0000000000000000000000000000000000000002",
             credentials=FAKE_CREDS,

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -96,7 +96,7 @@ def _assert_l2_headers(request: httpx.Request) -> None:
 
 def _make_client() -> AsyncSecureClient:
     return asyncio.run(
-        AsyncSecureClient.create(
+        AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -109,7 +109,7 @@ def test_get_closed_only_mode_returns_bool_and_uses_l2_headers() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> bool:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -147,7 +147,7 @@ def test_list_open_orders_paginates_until_end_cursor() -> None:
         return httpx.Response(200, json=next(responses), request=request)
 
     async def run() -> list[str]:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -177,7 +177,7 @@ def test_get_order_targets_data_order_path() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> str:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -209,7 +209,7 @@ def test_list_account_trades_paginates_and_passes_filters() -> None:
         return httpx.Response(200, json=next(responses), request=request)
 
     async def run() -> list[str]:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -239,7 +239,7 @@ def test_get_notifications_includes_signature_type_for_eoa_wallet() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -263,7 +263,7 @@ def test_drop_notifications_uses_delete_with_comma_separated_ids() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -286,7 +286,7 @@ def test_drop_notifications_uses_delete_with_comma_separated_ids() -> None:
 
 def test_drop_notifications_rejects_empty_id_list() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -305,7 +305,7 @@ def test_get_balance_allowance_for_collateral_omits_token_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> int:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -334,7 +334,7 @@ def test_get_balance_allowance_for_conditional_includes_token_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -366,7 +366,7 @@ def test_secure_client_classifies_eoa_when_wallet_equals_signer() -> None:
 
 def test_secure_client_normalizes_wallet_to_checksum() -> None:
     async def run() -> str:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS.lower(),
             credentials=FAKE_CREDS,
@@ -382,7 +382,7 @@ def test_secure_client_normalizes_wallet_to_checksum() -> None:
 
 def test_secure_client_rejects_invalid_wallet_address() -> None:
     async def run() -> None:
-        await AsyncSecureClient.create(
+        await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet="not-an-address",
             credentials=FAKE_CREDS,
@@ -400,7 +400,7 @@ def test_secure_client_defaults_wallet_to_signer_address() -> None:
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
     async def run() -> str:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             credentials=FAKE_CREDS,
             validate_credentials=False,
@@ -416,7 +416,7 @@ def test_secure_client_defaults_wallet_to_signer_address() -> None:
 
 def test_secure_client_rejects_unrelated_wallet_address() -> None:
     async def run() -> None:
-        await AsyncSecureClient.create(
+        await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet="0x0000000000000000000000000000000000000002",
             credentials=FAKE_CREDS,

--- a/tests/unit/test_auth_transport.py
+++ b/tests/unit/test_auth_transport.py
@@ -126,7 +126,7 @@ def test_async_secure_create_falls_back_to_derive_on_400() -> None:
 
 def test_async_secure_create_with_credentials_skips_auth_flow() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -144,7 +144,7 @@ def test_fetch_api_keys_sends_l2_headers() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> tuple[str, ...]:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -173,7 +173,7 @@ def test_delete_api_key_succeeds_on_ok_response() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -193,7 +193,7 @@ def test_delete_api_key_succeeds_on_ok_response() -> None:
 
 def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -211,7 +211,7 @@ def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
 
 def test_fetch_api_keys_propagates_401_as_request_rejected() -> None:
     async def run() -> tuple[str, ...]:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -232,7 +232,7 @@ def test_async_secure_create_rejects_credentials_with_nonzero_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient.create(
+        await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, credentials=FAKE_CREDS, nonce=1
         )
 
@@ -244,7 +244,11 @@ def test_async_secure_create_rejects_negative_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient.create(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
+        await AsyncSecureClient._create_for_testing(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            nonce=-1,
+        )
 
     with pytest.raises(UserInputError, match="non-negative integer"):
         asyncio.run(run())
@@ -254,7 +258,11 @@ def test_async_secure_create_rejects_bool_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient.create(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=True)  # type: ignore[arg-type]
+        await AsyncSecureClient._create_for_testing(
+            private_key=PRIVATE_KEY,
+            wallet=SIGNER_ADDRESS,
+            nonce=True,  # type: ignore[arg-type]
+        )
 
     with pytest.raises(UserInputError, match="non-negative integer"):
         asyncio.run(run())
@@ -298,7 +306,7 @@ def test_l2_signature_includes_canonical_body_for_authenticated_post() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_auth_transport.py
+++ b/tests/unit/test_auth_transport.py
@@ -126,7 +126,7 @@ def test_async_secure_create_falls_back_to_derive_on_400() -> None:
 
 def test_async_secure_create_with_credentials_skips_auth_flow() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -144,7 +144,7 @@ def test_fetch_api_keys_sends_l2_headers() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> tuple[str, ...]:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -173,7 +173,7 @@ def test_delete_api_key_succeeds_on_ok_response() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -193,7 +193,7 @@ def test_delete_api_key_succeeds_on_ok_response() -> None:
 
 def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -211,7 +211,7 @@ def test_delete_api_key_raises_unexpected_response_on_non_ok_payload() -> None:
 
 def test_fetch_api_keys_propagates_401_as_request_rejected() -> None:
     async def run() -> tuple[str, ...]:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -232,7 +232,7 @@ def test_async_secure_create_rejects_credentials_with_nonzero_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient._create_for_testing(
+        await AsyncSecureClient._create(
             private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, credentials=FAKE_CREDS, nonce=1
         )
 
@@ -244,7 +244,7 @@ def test_async_secure_create_rejects_negative_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient._create_for_testing(
+        await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             nonce=-1,
@@ -258,7 +258,7 @@ def test_async_secure_create_rejects_bool_nonce() -> None:
     from polymarket.errors import UserInputError
 
     async def run() -> None:
-        await AsyncSecureClient._create_for_testing(
+        await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             nonce=True,  # type: ignore[arg-type]
@@ -306,7 +306,7 @@ def test_l2_signature_includes_canonical_body_for_authenticated_post() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_builder_attribution.py
+++ b/tests/unit/test_builder_attribution.py
@@ -190,7 +190,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=_PRIVATE_KEY,
         wallet=_SIGNER_ADDRESS,
         credentials=_FAKE_CREDS,

--- a/tests/unit/test_builder_attribution.py
+++ b/tests/unit/test_builder_attribution.py
@@ -190,7 +190,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=_PRIVATE_KEY,
         wallet=_SIGNER_ADDRESS,
         credentials=_FAKE_CREDS,

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -342,7 +342,7 @@ class TestAsyncSecureClientListBuilderTrades:
             )
 
         async def run() -> BuilderTrade:
-            client = await AsyncSecureClient._create_for_testing(
+            client = await AsyncSecureClient._create(
                 private_key=_PRIVATE_KEY,
                 wallet=_SIGNER,
                 credentials=_FAKE_CREDS,

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -342,7 +342,7 @@ class TestAsyncSecureClientListBuilderTrades:
             )
 
         async def run() -> BuilderTrade:
-            client = await AsyncSecureClient.create(
+            client = await AsyncSecureClient._create_for_testing(
                 private_key=_PRIVATE_KEY,
                 wallet=_SIGNER,
                 credentials=_FAKE_CREDS,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,4 +1,6 @@
+# pyright: reportPrivateUsage=false
 import asyncio
+import inspect
 from typing import cast
 
 import pytest
@@ -45,7 +47,7 @@ def test_async_public_client_supports_context_manager() -> None:
 
 
 def test_secure_client_factory_uses_production_by_default() -> None:
-    client = SecureClient.create(
+    client = SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -57,6 +59,11 @@ def test_secure_client_factory_uses_production_by_default() -> None:
         client.close()
 
 
+def test_secure_client_factory_signature_hides_test_validation_switch() -> None:
+    assert "validate_credentials" not in inspect.signature(SecureClient.create).parameters
+    assert "validate_credentials" not in inspect.signature(AsyncSecureClient.create).parameters
+
+
 def test_secure_client_requires_factory() -> None:
     from polymarket._internal.context import SyncSecureClientContext
 
@@ -65,7 +72,7 @@ def test_secure_client_requires_factory() -> None:
 
 
 def test_secure_client_supports_context_manager() -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -76,7 +83,7 @@ def test_secure_client_supports_context_manager() -> None:
 
 def test_async_secure_client_factory_uses_production_by_default() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -97,7 +104,7 @@ def test_async_secure_client_requires_factory() -> None:
 
 def test_async_secure_client_supports_context_manager() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -110,7 +117,7 @@ def test_async_secure_client_supports_context_manager() -> None:
 
 
 def test_secure_client_exposes_signer_wallet() -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -121,7 +128,7 @@ def test_secure_client_exposes_signer_wallet() -> None:
 
 def test_async_secure_client_exposes_signer_wallet() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -146,7 +153,7 @@ def test_secure_client_wallet_defaults_to_signer_when_omitted() -> None:
 
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         credentials=FAKE_CREDS,
         validate_credentials=False,
@@ -170,7 +177,7 @@ def test_async_secure_client_wallet_defaults_to_signer_when_omitted() -> None:
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
     async def run() -> str:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             validate_credentials=False,
         )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -47,7 +47,7 @@ def test_async_public_client_supports_context_manager() -> None:
 
 
 def test_secure_client_factory_uses_production_by_default() -> None:
-    client = SecureClient._create_for_testing(
+    client = SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -72,7 +72,7 @@ def test_secure_client_requires_factory() -> None:
 
 
 def test_secure_client_supports_context_manager() -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -83,7 +83,7 @@ def test_secure_client_supports_context_manager() -> None:
 
 def test_async_secure_client_factory_uses_production_by_default() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -104,7 +104,7 @@ def test_async_secure_client_requires_factory() -> None:
 
 def test_async_secure_client_supports_context_manager() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -117,7 +117,7 @@ def test_async_secure_client_supports_context_manager() -> None:
 
 
 def test_secure_client_exposes_signer_wallet() -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -128,7 +128,7 @@ def test_secure_client_exposes_signer_wallet() -> None:
 
 def test_async_secure_client_exposes_signer_wallet() -> None:
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -153,7 +153,7 @@ def test_secure_client_wallet_defaults_to_signer_when_omitted() -> None:
 
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         credentials=FAKE_CREDS,
         validate_credentials=False,
@@ -177,7 +177,7 @@ def test_async_secure_client_wallet_defaults_to_signer_when_omitted() -> None:
     expected = to_checksum_address(Account.from_key(PRIVATE_KEY).address)
 
     async def run() -> str:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             validate_credentials=False,
         )

--- a/tests/unit/test_client_request_params.py
+++ b/tests/unit/test_client_request_params.py
@@ -116,7 +116,7 @@ def test_async_public_list_trades_passes_event_id() -> None:
 
 def test_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -134,7 +134,7 @@ def test_async_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -178,7 +178,7 @@ def test_async_public_list_activity_passes_event_id() -> None:
 
 def test_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -196,7 +196,7 @@ def test_async_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -228,7 +228,7 @@ def test_public_list_positions_passes_event_id() -> None:
 
 def test_secure_list_positions_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -259,7 +259,7 @@ def test_secure_list_trades_rejects_market_and_event_id_together() -> None:
     from polymarket.errors import UserInputError
 
     with (
-        SecureClient._create_for_testing(
+        SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_client_request_params.py
+++ b/tests/unit/test_client_request_params.py
@@ -116,7 +116,7 @@ def test_async_public_list_trades_passes_event_id() -> None:
 
 def test_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -134,7 +134,7 @@ def test_async_secure_list_trades_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -178,7 +178,7 @@ def test_async_public_list_activity_passes_event_id() -> None:
 
 def test_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -196,7 +196,7 @@ def test_async_secure_list_activity_passes_event_id() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -228,7 +228,7 @@ def test_public_list_positions_passes_event_id() -> None:
 
 def test_secure_list_positions_passes_event_id() -> None:
     captured: list[httpx.Request] = []
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -259,7 +259,7 @@ def test_secure_list_trades_rejects_market_and_event_id_together() -> None:
     from polymarket.errors import UserInputError
 
     with (
-        SecureClient.create(
+        SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -73,7 +73,7 @@ def test_async_secure_get_midpoint_uses_same_clob_endpoint() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> Decimal:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -73,7 +73,7 @@ def test_async_secure_get_midpoint_uses_same_clob_endpoint() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> Decimal:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -61,7 +61,7 @@ def _body(request: httpx.Request) -> object:
 
 
 def _secure_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -61,7 +61,7 @@ def _body(request: httpx.Request) -> object:
 
 
 def _secure_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_end_authentication.py
+++ b/tests/unit/test_end_authentication.py
@@ -35,7 +35,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _build_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_end_authentication.py
+++ b/tests/unit/test_end_authentication.py
@@ -35,7 +35,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _build_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_market_order_overloads.py
+++ b/tests/unit/test_market_order_overloads.py
@@ -19,7 +19,7 @@ _FAKE_CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
 
 def _make_client() -> AsyncSecureClient:
     return asyncio.run(
-        AsyncSecureClient.create(
+        AsyncSecureClient._create_for_testing(
             private_key=_PRIVATE_KEY,
             wallet=_SIGNER,
             credentials=_FAKE_CREDS,

--- a/tests/unit/test_market_order_overloads.py
+++ b/tests/unit/test_market_order_overloads.py
@@ -19,7 +19,7 @@ _FAKE_CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
 
 def _make_client() -> AsyncSecureClient:
     return asyncio.run(
-        AsyncSecureClient._create_for_testing(
+        AsyncSecureClient._create(
             private_key=_PRIVATE_KEY,
             wallet=_SIGNER,
             credentials=_FAKE_CREDS,

--- a/tests/unit/test_order_allowance.py
+++ b/tests/unit/test_order_allowance.py
@@ -32,7 +32,7 @@ def _install_secure_clob(client: AsyncSecureClient, payload: dict[str, Any]) -> 
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_allowance.py
+++ b/tests/unit/test_order_allowance.py
@@ -32,7 +32,7 @@ def _install_secure_clob(client: AsyncSecureClient, payload: dict[str, Any]) -> 
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_client.py
+++ b/tests/unit/test_order_client.py
@@ -104,7 +104,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_client.py
+++ b/tests/unit/test_order_client.py
@@ -104,7 +104,7 @@ def _install_secure_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_estimate.py
+++ b/tests/unit/test_order_estimate.py
@@ -49,7 +49,7 @@ def _install_public_clob(
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_estimate.py
+++ b/tests/unit/test_order_estimate.py
@@ -49,7 +49,7 @@ def _install_public_clob(
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -43,7 +43,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -43,7 +43,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_market.py
+++ b/tests/unit/test_order_market.py
@@ -57,7 +57,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_market.py
+++ b/tests/unit/test_order_market.py
@@ -57,7 +57,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_market_data.py
+++ b/tests/unit/test_order_market_data.py
@@ -41,7 +41,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_order_market_data.py
+++ b/tests/unit/test_order_market_data.py
@@ -41,7 +41,7 @@ def _install_public_clob(client: AsyncSecureClient, handler: httpx.MockTransport
 
 
 async def _make_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -33,7 +33,7 @@ async def _make_deposit_client() -> AsyncSecureClient:
 
     signer = Account.from_key(_PRIVATE_KEY)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=_PRIVATE_KEY,
         wallet=wallet,
         credentials=_CREDS,

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -33,7 +33,7 @@ async def _make_deposit_client() -> AsyncSecureClient:
 
     signer = Account.from_key(_PRIVATE_KEY)
     wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=_PRIVATE_KEY,
         wallet=wallet,
         credentials=_CREDS,

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -35,7 +35,7 @@ def test_approve_erc20_rejects_when_no_api_key() -> None:
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
             credentials=FAKE_CREDS,
@@ -425,7 +425,7 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -35,7 +35,7 @@ def test_approve_erc20_rejects_when_no_api_key() -> None:
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
             credentials=FAKE_CREDS,
@@ -425,7 +425,7 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_relayer_is_gasless_ready.py
+++ b/tests/unit/test_relayer_is_gasless_ready.py
@@ -27,7 +27,7 @@ async def _make_eoa_secure_client() -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_relayer_is_gasless_ready.py
+++ b/tests/unit/test_relayer_is_gasless_ready.py
@@ -27,7 +27,7 @@ async def _make_eoa_secure_client() -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=signer.address,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_rewards_transport.py
+++ b/tests/unit/test_rewards_transport.py
@@ -65,7 +65,7 @@ def _install_secure_public_clob(client: AsyncSecureClient, handler: httpx.MockTr
 
 
 async def _make_secure_client() -> AsyncSecureClient:
-    return await AsyncSecureClient.create(
+    return await AsyncSecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_rewards_transport.py
+++ b/tests/unit/test_rewards_transport.py
@@ -65,7 +65,7 @@ def _install_secure_public_clob(client: AsyncSecureClient, handler: httpx.MockTr
 
 
 async def _make_secure_client() -> AsyncSecureClient:
-    return await AsyncSecureClient._create_for_testing(
+    return await AsyncSecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_rewards_transport_sync.py
+++ b/tests/unit/test_rewards_transport_sync.py
@@ -106,7 +106,7 @@ class TestListCurrentRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient.create(
+        with SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -143,7 +143,7 @@ class TestListMarketRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient.create(
+        with SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_rewards_transport_sync.py
+++ b/tests/unit/test_rewards_transport_sync.py
@@ -106,7 +106,7 @@ class TestListCurrentRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient._create_for_testing(
+        with SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -143,7 +143,7 @@ class TestListMarketRewards:
 
     def test_secure_uses_unsigned_clob_not_secure_clob(self) -> None:
         captured: list[httpx.Request] = []
-        with SecureClient._create_for_testing(
+        with SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_account_sync.py
+++ b/tests/unit/test_secure_account_sync.py
@@ -94,7 +94,7 @@ def _assert_l2_headers(request: httpx.Request) -> None:
 
 
 def _make_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_account_sync.py
+++ b/tests/unit/test_secure_account_sync.py
@@ -94,7 +94,7 @@ def _assert_l2_headers(request: httpx.Request) -> None:
 
 
 def _make_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_api_keys_sync.py
+++ b/tests/unit/test_secure_api_keys_sync.py
@@ -34,7 +34,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_api_keys_sync.py
+++ b/tests/unit/test_secure_api_keys_sync.py
@@ -34,7 +34,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -26,7 +26,7 @@ def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.
 
 
 def _make_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -107,7 +107,7 @@ def test_create_or_derive_api_key_sync_falls_back_to_derive_on_400() -> None:
 
 
 def test_create_with_credentials_skips_auth_flow_when_validation_disabled() -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -147,7 +147,7 @@ def test_create_validates_credentials_via_fetch_api_keys_when_enabled() -> None:
 
 def test_create_rejects_credentials_with_nonzero_nonce() -> None:
     with pytest.raises(UserInputError, match="nonce cannot be combined"):
-        SecureClient.create(
+        SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -157,12 +157,12 @@ def test_create_rejects_credentials_with_nonzero_nonce() -> None:
 
 def test_create_rejects_negative_nonce() -> None:
     with pytest.raises(UserInputError, match="non-negative integer"):
-        SecureClient.create(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
+        SecureClient._create_for_testing(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
 
 
 def test_create_rejects_bool_nonce() -> None:
     with pytest.raises(UserInputError, match="non-negative integer"):
-        SecureClient.create(
+        SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             nonce=cast(int, True),
@@ -170,7 +170,7 @@ def test_create_rejects_bool_nonce() -> None:
 
 
 def test_create_defaults_wallet_to_signer_when_omitted() -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         credentials=FAKE_CREDS,
         validate_credentials=False,
@@ -181,7 +181,7 @@ def test_create_defaults_wallet_to_signer_when_omitted() -> None:
 
 def test_create_rejects_invalid_wallet_address() -> None:
     with pytest.raises(UserInputError, match="Invalid wallet address"):
-        SecureClient.create(
+        SecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet="not-an-address",
             credentials=FAKE_CREDS,
@@ -196,7 +196,7 @@ def test_create_classifies_eoa_when_wallet_equals_signer() -> None:
 
 
 def test_create_normalizes_wallet_to_checksum() -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS.lower(),
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -26,7 +26,7 @@ def _capture(captured: list[httpx.Request], status: int, payload: Any) -> httpx.
 
 
 def _make_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -107,7 +107,7 @@ def test_create_or_derive_api_key_sync_falls_back_to_derive_on_400() -> None:
 
 
 def test_create_with_credentials_skips_auth_flow_when_validation_disabled() -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -147,7 +147,7 @@ def test_create_validates_credentials_via_fetch_api_keys_when_enabled() -> None:
 
 def test_create_rejects_credentials_with_nonzero_nonce() -> None:
     with pytest.raises(UserInputError, match="nonce cannot be combined"):
-        SecureClient._create_for_testing(
+        SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -157,12 +157,12 @@ def test_create_rejects_credentials_with_nonzero_nonce() -> None:
 
 def test_create_rejects_negative_nonce() -> None:
     with pytest.raises(UserInputError, match="non-negative integer"):
-        SecureClient._create_for_testing(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
+        SecureClient._create(private_key=PRIVATE_KEY, wallet=SIGNER_ADDRESS, nonce=-1)
 
 
 def test_create_rejects_bool_nonce() -> None:
     with pytest.raises(UserInputError, match="non-negative integer"):
-        SecureClient._create_for_testing(
+        SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             nonce=cast(int, True),
@@ -170,7 +170,7 @@ def test_create_rejects_bool_nonce() -> None:
 
 
 def test_create_defaults_wallet_to_signer_when_omitted() -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         credentials=FAKE_CREDS,
         validate_credentials=False,
@@ -181,7 +181,7 @@ def test_create_defaults_wallet_to_signer_when_omitted() -> None:
 
 def test_create_rejects_invalid_wallet_address() -> None:
     with pytest.raises(UserInputError, match="Invalid wallet address"):
-        SecureClient._create_for_testing(
+        SecureClient._create(
             private_key=PRIVATE_KEY,
             wallet="not-an-address",
             credentials=FAKE_CREDS,
@@ -196,7 +196,7 @@ def test_create_classifies_eoa_when_wallet_equals_signer() -> None:
 
 
 def test_create_normalizes_wallet_to_checksum() -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS.lower(),
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_orders_sync.py
+++ b/tests/unit/test_secure_orders_sync.py
@@ -98,7 +98,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_orders_sync.py
+++ b/tests/unit/test_secure_orders_sync.py
@@ -98,7 +98,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_rewards_sync.py
+++ b/tests/unit/test_secure_rewards_sync.py
@@ -32,7 +32,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient._create_for_testing(
+    return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_rewards_sync.py
+++ b/tests/unit/test_secure_rewards_sync.py
@@ -32,7 +32,7 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
 
 
 def _make_client() -> SecureClient:
-    return SecureClient.create(
+    return SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -53,7 +53,7 @@ def _captured() -> list[httpx.Request]:
 
 
 def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -68,7 +68,7 @@ def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Req
 def test_secure_get_portfolio_values_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -86,7 +86,7 @@ def test_secure_get_portfolio_values_respects_explicit_user(
 def test_secure_get_traded_market_count_defaults_to_signer(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -103,7 +103,7 @@ def test_secure_get_traded_market_count_defaults_to_signer(
 def test_secure_get_traded_market_count_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -127,7 +127,7 @@ def test_secure_download_accounting_snapshot_defaults_to_signer(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -146,7 +146,7 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -162,7 +162,7 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
 
 
 def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -175,7 +175,7 @@ def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request])
 
 
 def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -191,7 +191,7 @@ def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Reque
 
 
 def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -207,7 +207,7 @@ def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Re
 
 
 def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -223,7 +223,7 @@ def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) ->
 
 
 def test_secure_list_activity_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -242,7 +242,7 @@ def test_async_secure_list_positions_defaults_to_signer() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -262,7 +262,7 @@ def test_async_secure_list_positions_respects_explicit_user() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -286,7 +286,7 @@ def test_async_secure_list_positions_defaults_to_wallet_when_proxy() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=proxy_wallet,
             credentials=FAKE_CREDS,
@@ -311,7 +311,7 @@ def test_async_secure_download_accounting_snapshot_defaults_to_signer() -> None:
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
     async def run() -> None:
-        client = await AsyncSecureClient.create(
+        client = await AsyncSecureClient._create_for_testing(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -335,7 +335,7 @@ def test_secure_list_positions_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -351,7 +351,7 @@ def test_secure_get_portfolio_values_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient.create(
+    with SecureClient._create_for_testing(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -53,7 +53,7 @@ def _captured() -> list[httpx.Request]:
 
 
 def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -68,7 +68,7 @@ def test_secure_get_portfolio_values_defaults_to_signer(captured: list[httpx.Req
 def test_secure_get_portfolio_values_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -86,7 +86,7 @@ def test_secure_get_portfolio_values_respects_explicit_user(
 def test_secure_get_traded_market_count_defaults_to_signer(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -103,7 +103,7 @@ def test_secure_get_traded_market_count_defaults_to_signer(
 def test_secure_get_traded_market_count_respects_explicit_user(
     captured: list[httpx.Request],
 ) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -127,7 +127,7 @@ def test_secure_download_accounting_snapshot_defaults_to_signer(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -146,7 +146,7 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
         captured.append(request)
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -162,7 +162,7 @@ def test_secure_download_accounting_snapshot_respects_explicit_user(
 
 
 def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -175,7 +175,7 @@ def test_secure_list_positions_defaults_to_signer(captured: list[httpx.Request])
 
 
 def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -191,7 +191,7 @@ def test_secure_list_positions_respects_explicit_user(captured: list[httpx.Reque
 
 
 def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -207,7 +207,7 @@ def test_secure_list_closed_positions_defaults_to_signer(captured: list[httpx.Re
 
 
 def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -223,7 +223,7 @@ def test_secure_list_trades_defaults_to_signer(captured: list[httpx.Request]) ->
 
 
 def test_secure_list_activity_defaults_to_signer(captured: list[httpx.Request]) -> None:
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -242,7 +242,7 @@ def test_async_secure_list_positions_defaults_to_signer() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -262,7 +262,7 @@ def test_async_secure_list_positions_respects_explicit_user() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -286,7 +286,7 @@ def test_async_secure_list_positions_defaults_to_wallet_when_proxy() -> None:
     captured: list[httpx.Request] = []
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=proxy_wallet,
             credentials=FAKE_CREDS,
@@ -311,7 +311,7 @@ def test_async_secure_download_accounting_snapshot_defaults_to_signer() -> None:
         return httpx.Response(200, content=b"PK\x03\x04", request=request)
 
     async def run() -> None:
-        client = await AsyncSecureClient._create_for_testing(
+        client = await AsyncSecureClient._create(
             private_key=PRIVATE_KEY,
             wallet=SIGNER_ADDRESS,
             credentials=FAKE_CREDS,
@@ -335,7 +335,7 @@ def test_secure_list_positions_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
@@ -351,7 +351,7 @@ def test_secure_get_portfolio_values_rejects_explicit_empty_user(
 ) -> None:
     from polymarket.errors import UserInputError
 
-    with SecureClient._create_for_testing(
+    with SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,


### PR DESCRIPTION
Linear: DEV-123

Summary:
- Remove validate_credentials from public secure client factory signatures.
- Keep the validation bypass on the private create helper used by tests.
- Update tests to use the private path.

Verification:
- uv run pytest tests/unit
- uv run pyright
- uv run ruff check .
- uv run ruff format --check .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public construction still validates credentials by default; only the documented factory surface and test call sites change.
> 
> **Overview**
> Removes **`validate_credentials`** from the public **`SecureClient.create`** and **`AsyncSecureClient.create`** signatures so callers can no longer skip API credential checks at construction time. The real factory logic moves to private **`_create`**, which still supports **`validate_credentials`**; public **`create`** always delegates with validation enabled (**`True`**).
> 
> Unit and integration tests that need fake credentials without a live auth probe now call **`_create(..., validate_credentials=False)`** instead of the public factory. A new test asserts **`validate_credentials`** is absent from the public **`create`** signatures via **`inspect.signature`**.
> 
> **Default behavior for SDK users is unchanged:** provided credentials are still validated unless tests use the private path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a2228dfa9f7f041b937ca0aea9d84d3518525d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->