### PR TITLE
release: revert manual beta version canonicalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "polymarket-client"
-version = "0.1.0b2"
+version = "0.1.0-b2"
 description = "Official Python client for Polymarket"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/polymarket/version.py
+++ b/src/polymarket/version.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("polymarket-client")
 except PackageNotFoundError:
-    __version__ = "0.1.0b2"
+    __version__ = "0.1.0-b2"

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-client"
-version = "0.1.0b1"
+version = "0.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "eth-abi" },

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-client"
-version = "0.1.0b2"
+version = "0.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "eth-abi" },


### PR DESCRIPTION
## Summary
- Reverts the manual PR #34 source-version canonicalization so Python source files match Release Please's generated beta form.
- Keeps `uv.lock` at the normalized `0.1.0b2` package version so locked installs and CI remain valid.

## Verification
- `uv sync --locked --all-extras --all-groups`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv build`

## Release note
Merging this PR may cause Release Please to retry the pending `0.1.0-b2` GitHub release, but publishing still depends on repository tag rules allowing the workflow to create/use `polymarket-client-v0.1.0-b2`.