### PR TITLE
docs: clarify market stream and orderbook fields

### DIFF
--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -21,7 +21,9 @@ class OrderBook(BaseModel):
     token_id: TokenId = Field(validation_alias="asset_id")
     timestamp: datetime | None = None
     bids: tuple[OrderBookLevel, ...]
+    """Bid levels in ascending price order, lowest bid first."""
     asks: tuple[OrderBookLevel, ...]
+    """Ask levels in descending price order, highest ask first."""
     min_order_size: _DecimalFromString
     tick_size: _DecimalFromString
     neg_risk: bool

--- a/src/polymarket/streams/_specs.py
+++ b/src/polymarket/streams/_specs.py
@@ -25,10 +25,16 @@ EquityPricesEventType = Literal["update", "subscribe"]
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class MarketSpec:
-    """Subscribe to realtime market updates for one or more token ids."""
+    """Subscribe to realtime market updates for one or more token ids.
+
+    Set ``custom_feature_enabled=True`` to additionally receive
+    ``MarketBestBidAskEvent``, ``NewMarketEvent``, and ``MarketResolvedEvent``.
+    """
 
     token_ids: Sequence[str]
+    """Token ids whose market events should be delivered."""
     custom_feature_enabled: bool = False
+    """Whether to enable top-of-book and market lifecycle events."""
     topic: Literal["market"] = field(default="market", init=False)
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Summary
- Document OrderBook bids and asks sort order.
- Clarify that MarketSpec custom_feature_enabled enables best bid/ask plus market lifecycle events.

## Verification
- uv run ruff check src/polymarket/models/clob/order_book.py src/polymarket/streams/_specs.py
- uv run pyright src/polymarket/models/clob/order_book.py src/polymarket/streams/_specs.py

Linear: DEV-135
Closes #42
Closes #43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Documentation-only updates so consumers interpret CLOB data and market subscriptions correctly.
> 
> **`OrderBook`** now documents that **`bids`** are sorted ascending (lowest bid first) and **`asks`** descending (highest ask first), which matters when reading top-of-book from full book snapshots.
> 
> **`MarketSpec`** docstrings clarify that **`token_ids`** selects which tokens receive events, and that **`custom_feature_enabled=True`** also enables **`MarketBestBidAskEvent`**, **`NewMarketEvent`**, and **`MarketResolvedEvent`** on top of the default market stream behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5fc337715840e06bda436c3777b10cad0819c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->