### PR TITLE
fix: accept GTD expiration boundary

### DIFF
--- a/src/polymarket/_internal/actions/orders/limit.py
+++ b/src/polymarket/_internal/actions/orders/limit.py
@@ -64,7 +64,7 @@ def validate_limit_order_params(
         if expiration < 0:
             raise UserInputError("expiration must be a non-negative integer.")
         minimum = int(time.time()) + _MIN_EXPIRATION_BUFFER_S
-        if expiration <= minimum:
+        if expiration < minimum:
             raise UserInputError(
                 f"expiration must be at least {_MIN_EXPIRATION_BUFFER_S} seconds in the future."
             )

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1595,6 +1595,10 @@ class AsyncSecureClient:
 
         Use :meth:`post_order` to submit the returned signed order, or
         :meth:`place_limit_order` to create and post in one call.
+
+        When ``expiration`` is provided, it must be a Unix timestamp at least
+        60 seconds in the future. Use extra buffer for immediate submissions to
+        account for latency and clock skew.
         """
         params = validate_limit_order_params(
             token_id=token_id,
@@ -1690,7 +1694,12 @@ class AsyncSecureClient:
         expiration: int | None = None,
         builder_code: str | None = None,
     ) -> OrderResponse:
-        """Create, sign, and post a limit order."""
+        """Create, sign, and post a limit order.
+
+        When ``expiration`` is provided, it must be a Unix timestamp at least
+        60 seconds in the future. Use extra buffer for immediate submissions to
+        account for latency and clock skew.
+        """
         signed = await self.create_limit_order(
             token_id=token_id,
             price=price,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1460,6 +1460,10 @@ class SecureClient:
         Use :meth:`post_order` to submit the returned signed order, or
         :meth:`place_limit_order` to create and post in one call.
 
+        When ``expiration`` is provided, it must be a Unix timestamp at least
+        60 seconds in the future. Use extra buffer for immediate submissions to
+        account for latency and clock skew.
+
         Raises:
             UserInputError: If order parameters are invalid.
             SigningError: If the order cannot be signed.
@@ -1539,6 +1543,10 @@ class SecureClient:
         builder_code: str | None = None,
     ) -> OrderResponse:
         """Create, sign, and post a limit order.
+
+        When ``expiration`` is provided, it must be a Unix timestamp at least
+        60 seconds in the future. Use extra buffer for immediate submissions to
+        account for latency and clock skew.
 
         Raises:
             UserInputError: If order parameters are invalid.

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -164,6 +164,36 @@ def test_validate_limit_order_params_rejects_near_expiration() -> None:
         )
 
 
+def test_validate_limit_order_params_rejects_expiration_below_minimum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000
+    monkeypatch.setattr("polymarket._internal.actions.orders.limit.time.time", lambda: now)
+    with pytest.raises(UserInputError, match="60 seconds"):
+        validate_limit_order_params(
+            token_id="8501497",
+            price="0.5",
+            size="10",
+            side="BUY",
+            expiration=now + 59,
+        )
+
+
+def test_validate_limit_order_params_accepts_minimum_expiration_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000
+    monkeypatch.setattr("polymarket._internal.actions.orders.limit.time.time", lambda: now)
+    params = validate_limit_order_params(
+        token_id="8501497",
+        price="0.5",
+        size="10",
+        side="BUY",
+        expiration=now + 60,
+    )
+    assert params.expiration == now + 60
+
+
 def test_validate_limit_order_params_accepts_far_expiration() -> None:
     params = validate_limit_order_params(
         token_id="8501497",


### PR DESCRIPTION
## Summary
- Align GTD expiration validation with the CLOB boundary by accepting expirations exactly 60 seconds in the future.
- Add deterministic unit coverage for the below-boundary and at-boundary cases.
- Document that immediate submissions should use extra expiration buffer for latency and clock skew.

## Verification
- uv run pytest tests/unit/test_order_limit.py
- uv run ruff check src/polymarket/_internal/actions/orders/limit.py src/polymarket/clients/secure.py src/polymarket/clients/async_secure.py tests/unit/test_order_limit.py
- uv run ruff format --check src/polymarket/_internal/actions/orders/limit.py src/polymarket/clients/secure.py src/polymarket/clients/async_secure.py tests/unit/test_order_limit.py
- uv run pyright src/polymarket/_internal/actions/orders/limit.py src/polymarket/clients/secure.py src/polymarket/clients/async_secure.py tests/unit/test_order_limit.py

Linear: DEV-136
Closes #44

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation boundary fix for limit-order expiration with tests; no auth or payment paths touched.
> 
> **Overview**
> **GTD limit orders** can use an `expiration` exactly **60 seconds** ahead of “now.” Validation in `validate_limit_order_params` no longer rejects that timestamp: the check changes from `expiration <= minimum` to `expiration < minimum`, matching the CLOB’s inclusive minimum.
> 
> **Docs** on sync/async `create_limit_order` and `place_limit_order` now state the 60-second rule and suggest extra buffer for immediate posts (latency/clock skew).
> 
> **Tests** add frozen-clock cases for `now + 59` (reject) and `now + 60` (accept).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c9600c40fe7420a2ed20da993c357db28abf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->