### PR TITLE
docs(readme): align getting-started URL example with parser convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Synchronous client:
 from polymarket import Market, PublicClient
 
 with PublicClient() as client:
-    market: Market = client.get_market(url="https://polymarket.com/event/example-market")
+    market: Market = client.get_market(url="https://polymarket.com/market/example-market")
 ```
 
 Asynchronous client:
@@ -46,7 +46,7 @@ from polymarket import AsyncPublicClient, Market
 async def main() -> None:
     async with AsyncPublicClient() as client:
         market: Market = await client.get_market(
-            url="https://polymarket.com/event/example-market"
+            url="https://polymarket.com/market/example-market"
         )
 
 


### PR DESCRIPTION
Refs #57.

## Summary

The README's getting-started examples pass `url="https://polymarket.com/event/example-market"` to `get_market(url=...)`. With current parser code that throws — `_parse_polymarket_url` in `src/polymarket/_internal/gamma_paths.py:88-97` requires the URL's first path segment to match the entity `kind`, so an `/event/...` URL passed to `get_market` (kind="market") raises:

```
UserInputError: Expected a Polymarket market URL.
```

Both README snippets (sync `with PublicClient()` block and async `AsyncPublicClient` block) hit this on first run.

## Change

Two-line README update to use `polymarket.com/market/<slug>` — what the current parser accepts. No code changes, no test changes.

## Scope note

This only aligns the documented example with the current parser convention. It does **not** address the broader question that the Polymarket website itself only serves `/event/<slug>` URLs (so users pasting from the address bar still hit the same `UserInputError`). That deeper question is tracked separately in #57, where I've laid out a few possible directions (accept event URLs, deprecate `url=` on `get_market`, etc.). Filing this PR as the conservative interim fix that at least makes the README example parse against today's code.

Verified against `src/polymarket/_internal/gamma_paths.py:88-97` (`_parse_polymarket_url`) and the assertion in `tests/unit/test_gamma_paths.py:26-30` (`test_build_market_path_by_url` — expects `polymarket.com/market/some-slug` as the URL form).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or test impact.
> 
> **Overview**
> Updates the **README** getting-started examples so `get_market(url=...)` uses `https://polymarket.com/market/example-market` instead of `/event/...` in both the sync and async snippets.
> 
> That matches `_parse_polymarket_url`, which requires the first path segment to equal the entity kind (`market`), so the old examples would raise `UserInputError` on copy-paste. **No runtime, test, or API changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7e1733244a6b6ec4f2d93fc72cbca2c582b69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->