### PR TITLE
Drop unsupported tag/series request params and response fields

### DIFF
--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -225,14 +225,13 @@ def get_event_tags_spec(id: str) -> RequestSpec[tuple[TagReference, ...]]:
 def get_series_spec(
     id: str,
     *,
-    include_chat: bool | None,
     locale: str | None,
 ) -> RequestSpec[Series]:
     return RequestSpec(
         service="gamma",
         method="GET",
         path=build_series_path(id),
-        params={"include_chat": include_chat, "locale": locale},
+        params={"locale": locale},
         parse=Series.parse_response,
     )
 
@@ -241,20 +240,16 @@ def get_tag_spec(
     *,
     id: str | None,
     slug: str | None,
-    include_chat: bool | None,
     include_template: bool | None,
     locale: str | None,
 ) -> RequestSpec[Tag]:
-    if slug is not None and (include_chat is not None or include_template is not None):
-        raise UserInputError(
-            "include_chat and include_template are only supported for tag id lookup."
-        )
+    if slug is not None and include_template is not None:
+        raise UserInputError("include_template is only supported for tag id lookup.")
     return RequestSpec(
         service="gamma",
         method="GET",
         path=build_tag_path(id=id, slug=slug),
         params={
-            "include_chat": include_chat,
             "include_template": include_template,
             "locale": locale,
         },
@@ -534,11 +529,8 @@ def list_markets_spec(
 def list_series_spec(
     *,
     ascending: bool | None = None,
-    categories_ids: int | Sequence[int] | None = None,
-    categories_labels: str | Sequence[str] | None = None,
     closed: bool | None = None,
     exclude_events: bool | None = None,
-    include_chat: bool | None = None,
     locale: str | None = None,
     order: str | None = None,
     recurrence: Recurrence | None = None,
@@ -548,11 +540,8 @@ def list_series_spec(
 
     params: dict[str, QueryParamValue] = {}
     _add_optional(params, "ascending", ascending)
-    _add_optional_seq(params, "categories_ids", categories_ids)
-    _add_optional_seq(params, "categories_labels", categories_labels)
     _add_optional(params, "closed", closed)
     _add_optional(params, "exclude_events", exclude_events)
-    _add_optional(params, "include_chat", include_chat)
     _add_optional(params, "locale", locale)
     _add_optional(params, "order", order)
     _add_optional(params, "recurrence", recurrence)
@@ -569,7 +558,6 @@ def list_series_spec(
 def list_tags_spec(
     *,
     ascending: bool | None = None,
-    include_chat: bool | None = None,
     include_template: bool | None = None,
     is_carousel: bool | None = None,
     locale: str | None = None,
@@ -577,7 +565,6 @@ def list_tags_spec(
 ) -> OffsetPaginatedSpec[Tag]:
     params: dict[str, QueryParamValue] = {}
     _add_optional(params, "ascending", ascending)
-    _add_optional(params, "include_chat", include_chat)
     _add_optional(params, "include_template", include_template)
     _add_optional(params, "is_carousel", is_carousel)
     _add_optional(params, "locale", locale)

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -343,13 +343,12 @@ class AsyncPublicClient:
         self,
         id: str,
         *,
-        include_chat: bool | None = None,
         locale: str | None = None,
     ) -> Series:
         """Get a series."""
         return await async_dispatch(
             self._ctx,
-            _gamma_actions.get_series_spec(id, include_chat=include_chat, locale=locale),
+            _gamma_actions.get_series_spec(id, locale=locale),
         )
 
     async def get_tag(
@@ -357,7 +356,6 @@ class AsyncPublicClient:
         *,
         id: str | None = None,
         slug: str | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         locale: str | None = None,
     ) -> Tag:
@@ -367,7 +365,6 @@ class AsyncPublicClient:
             _gamma_actions.get_tag_spec(
                 id=id,
                 slug=slug,
-                include_chat=include_chat,
                 include_template=include_template,
                 locale=locale,
             ),
@@ -874,11 +871,8 @@ class AsyncPublicClient:
         self,
         *,
         ascending: bool | None = None,
-        categories_ids: int | Sequence[int] | None = None,
-        categories_labels: str | Sequence[str] | None = None,
         closed: bool | None = None,
         exclude_events: bool | None = None,
-        include_chat: bool | None = None,
         locale: str | None = None,
         order: str | None = None,
         recurrence: Recurrence | None = None,
@@ -892,11 +886,8 @@ class AsyncPublicClient:
         """
         spec = _gamma_actions.list_series_spec(
             ascending=ascending,
-            categories_ids=categories_ids,
-            categories_labels=categories_labels,
             closed=closed,
             exclude_events=exclude_events,
-            include_chat=include_chat,
             locale=locale,
             order=order,
             recurrence=recurrence,
@@ -908,7 +899,6 @@ class AsyncPublicClient:
         self,
         *,
         ascending: bool | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         is_carousel: bool | None = None,
         locale: str | None = None,
@@ -922,7 +912,6 @@ class AsyncPublicClient:
         """
         spec = _gamma_actions.list_tags_spec(
             ascending=ascending,
-            include_chat=include_chat,
             include_template=include_template,
             is_carousel=is_carousel,
             locale=locale,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -652,13 +652,12 @@ class AsyncSecureClient:
         self,
         id: str,
         *,
-        include_chat: bool | None = None,
         locale: str | None = None,
     ) -> Series:
         """Get a series."""
         return await async_dispatch(
             self._ctx,
-            _gamma_actions.get_series_spec(id, include_chat=include_chat, locale=locale),
+            _gamma_actions.get_series_spec(id, locale=locale),
         )
 
     async def get_tag(
@@ -666,7 +665,6 @@ class AsyncSecureClient:
         *,
         id: str | None = None,
         slug: str | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         locale: str | None = None,
     ) -> Tag:
@@ -676,7 +674,6 @@ class AsyncSecureClient:
             _gamma_actions.get_tag_spec(
                 id=id,
                 slug=slug,
-                include_chat=include_chat,
                 include_template=include_template,
                 locale=locale,
             ),
@@ -1177,11 +1174,8 @@ class AsyncSecureClient:
         self,
         *,
         ascending: bool | None = None,
-        categories_ids: int | Sequence[int] | None = None,
-        categories_labels: str | Sequence[str] | None = None,
         closed: bool | None = None,
         exclude_events: bool | None = None,
-        include_chat: bool | None = None,
         locale: str | None = None,
         order: str | None = None,
         recurrence: Recurrence | None = None,
@@ -1195,11 +1189,8 @@ class AsyncSecureClient:
         """
         spec = _gamma_actions.list_series_spec(
             ascending=ascending,
-            categories_ids=categories_ids,
-            categories_labels=categories_labels,
             closed=closed,
             exclude_events=exclude_events,
-            include_chat=include_chat,
             locale=locale,
             order=order,
             recurrence=recurrence,
@@ -1211,7 +1202,6 @@ class AsyncSecureClient:
         self,
         *,
         ascending: bool | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         is_carousel: bool | None = None,
         locale: str | None = None,
@@ -1225,7 +1215,6 @@ class AsyncSecureClient:
         """
         spec = _gamma_actions.list_tags_spec(
             ascending=ascending,
-            include_chat=include_chat,
             include_template=include_template,
             is_carousel=is_carousel,
             locale=locale,

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -188,13 +188,12 @@ class PublicClient:
         self,
         id: str,
         *,
-        include_chat: bool | None = None,
         locale: str | None = None,
     ) -> Series:
         """Get a series."""
         return sync_dispatch(
             self._ctx,
-            _gamma_actions.get_series_spec(id, include_chat=include_chat, locale=locale),
+            _gamma_actions.get_series_spec(id, locale=locale),
         )
 
     def get_tag(
@@ -202,7 +201,6 @@ class PublicClient:
         *,
         id: str | None = None,
         slug: str | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         locale: str | None = None,
     ) -> Tag:
@@ -212,7 +210,6 @@ class PublicClient:
             _gamma_actions.get_tag_spec(
                 id=id,
                 slug=slug,
-                include_chat=include_chat,
                 include_template=include_template,
                 locale=locale,
             ),
@@ -728,11 +725,8 @@ class PublicClient:
         self,
         *,
         ascending: bool | None = None,
-        categories_ids: int | Sequence[int] | None = None,
-        categories_labels: str | Sequence[str] | None = None,
         closed: bool | None = None,
         exclude_events: bool | None = None,
-        include_chat: bool | None = None,
         locale: str | None = None,
         order: str | None = None,
         recurrence: Recurrence | None = None,
@@ -746,11 +740,8 @@ class PublicClient:
         """
         spec = _gamma_actions.list_series_spec(
             ascending=ascending,
-            categories_ids=categories_ids,
-            categories_labels=categories_labels,
             closed=closed,
             exclude_events=exclude_events,
-            include_chat=include_chat,
             locale=locale,
             order=order,
             recurrence=recurrence,
@@ -762,7 +753,6 @@ class PublicClient:
         self,
         *,
         ascending: bool | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         is_carousel: bool | None = None,
         locale: str | None = None,
@@ -776,7 +766,6 @@ class PublicClient:
         """
         spec = _gamma_actions.list_tags_spec(
             ascending=ascending,
-            include_chat=include_chat,
             include_template=include_template,
             is_carousel=is_carousel,
             locale=locale,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -482,13 +482,12 @@ class SecureClient:
         self,
         id: str,
         *,
-        include_chat: bool | None = None,
         locale: str | None = None,
     ) -> Series:
         """Get a series."""
         return sync_dispatch(
             self._ctx,
-            _gamma_actions.get_series_spec(id, include_chat=include_chat, locale=locale),
+            _gamma_actions.get_series_spec(id, locale=locale),
         )
 
     def get_tag(
@@ -496,7 +495,6 @@ class SecureClient:
         *,
         id: str | None = None,
         slug: str | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         locale: str | None = None,
     ) -> Tag:
@@ -506,7 +504,6 @@ class SecureClient:
             _gamma_actions.get_tag_spec(
                 id=id,
                 slug=slug,
-                include_chat=include_chat,
                 include_template=include_template,
                 locale=locale,
             ),
@@ -1007,11 +1004,8 @@ class SecureClient:
         self,
         *,
         ascending: bool | None = None,
-        categories_ids: int | Sequence[int] | None = None,
-        categories_labels: str | Sequence[str] | None = None,
         closed: bool | None = None,
         exclude_events: bool | None = None,
-        include_chat: bool | None = None,
         locale: str | None = None,
         order: str | None = None,
         recurrence: Recurrence | None = None,
@@ -1025,11 +1019,8 @@ class SecureClient:
         """
         spec = _gamma_actions.list_series_spec(
             ascending=ascending,
-            categories_ids=categories_ids,
-            categories_labels=categories_labels,
             closed=closed,
             exclude_events=exclude_events,
-            include_chat=include_chat,
             locale=locale,
             order=order,
             recurrence=recurrence,
@@ -1041,7 +1032,6 @@ class SecureClient:
         self,
         *,
         ascending: bool | None = None,
-        include_chat: bool | None = None,
         include_template: bool | None = None,
         is_carousel: bool | None = None,
         locale: str | None = None,
@@ -1055,7 +1045,6 @@ class SecureClient:
         """
         spec = _gamma_actions.list_tags_spec(
             ascending=ascending,
-            include_chat=include_chat,
             include_template=include_template,
             is_carousel=is_carousel,
             locale=locale,

--- a/src/polymarket/models/gamma/series.py
+++ b/src/polymarket/models/gamma/series.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from polymarket.models.gamma.common import (
-    CategoryReference,
-    Chat,
     CollectionReference,
     SeriesReference,
 )
@@ -15,8 +13,6 @@ from polymarket.models.gamma.tag import Tag
 class Series(SeriesReference):
     events: tuple[Event, ...] | None = None
     collections: tuple[CollectionReference, ...] | None = None
-    categories: tuple[CategoryReference, ...] | None = None
-    chats: tuple[Chat, ...] | None = None
     tags: tuple[Tag, ...] | None = None
 
 

--- a/src/polymarket/models/gamma/tag.py
+++ b/src/polymarket/models/gamma/tag.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from pydantic import Field
 
 from polymarket.models.base import BaseModel
-from polymarket.models.gamma.common import Chat, TagReference, TemplateReference
+from polymarket.models.gamma.common import TagReference, TemplateReference
 
 
 class Tag(TagReference):
-    chats: tuple[Chat, ...] | None = None
     templates: tuple[TemplateReference, ...] | None = None
 
 

--- a/tests/unit/test_gamma_models.py
+++ b/tests/unit/test_gamma_models.py
@@ -420,7 +420,6 @@ def test_series_parses_with_nested_collections() -> None:
             "liquidity": "800",
             "events": [{"id": "EVENT-1"}],
             "collections": [{"id": "COLL-1", "slug": "c1"}],
-            "categories": [{"id": "CAT-1", "label": "Cat 1"}],
             "tags": [{"id": "TAG-1", "label": "Tag 1"}],
         }
     )
@@ -429,7 +428,6 @@ def test_series_parses_with_nested_collections() -> None:
     assert series.volume == Decimal("1500")
     assert series.events is not None and len(series.events) == 1
     assert series.collections is not None and series.collections[0].slug == "c1"
-    assert series.categories is not None and series.categories[0].label == "Cat 1"
 
 
 def test_series_accepts_integer_id_per_ts_schema() -> None:
@@ -445,13 +443,6 @@ def test_tag_inherits_tag_reference_fields_and_adds_chats() -> None:
             "label": "Politics",
             "slug": "politics",
             "isCarousel": True,
-            "chats": [
-                {
-                    "id": "CHAT-1",
-                    "channelId": "ch-1",
-                    "live": False,
-                }
-            ],
             "templates": [
                 {
                     "id": "TPL-1",
@@ -464,7 +455,6 @@ def test_tag_inherits_tag_reference_fields_and_adds_chats() -> None:
     assert tag.id == "TAG-1"
     assert tag.label == "Politics"
     assert tag.is_carousel is True
-    assert tag.chats is not None and tag.chats[0].channel_id == "ch-1"
     assert tag.templates is not None and tag.templates[0].display_name == "Template"
 
 

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -77,10 +77,10 @@ def test_list_series_spec_default_has_no_params() -> None:
     assert spec.base_params is None
 
 
-def test_list_series_spec_with_categories() -> None:
-    spec = gamma_actions.list_series_spec(closed=False, categories_ids=[1, 2])
+def test_list_series_spec_collects_filter_params() -> None:
+    spec = gamma_actions.list_series_spec(closed=False, exclude_events=True, slug=["nba"])
 
-    assert spec.base_params == {"closed": False, "categories_ids": (1, 2)}
+    assert spec.base_params == {"closed": False, "exclude_events": True, "slug": ("nba",)}
 
 
 def test_list_series_spec_rejects_invalid_recurrence() -> None:
@@ -97,9 +97,9 @@ def test_list_tags_spec_default_has_no_params() -> None:
 
 
 def test_list_tags_spec_with_options() -> None:
-    spec = gamma_actions.list_tags_spec(include_chat=True, locale="en")
+    spec = gamma_actions.list_tags_spec(include_template=True, locale="en")
 
-    assert spec.base_params == {"include_chat": True, "locale": "en"}
+    assert spec.base_params == {"include_template": True, "locale": "en"}
 
 
 def test_list_teams_spec_default_has_no_params() -> None:

--- a/tests/unit/test_gamma_specs.py
+++ b/tests/unit/test_gamma_specs.py
@@ -96,66 +96,47 @@ def test_get_event_tags_spec_rejects_empty_id() -> None:
 
 
 def test_get_series_spec_includes_optional_params() -> None:
-    spec = gamma_actions.get_series_spec("series-id", include_chat=True, locale="en")
+    spec = gamma_actions.get_series_spec("series-id", locale="en")
 
     assert spec.service == "gamma"
     assert spec.path == "/series/series-id"
-    assert spec.params == {"include_chat": True, "locale": "en"}
+    assert spec.params == {"locale": "en"}
 
 
 def test_get_series_spec_omits_unset_params() -> None:
-    spec = gamma_actions.get_series_spec("series-id", include_chat=None, locale=None)
+    spec = gamma_actions.get_series_spec("series-id", locale=None)
 
-    assert spec.params == {"include_chat": None, "locale": None}
+    assert spec.params == {"locale": None}
 
 
 def test_get_series_spec_rejects_empty_id() -> None:
     with pytest.raises(UserInputError, match="id is required"):
-        gamma_actions.get_series_spec("", include_chat=None, locale=None)
+        gamma_actions.get_series_spec("", locale=None)
 
 
 def test_get_tag_spec_by_id_includes_options() -> None:
-    spec = gamma_actions.get_tag_spec(
-        id="42", slug=None, include_chat=True, include_template=True, locale="en"
-    )
+    spec = gamma_actions.get_tag_spec(id="42", slug=None, include_template=True, locale="en")
 
     assert spec.path == "/tags/42"
     assert spec.params == {
-        "include_chat": True,
         "include_template": True,
         "locale": "en",
     }
 
 
 def test_get_tag_spec_by_slug_with_only_locale() -> None:
-    spec = gamma_actions.get_tag_spec(
-        id=None, slug="politics", include_chat=None, include_template=None, locale="en"
-    )
+    spec = gamma_actions.get_tag_spec(id=None, slug="politics", include_template=None, locale="en")
 
     assert spec.path == "/tags/slug/politics"
     assert spec.params == {
-        "include_chat": None,
         "include_template": None,
         "locale": "en",
     }
 
 
-def test_get_tag_spec_rejects_slug_with_include_chat() -> None:
-    with pytest.raises(
-        UserInputError, match="include_chat and include_template are only supported for tag id"
-    ):
-        gamma_actions.get_tag_spec(
-            id=None, slug="politics", include_chat=True, include_template=None, locale=None
-        )
-
-
 def test_get_tag_spec_rejects_slug_with_include_template() -> None:
-    with pytest.raises(
-        UserInputError, match="include_chat and include_template are only supported for tag id"
-    ):
-        gamma_actions.get_tag_spec(
-            id=None, slug="politics", include_chat=None, include_template=True, locale=None
-        )
+    with pytest.raises(UserInputError, match="include_template is only supported for tag id"):
+        gamma_actions.get_tag_spec(id=None, slug="politics", include_template=True, locale=None)
 
 
 def test_get_related_tags_spec_by_id_includes_filters() -> None:


### PR DESCRIPTION
Removes tag/series request params (`include_chat`, `categories_ids`, `categories_labels`) the clients accept but the upstream never binds, and response fields (`Tag.chats`, `Series.categories`, `Series.chats`) it never populates — across the sync and async clients.

`include_template` and the events `include_chat` are real and retained (the tag slug-guard is narrowed accordingly). Response casing is unchanged — the public attrs are already `tag_id`/`related_tag_id` and the `validation_alias` keeps reading the upstream `tagID` wire key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API removals across four client modules; low runtime risk since removed options were ineffective upstream, but integrators must update call sites.
> 
> **Overview**
> Removes **gamma tag/series API surface** that the upstream does not support, across internal specs, sync/async public and secure clients, and Pydantic models.
> 
> **Request parameters dropped:** `include_chat` on `get_series`, `get_tag`, `list_series`, and `list_tags`; `categories_ids` and `categories_labels` on `list_series`. **Event** `include_chat` (get/list events) is unchanged. **`include_template`** stays on tag endpoints; slug lookup now only rejects `include_template` (not `include_chat`).
> 
> **Response fields removed:** `Series.categories`, `Series.chats`, and `Tag.chats`. Unit tests for specs and models are updated accordingly.
> 
> This is a **breaking change** for callers passing the removed kwargs or reading the removed attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ff6f9ce20f53b46c2e84083739ab9b8ee5bf57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->