### PR TITLE
ci: use public integration test runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   integration:
     name: Integration tests
-    runs-on: arc-runner-set-euw1
+    runs-on: arc-public-runner-set-euw1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Switch integration tests to `arc-public-runner-set-euw1`

## Verification
- `uv sync --locked --all-extras --all-groups`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv build`
- `uv run pytest -m "not integration"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the GitHub Actions runner label changes; no application, auth, or test logic is modified.
> 
> **Overview**
> Integration workflow jobs now run on **`arc-public-runner-set-euw1`** instead of **`arc-runner-set-euw1`**, routing integration tests to the public ARC runner pool in EU West 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f351c31186a1a966c1b27cc10f36a9cd4007e20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->