### PR TITLE
feat(frames): add dataframe conversion foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ dependencies = [
   "websockets>=13,<16",
 ]
 
+[project.optional-dependencies]
+arrow = ["pyarrow>=15,<22"]
+pandas = ["pandas>=2,<3", "pyarrow>=15,<22"]
+polars = ["polars>=1,<2", "pyarrow>=15,<22"]
+quant = ["pandas>=2,<3", "polars>=1,<2", "pyarrow>=15,<22"]
+
 [project.urls]
 Homepage = "https://polymarket.com"
 Documentation = "https://docs.polymarket.com"
@@ -51,6 +57,12 @@ dev = [
   "pyright>=1.1,<2",
   "pytest-watcher>=0.6.3",
   "python-dotenv>=1.2.2",
+  # Frames extras — dev needs all of them to run the frames test suite.
+  # Production users install only the extras they need via
+  # ``polymarket-client[pandas|polars|arrow|quant]``.
+  "pyarrow>=15,<22",
+  "pandas>=2,<3",
+  "polars>=1,<2",
 ]
 
 [tool.hatch.build]
@@ -102,3 +114,15 @@ pythonVersion = "3.11"
 typeCheckingMode = "strict"
 venvPath = "."
 venv = ".venv"
+
+# The frames adapters wrap pyarrow / pandas / polars, none of which ship
+# first-class type stubs that satisfy strict mode. Loosen the unknown-type
+# reports for these modules only; everything else stays strict.
+[[tool.pyright.executionEnvironments]]
+root = "src/polymarket/frames"
+reportMissingTypeStubs = "none"
+reportUnknownMemberType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportUnknownParameterType = "none"
+reportUnknownLambdaType = "none"

--- a/src/polymarket/_frames_bridge.py
+++ b/src/polymarket/_frames_bridge.py
@@ -1,0 +1,14 @@
+"""Lazy, type-erased lookup of :mod:`polymarket.frames` functions for non-frames modules."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+
+def frames_func(name: Literal["to_arrow", "to_pandas", "to_polars"]) -> Any:
+    from polymarket import frames
+
+    return getattr(frames, name)
+
+
+__all__ = ["frames_func"]

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -831,7 +831,7 @@ class AsyncPublicClient:
         Examples:
             Iterate over individual market items::
 
-                async for market in client.list_markets(closed=False).items():
+                async for market in client.list_markets(closed=False).iter_items():
                     print(market.question)
         """
         spec = _gamma_actions.list_markets_spec(

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -685,7 +685,7 @@ class PublicClient:
 
             Iterate over every market item::
 
-                for market in client.list_markets(closed=False).items():
+                for market in client.list_markets(closed=False).iter_items():
                     print(market.question)
         """
         spec = _gamma_actions.list_markets_spec(
@@ -871,7 +871,7 @@ class PublicClient:
         Examples:
             Search markets and events::
 
-                for result in client.search(q="election").items():
+                for result in client.search(q="election").iter_items():
                     print(result)
         """
         spec = _gamma_actions.search_spec(

--- a/src/polymarket/frames/__init__.py
+++ b/src/polymarket/frames/__init__.py
@@ -1,0 +1,14 @@
+"""Dataframe conversion for Polymarket SDK objects. See ``docs/frames.md``."""
+
+from polymarket.frames import _builtin_overrides as _  # noqa: F401
+from polymarket.frames._arrow import to_arrow
+from polymarket.frames._errors import MissingOptionalDependencyError
+from polymarket.frames._pandas import to_pandas
+from polymarket.frames._polars import to_polars
+
+__all__ = [
+    "MissingOptionalDependencyError",
+    "to_arrow",
+    "to_pandas",
+    "to_polars",
+]

--- a/src/polymarket/frames/_arrow.py
+++ b/src/polymarket/frames/_arrow.py
@@ -38,8 +38,7 @@ def to_arrow(value: object) -> pa.Table:
         )
     if isinstance(value, AsyncPaginator):
         raise TypeError(
-            "to_arrow() does not accept AsyncPaginator. Use "
-            "`await paginator.to_arrow(limit=N)`."
+            "to_arrow() does not accept AsyncPaginator. Use `await paginator.to_arrow(limit=N)`."
         )
 
     if isinstance(value, BaseModel):

--- a/src/polymarket/frames/_arrow.py
+++ b/src/polymarket/frames/_arrow.py
@@ -28,7 +28,7 @@ def to_arrow(value: object) -> pa.Table:
         return override(value)
 
     if isinstance(value, Page):
-        return _build_table_from_models(list(value.items))
+        return to_arrow(tuple(value.items))
 
     if isinstance(value, Paginator):
         raise TypeError(
@@ -49,6 +49,13 @@ def to_arrow(value: object) -> pa.Table:
         items = list(value)
         if not items:
             return pa.table({})
+        # Homogeneous sequence whose element type has an override:
+        # hand the whole list to the override so it can emit identity columns.
+        types_seen = {type(it) for it in items}
+        if len(types_seen) == 1:
+            seq_override = lookup_override(next(iter(types_seen)))
+            if seq_override is not None:
+                return seq_override(items)
         if all(isinstance(item, BaseModel) for item in items):
             return _build_table_from_models(items)
         raise TypeError(

--- a/src/polymarket/frames/_arrow.py
+++ b/src/polymarket/frames/_arrow.py
@@ -1,0 +1,351 @@
+"""SDK-object → :class:`pyarrow.Table` engine; the pandas and polars adapters cast on top of it."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Sequence
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from polymarket.frames._errors import MissingOptionalDependencyError
+from polymarket.frames._overrides import lookup_override
+from polymarket.pagination import AsyncPaginator, Page, Paginator
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+def to_arrow(value: object) -> pa.Table:
+    """Convert a model, sequence of models, or :class:`Page` to a :class:`pyarrow.Table`."""
+    pa = _require_pyarrow()
+
+    override = lookup_override(type(value))
+    if override is not None:
+        return override(value)
+
+    if isinstance(value, Page):
+        return _build_table_from_models(list(value.items))
+
+    if isinstance(value, Paginator):
+        raise TypeError(
+            "to_arrow() does not accept Paginator (would silently drain "
+            "all pages). Use `paginator.to_arrow(limit=N)` or "
+            "`paginator.to_arrow(limit=None)`."
+        )
+    if isinstance(value, AsyncPaginator):
+        raise TypeError(
+            "to_arrow() does not accept AsyncPaginator. Use "
+            "`await paginator.to_arrow(limit=N)`."
+        )
+
+    if isinstance(value, BaseModel):
+        return _build_table_from_models([value])
+
+    if isinstance(value, (tuple, list)):
+        items = list(value)
+        if not items:
+            return pa.table({})
+        if all(isinstance(item, BaseModel) for item in items):
+            return _build_table_from_models(items)
+        raise TypeError(
+            "to_arrow() expects a sequence of pydantic models; got mixed "
+            f"types including {type(items[0]).__name__!r}."
+        )
+
+    raise TypeError(
+        f"to_arrow() does not know how to convert {type(value).__name__!r}. "
+        "Pass a pydantic model, a tuple/list of models, a Page, or use the "
+        "method form on a Paginator."
+    )
+
+
+def _build_table_from_models(models: Sequence[BaseModel]) -> pa.Table:
+    if not models:
+        return _require_pyarrow().table({})
+    rows = [m.model_dump(mode="python") for m in models]
+    return _build_table_from_rows(rows)
+
+
+def _build_table_from_rows(rows: Sequence[dict[str, Any]]) -> pa.Table:
+    pa = _require_pyarrow()
+    if not rows:
+        return pa.table({})
+
+    field_names: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for name in row:
+            if name not in seen:
+                seen.add(name)
+                field_names.append(name)
+
+    columns: list[pa.Array] = []
+    schema_fields: list[pa.Field] = []
+    for name in field_names:
+        column_values = [row.get(name) for row in rows]
+        arrow_type = _infer_column_type(column_values)
+        columns.append(_build_column(column_values, arrow_type))
+        schema_fields.append(pa.field(name, arrow_type, nullable=True))
+
+    return pa.table(columns, schema=pa.schema(schema_fields))
+
+
+def _infer_column_type(values: Sequence[object]) -> pa.DataType:
+    pa = _require_pyarrow()
+
+    non_null = [v for v in values if v is not None]
+    if not non_null:
+        return pa.string()
+
+    seed = non_null[0]
+
+    if isinstance(seed, dict):
+        _require_homogeneous_nested(non_null, expected_kind=dict, kind_label="dict (struct)")
+        return _infer_struct_type([v for v in non_null if isinstance(v, dict)])
+
+    if isinstance(seed, (list, tuple)):
+        _require_homogeneous_nested(non_null, expected_kind=(list, tuple), kind_label="list/tuple")
+        non_empty: list[object] = []
+        for v in non_null:
+            if isinstance(v, (list, tuple)) and len(v) > 0:
+                non_empty.extend(v)
+        if not non_empty:
+            return pa.list_(pa.string())
+        return pa.list_(_infer_column_type(non_empty))
+
+    return _infer_scalar_column_type(non_null)
+
+
+def _require_homogeneous_nested(
+    values: Sequence[object],
+    *,
+    expected_kind: type | tuple[type, ...],
+    kind_label: str,
+) -> None:
+    offenders: list[type] = []
+    seen: set[type] = set()
+    for v in values:
+        if not isinstance(v, expected_kind):
+            t = type(v)
+            if t not in seen:
+                seen.add(t)
+                offenders.append(t)
+    if not offenders:
+        return
+    raise TypeError(
+        f"polymarket.frames cannot mix {kind_label} values with other "
+        f"value kinds in one column. Found incompatible types: "
+        f"{sorted(t.__name__ for t in offenders)}. Pick a single shape per "
+        "field in your model, or split the field into separate fields per "
+        "variant."
+    )
+
+
+def _infer_struct_type(struct_rows: Sequence[dict[str, Any]]) -> pa.DataType:
+    pa = _require_pyarrow()
+    field_names: list[str] = []
+    seen: set[str] = set()
+    for row in struct_rows:
+        for name in row:
+            if name not in seen:
+                seen.add(name)
+                field_names.append(name)
+    fields: list[pa.Field] = []
+    for name in field_names:
+        column_values = [row.get(name) for row in struct_rows]
+        fields.append(pa.field(name, _infer_column_type(column_values), nullable=True))
+    return pa.struct(fields)
+
+
+# Arrow decimal128 caps at precision 38; decimal256 at 76.
+_DECIMAL128_MAX_PRECISION = 38
+_DECIMAL256_MAX_PRECISION = 76
+
+
+def _infer_scalar_column_type(non_null_values: Sequence[object]) -> pa.DataType:
+    pa = _require_pyarrow()
+
+    # bool subclasses int; treat them as distinct categories.
+    types_seen = {type(v) for v in non_null_values}
+
+    if len(types_seen) == 1:
+        return _single_type_arrow_type(non_null_values, next(iter(types_seen)))
+
+    if types_seen <= {bool, int, float, Decimal}:
+        has_float = float in types_seen
+        has_decimal = Decimal in types_seen
+        if has_float and has_decimal:
+            raise TypeError(
+                "polymarket.frames cannot mix `float` and `Decimal` values "
+                "in the same column — the promotion is ambiguous (preserve "
+                "precision vs. allow vectorised math). Pick one type in your "
+                "model."
+            )
+        if has_decimal:
+            promoted: list[Decimal] = []
+            for v in non_null_values:
+                if isinstance(v, Decimal):
+                    promoted.append(v)
+                elif isinstance(v, bool):
+                    promoted.append(Decimal(int(v)))
+                elif isinstance(v, int):
+                    promoted.append(Decimal(v))
+            return _infer_decimal_type(promoted)
+        if has_float:
+            return pa.float64()
+        return pa.int64()
+
+    raise TypeError(
+        "polymarket.frames cannot mix incompatible scalar types in one "
+        f"column: {sorted(t.__name__ for t in types_seen)}. Pick a single "
+        "type in your model or split into separate fields."
+    )
+
+
+def _single_type_arrow_type(values: Sequence[object], cls: type) -> pa.DataType:
+    if cls is Decimal:
+        return _infer_decimal_type([v for v in values if isinstance(v, Decimal)])
+    return _scalar_type_for(values[0])
+
+
+def _infer_decimal_type(values: Sequence[Decimal]) -> pa.DataType:
+    pa = _require_pyarrow()
+    if not values:
+        return pa.decimal128(1, 0)
+
+    max_scale = 0
+    max_integer_digits = 0
+    for v in values:
+        _, scale, integer_digits = _decimal_dimensions(v)
+        max_scale = max(max_scale, scale)
+        max_integer_digits = max(max_integer_digits, integer_digits)
+
+    final_precision = max(1, max_integer_digits + max_scale)
+
+    if final_precision <= _DECIMAL128_MAX_PRECISION:
+        return pa.decimal128(final_precision, max_scale)
+    if final_precision <= _DECIMAL256_MAX_PRECISION:
+        return pa.decimal256(final_precision, max_scale)
+    raise ValueError(
+        f"polymarket.frames: Decimal column requires precision "
+        f"{final_precision} (scale {max_scale}), which exceeds Arrow's "
+        f"decimal256 maximum of {_DECIMAL256_MAX_PRECISION}. Reduce the "
+        "magnitude or precision of the input values."
+    )
+
+
+def _decimal_dimensions(d: Decimal) -> tuple[int, int, int]:
+    _, digits, exponent = d.as_tuple()
+    if not isinstance(exponent, int):
+        # 'F' (Infinity), 'n'/'N' (NaN).
+        raise ValueError(f"polymarket.frames cannot represent special Decimal value: {d!r}")
+
+    digit_count = len(digits)
+
+    if exponent >= 0:
+        scale = 0
+        integer_digits = digit_count + exponent
+        precision = max(1, integer_digits)
+    else:
+        scale = -exponent
+        integer_digits = max(0, digit_count - scale)
+        precision = max(digit_count, scale)
+
+    return precision, scale, integer_digits
+
+
+def _scalar_type_for(value: object) -> pa.DataType:
+    pa = _require_pyarrow()
+
+    # bool subclasses int, so check it first.
+    if isinstance(value, bool):
+        return pa.bool_()
+    if isinstance(value, int):
+        return pa.int64()
+    if isinstance(value, float):
+        return pa.float64()
+    if isinstance(value, Decimal):
+        return _infer_decimal_type([value])
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            warnings.warn(
+                "polymarket.frames received a naive datetime; the SDK is "
+                "expected to produce tz-aware (UTC) datetimes. Please report "
+                "a bug if you see this from SDK output.",
+                stacklevel=4,
+            )
+            return pa.timestamp("us")
+        return pa.timestamp("us", tz="UTC")
+    # datetime subclasses date, so check date last.
+    if isinstance(value, date):
+        return pa.date32()
+    if isinstance(value, Enum):
+        return _scalar_type_for(value.value)
+    if isinstance(value, str):
+        return pa.string()
+    if isinstance(value, bytes):
+        return pa.binary()
+    raise TypeError(
+        f"polymarket.frames cannot map Python value of type "
+        f"{type(value).__name__!r} to an Arrow type."
+    )
+
+
+def _build_column(values: Sequence[object], arrow_type: pa.DataType) -> pa.Array:
+    # pa.array refuses to coerce bool→int or int→decimal(scale>0); pre-coerce.
+    pa = _require_pyarrow()
+    serialized = [_serialize_value(v) for v in values]
+
+    if pa.types.is_integer(arrow_type) and not pa.types.is_boolean(arrow_type):
+        serialized = [int(v) if isinstance(v, bool) else v for v in serialized]
+    elif pa.types.is_decimal(arrow_type):
+        serialized = [_coerce_to_decimal(v) for v in serialized]
+
+    return pa.array(serialized, type=arrow_type)
+
+
+def _coerce_to_decimal(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, bool):
+        return Decimal(int(value))
+    if isinstance(value, int):
+        return Decimal(value)
+    return value
+
+
+def _serialize_value(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return _serialize_value(value.value)
+    if isinstance(value, dict):
+        return {k: _serialize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize_value(v) for v in value]
+    return value
+
+
+def _require_pyarrow():  # noqa: ANN202
+    try:
+        import pyarrow as pa
+    except ImportError as e:  # pragma: no cover
+        raise MissingOptionalDependencyError(
+            "polymarket.frames requires pyarrow. "
+            "Install via `pip install polymarket-client[arrow]` (or "
+            "`[pandas]` / `[polars]` / `[quant]`)."
+        ) from e
+    return pa
+
+
+__all__ = [
+    "to_arrow",
+    "_build_table_from_models",
+    "_build_table_from_rows",
+]

--- a/src/polymarket/frames/_builtin_overrides.py
+++ b/src/polymarket/frames/_builtin_overrides.py
@@ -1,0 +1,24 @@
+"""Built-in Arrow overrides registered on ``polymarket.frames`` import."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polymarket.frames._overrides import register_override
+from polymarket.models import OrderBook
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+@register_override(OrderBook)
+def _orderbook_to_arrow(value: object) -> pa.Table:  # pyright: ignore[reportUnusedFunction]
+    from polymarket.frames._arrow import _build_table_from_rows
+
+    assert isinstance(value, OrderBook)
+    rows: list[dict[str, object]] = []
+    for level_idx, lvl in enumerate(value.bids):
+        rows.append({"side": "bid", "level": level_idx, "price": lvl.price, "size": lvl.size})
+    for level_idx, lvl in enumerate(value.asks):
+        rows.append({"side": "ask", "level": level_idx, "price": lvl.price, "size": lvl.size})
+    return _build_table_from_rows(rows)

--- a/src/polymarket/frames/_builtin_overrides.py
+++ b/src/polymarket/frames/_builtin_overrides.py
@@ -13,12 +13,26 @@ if TYPE_CHECKING:
 
 @register_override(OrderBook)
 def _orderbook_to_arrow(value: object) -> pa.Table:  # pyright: ignore[reportUnusedFunction]
+    # Single book -> [side, level, price, size]; sequence of books ->
+    # [market, token_id, side, level, price, size] so rows stay attributable.
     from polymarket.frames._arrow import _build_table_from_rows
 
-    assert isinstance(value, OrderBook)
+    if isinstance(value, OrderBook):
+        return _build_table_from_rows(_orderbook_rows(value))
+
+    assert isinstance(value, (list, tuple))
     rows: list[dict[str, object]] = []
-    for level_idx, lvl in enumerate(value.bids):
-        rows.append({"side": "bid", "level": level_idx, "price": lvl.price, "size": lvl.size})
-    for level_idx, lvl in enumerate(value.asks):
-        rows.append({"side": "ask", "level": level_idx, "price": lvl.price, "size": lvl.size})
+    for book in value:
+        assert isinstance(book, OrderBook)
+        for r in _orderbook_rows(book):
+            rows.append({"market": book.market, "token_id": book.token_id, **r})
     return _build_table_from_rows(rows)
+
+
+def _orderbook_rows(book: OrderBook) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for level_idx, lvl in enumerate(book.bids):
+        rows.append({"side": "bid", "level": level_idx, "price": lvl.price, "size": lvl.size})
+    for level_idx, lvl in enumerate(book.asks):
+        rows.append({"side": "ask", "level": level_idx, "price": lvl.price, "size": lvl.size})
+    return rows

--- a/src/polymarket/frames/_builtin_overrides.py
+++ b/src/polymarket/frames/_builtin_overrides.py
@@ -13,8 +13,10 @@ if TYPE_CHECKING:
 
 @register_override(OrderBook)
 def _orderbook_to_arrow(value: object) -> pa.Table:  # pyright: ignore[reportUnusedFunction]
-    # Single book -> [side, level, price, size]; sequence of books ->
-    # [market, token_id, side, level, price, size] so rows stay attributable.
+    # Single book -> [side, level, price, size]. Sequence of books ->
+    # [market, token_id, timestamp, hash, side, level, price, size] so
+    # rows stay attributable across instruments AND snapshots of the same
+    # instrument over time.
     from polymarket.frames._arrow import _build_table_from_rows
 
     if isinstance(value, OrderBook):
@@ -24,8 +26,14 @@ def _orderbook_to_arrow(value: object) -> pa.Table:  # pyright: ignore[reportUnu
     rows: list[dict[str, object]] = []
     for book in value:
         assert isinstance(book, OrderBook)
+        identity = {
+            "market": book.market,
+            "token_id": book.token_id,
+            "timestamp": book.timestamp,
+            "hash": book.hash,
+        }
         for r in _orderbook_rows(book):
-            rows.append({"market": book.market, "token_id": book.token_id, **r})
+            rows.append({**identity, **r})
     return _build_table_from_rows(rows)
 
 

--- a/src/polymarket/frames/_errors.py
+++ b/src/polymarket/frames/_errors.py
@@ -1,0 +1,10 @@
+"""Errors raised by :mod:`polymarket.frames`."""
+
+from __future__ import annotations
+
+
+class MissingOptionalDependencyError(ImportError):
+    """An optional dependency required by a frames operation is not installed."""
+
+
+__all__ = ["MissingOptionalDependencyError"]

--- a/src/polymarket/frames/_overrides.py
+++ b/src/polymarket/frames/_overrides.py
@@ -1,0 +1,48 @@
+"""Per-type override registry for the Arrow conversion engine. Lookup walks the MRO."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+_REGISTRY: dict[type, Callable[[object], pa.Table]] = {}
+
+
+def register_override(
+    cls: type,
+) -> Callable[[Callable[[object], pa.Table]], Callable[[object], pa.Table]]:
+    def decorator(
+        fn: Callable[[object], pa.Table],
+    ) -> Callable[[object], pa.Table]:
+        _REGISTRY[cls] = fn
+        return fn
+
+    return decorator
+
+
+def lookup_override(cls: type) -> Callable[[object], pa.Table] | None:
+    for ancestor in cls.__mro__:
+        converter = _REGISTRY.get(ancestor)
+        if converter is not None:
+            return converter
+    return None
+
+
+def clear_overrides() -> None:
+    _REGISTRY.clear()
+
+
+def registered_types() -> tuple[type, ...]:
+    return tuple(_REGISTRY.keys())
+
+
+__all__ = [
+    "clear_overrides",
+    "lookup_override",
+    "register_override",
+    "registered_types",
+]

--- a/src/polymarket/frames/_pandas.py
+++ b/src/polymarket/frames/_pandas.py
@@ -1,0 +1,88 @@
+"""pandas adapter for :mod:`polymarket.frames`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
+
+from polymarket.frames._arrow import to_arrow
+from polymarket.frames._errors import MissingOptionalDependencyError
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+DecimalMode = Literal["decimal", "float"]
+
+
+def to_pandas(
+    value: object,
+    *,
+    decimal: DecimalMode = "decimal",
+    explode: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    pa, pd = _require_pandas_stack()
+
+    if decimal not in ("decimal", "float"):
+        raise TypeError(f"decimal must be 'decimal' or 'float'; got {decimal!r}")
+
+    table = to_arrow(value)
+
+    if decimal == "float":
+        table = _cast_decimal_to_float(table, pa)
+
+    df = _arrow_table_to_pandas(table, pa, pd, decimal=decimal)
+
+    if explode:
+        df = df.explode(list(explode))
+
+    return df
+
+
+def _arrow_table_to_pandas(
+    table,  # type: ignore[no-untyped-def]
+    pa,  # type: ignore[no-untyped-def]  # noqa: ARG001
+    pd,  # type: ignore[no-untyped-def]
+    *,
+    decimal: DecimalMode,
+):  # noqa: ANN202
+    if decimal == "decimal":
+        return table.to_pandas(types_mapper=pd.ArrowDtype)
+    return table.to_pandas()
+
+
+def _cast_decimal_to_float(table, pa):  # type: ignore[no-untyped-def] # noqa: ANN202
+    if not any(pa.types.is_decimal(field.type) for field in table.schema):
+        return table
+
+    new_arrays = []
+    new_fields = []
+    for i, field in enumerate(table.schema):
+        column = table.column(i)
+        if pa.types.is_decimal(field.type):
+            column = column.cast(pa.float64())
+            field = pa.field(field.name, pa.float64(), nullable=field.nullable)
+        new_arrays.append(column)
+        new_fields.append(field)
+    return pa.Table.from_arrays(new_arrays, schema=pa.schema(new_fields))
+
+
+def _require_pandas_stack():  # noqa: ANN202
+    try:
+        import pyarrow as pa
+    except ImportError as e:  # pragma: no cover
+        raise MissingOptionalDependencyError(
+            "polymarket.frames.to_pandas() requires pyarrow. "
+            "Install via `pip install polymarket-client[pandas]`."
+        ) from e
+    try:
+        import pandas as pd
+    except ImportError as e:  # pragma: no cover
+        raise MissingOptionalDependencyError(
+            "polymarket.frames.to_pandas() requires pandas. "
+            "Install via `pip install polymarket-client[pandas]`."
+        ) from e
+    return pa, pd
+
+
+__all__ = ["DecimalMode", "to_pandas"]

--- a/src/polymarket/frames/_pandas.py
+++ b/src/polymarket/frames/_pandas.py
@@ -21,6 +21,13 @@ def to_pandas(
     decimal: DecimalMode = "decimal",
     explode: Sequence[str] | None = None,
 ) -> pd.DataFrame:
+    """Convert SDK objects to a pandas DataFrame.
+
+    ``decimal="float"`` casts only top-level Arrow decimal columns to
+    ``float64``. Decimal values nested inside struct/list columns stay
+    precision-preserving; explode or normalize those columns first if you
+    want to cast them explicitly.
+    """
     pa, pd = _require_pandas_stack()
 
     if decimal not in ("decimal", "float"):

--- a/src/polymarket/frames/_polars.py
+++ b/src/polymarket/frames/_polars.py
@@ -1,0 +1,94 @@
+"""polars adapter for :mod:`polymarket.frames`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from polymarket.frames._arrow import to_arrow
+from polymarket.frames._errors import MissingOptionalDependencyError
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def to_polars(
+    value: object,
+    *,
+    explode: Sequence[str] | None = None,
+) -> pl.DataFrame:
+    pl = _require_polars()
+    table = to_arrow(value)
+    _reject_unsupported_polars_types(table.schema)
+
+    df = pl.from_arrow(table)
+    assert isinstance(df, pl.DataFrame)
+
+    if explode:
+        df = df.explode(list(explode))
+
+    return df
+
+
+def _reject_unsupported_polars_types(schema: Any) -> None:
+    # pl.from_arrow panics in Rust on decimal256; raise a clean Python error first.
+    import pyarrow as pa  # noqa: PLC0415
+
+    bad = _find_decimal256_paths(schema, pa, prefix="")
+    if bad:
+        raise TypeError(
+            "polymarket.frames.to_polars() cannot convert columns whose "
+            f"Arrow type is decimal256: {', '.join(bad)}. polars's native "
+            "Decimal maxes out at precision 38. Use "
+            "polymarket.frames.to_arrow() or to_pandas() for higher precision, "
+            "or reduce the input precision."
+        )
+
+
+def _find_decimal256_paths(node: Any, pa: Any, *, prefix: str) -> list[str]:
+    paths: list[str] = []
+
+    if isinstance(node, pa.Schema):  # type: ignore[attr-defined]
+        for field in node:
+            paths.extend(_find_decimal256_paths(field.type, pa, prefix=field.name))
+        return paths
+
+    arrow_type = node
+
+    if pa.types.is_decimal256(arrow_type):  # type: ignore[attr-defined]
+        paths.append(prefix or "(root)")
+        return paths
+
+    if pa.types.is_struct(arrow_type):  # type: ignore[attr-defined]
+        for field in arrow_type:
+            child = f"{prefix}.{field.name}" if prefix else field.name
+            paths.extend(_find_decimal256_paths(field.type, pa, prefix=child))
+        return paths
+
+    if pa.types.is_list(arrow_type) or pa.types.is_large_list(arrow_type):  # type: ignore[attr-defined]
+        child = f"{prefix}[]"
+        paths.extend(_find_decimal256_paths(arrow_type.value_type, pa, prefix=child))
+        return paths
+
+    return paths
+
+
+def _require_polars():  # noqa: ANN202
+    try:
+        import pyarrow  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    except ImportError as e:  # pragma: no cover
+        raise MissingOptionalDependencyError(
+            "polymarket.frames.to_polars() requires pyarrow. "
+            "Install via `pip install polymarket-client[polars]`."
+        ) from e
+    try:
+        import polars as pl
+    except ImportError as e:  # pragma: no cover
+        raise MissingOptionalDependencyError(
+            "polymarket.frames.to_polars() requires polars. "
+            "Install via `pip install polymarket-client[polars]`."
+        ) from e
+    return pl
+
+
+__all__ = ["to_polars"]

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
+from typing import Any, Literal
 
 from pydantic import Field, field_validator
 
+from polymarket._frames_bridge import frames_func as _frames_func
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import TokenId
+
+_DecimalMode = Literal["decimal", "float"]
 
 
 class OrderBookLevel(BaseModel):
@@ -21,9 +26,9 @@ class OrderBook(BaseModel):
     token_id: TokenId = Field(validation_alias="asset_id")
     timestamp: datetime | None = None
     bids: tuple[OrderBookLevel, ...]
-    """Bid levels in ascending price order, lowest bid first."""
+    """Ascending price order, lowest bid first."""
     asks: tuple[OrderBookLevel, ...]
-    """Ask levels in descending price order, highest ask first."""
+    """Descending price order, highest ask first."""
     min_order_size: _DecimalFromString
     tick_size: _DecimalFromString
     neg_risk: bool
@@ -55,6 +60,25 @@ class OrderBook(BaseModel):
     @classmethod
     def _parse_last_trade_price(cls, value: object) -> object:
         return None if value in (None, "") else value
+
+    def to_arrow(self) -> Any:
+        """Flatten this book into ``[side, level, price, size]`` rows."""
+        return _frames_func("to_arrow")(self)
+
+    def to_pandas(
+        self,
+        *,
+        decimal: _DecimalMode = "decimal",
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        return _frames_func("to_pandas")(self, decimal=decimal, explode=explode)
+
+    def to_polars(
+        self,
+        *,
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        return _frames_func("to_polars")(self, explode=explode)
 
 
 __all__ = ["OrderBook", "OrderBookLevel"]

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -1,35 +1,51 @@
+"""Paginators and pages returned by SDK list-style endpoints."""
+
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Generic, TypeVar, cast
+from typing import Any, Generic, Literal, TypeVar, cast
 
+from polymarket._frames_bridge import frames_func as _frames_func
 from polymarket.errors import UnexpectedResponseError
 
 T = TypeVar("T")
 
 
+# Frame-method returns are typed as ``Any`` because pandas/polars/pyarrow
+# stubs don't survive strict-mode pyright. Drain ``limit`` is required so
+# multi-page truncation can't be silent.
+LimitArg = int | None
+DecimalMode = Literal["decimal", "float"]
+
+
 @dataclass(frozen=True, slots=True)
 class Page(Generic[T]):
-    """One page of paginated SDK results."""
-
     items: tuple[T, ...]
-    """Items returned on this page."""
     has_more: bool
-    """Whether another page is available."""
     next_cursor: str | None = None
-    """Cursor to pass to ``from_cursor()`` for the next page, when available."""
     total_count: int | None = None
-    """Total matching item count when the API provides it."""
+
+    def to_arrow(self) -> Any:
+        return _frames_func("to_arrow")(self)
+
+    def to_pandas(
+        self,
+        *,
+        decimal: DecimalMode = "decimal",
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        return _frames_func("to_pandas")(self, decimal=decimal, explode=explode)
+
+    def to_polars(
+        self,
+        *,
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        return _frames_func("to_polars")(self, explode=explode)
 
 
 class Paginator(Generic[T]):
-    """Synchronous paginator returned by list-style client methods.
-
-    Iterate over the paginator to fetch pages lazily, or call ``items()`` to
-    iterate over individual items across pages.
-    """
-
     def __init__(
         self,
         fetch: Callable[[str | None], Page[T]],
@@ -39,14 +55,9 @@ class Paginator(Generic[T]):
         self._initial_cursor = initial_cursor
 
     def first_page(self) -> Page[T]:
-        """Fetch the first page for this paginator."""
         return self._fetch(self._initial_cursor)
 
     def from_cursor(self, cursor: str | None) -> Paginator[T]:
-        """Create a paginator that starts from ``cursor``.
-
-        Passing ``None`` returns an empty paginator because no next page exists.
-        """
         if cursor is None:
             return cast(Paginator[T], _EmptyPaginator())
         return Paginator(self._fetch, initial_cursor=cursor)
@@ -55,7 +66,6 @@ class Paginator(Generic[T]):
         return self._iter_pages()
 
     def items(self) -> Iterator[T]:
-        """Iterate over individual items across all fetched pages."""
         for page in self._iter_pages():
             yield from page.items
 
@@ -72,14 +82,34 @@ class Paginator(Generic[T]):
                 )
             cursor = page.next_cursor
 
+    def to_arrow(self, *, limit: LimitArg) -> Any:
+        items, _truncated = _drain_paginator(self, limit)
+        return _frames_func("to_arrow")(tuple(items))
+
+    def to_pandas(
+        self,
+        *,
+        limit: LimitArg,
+        decimal: DecimalMode = "decimal",
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        items, truncated = _drain_paginator(self, limit)
+        df = _frames_func("to_pandas")(tuple(items), decimal=decimal, explode=explode)
+        if truncated:
+            df.attrs["polymarket_truncated"] = True
+        return df
+
+    def to_polars(
+        self,
+        *,
+        limit: LimitArg,
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        items, _truncated = _drain_paginator(self, limit)
+        return _frames_func("to_polars")(tuple(items), explode=explode)
+
 
 class AsyncPaginator(Generic[T]):
-    """Async paginator returned by async list-style client methods.
-
-    Use ``async for`` over the paginator to fetch pages lazily, or call
-    ``items()`` to iterate over individual items across pages.
-    """
-
     def __init__(
         self,
         fetch: Callable[[str | None], Awaitable[Page[T]]],
@@ -89,14 +119,9 @@ class AsyncPaginator(Generic[T]):
         self._initial_cursor = initial_cursor
 
     async def first_page(self) -> Page[T]:
-        """Fetch the first page for this paginator."""
         return await self._fetch(self._initial_cursor)
 
     def from_cursor(self, cursor: str | None) -> AsyncPaginator[T]:
-        """Create an async paginator that starts from ``cursor``.
-
-        Passing ``None`` returns an empty paginator because no next page exists.
-        """
         if cursor is None:
             return cast(AsyncPaginator[T], _EmptyAsyncPaginator())
         return AsyncPaginator(self._fetch, initial_cursor=cursor)
@@ -105,7 +130,6 @@ class AsyncPaginator(Generic[T]):
         return self._iter_pages()
 
     def items(self) -> AsyncIterator[T]:
-        """Iterate over individual items across all fetched pages."""
         return self._iter_items()
 
     async def _iter_pages(self) -> AsyncIterator[Page[T]]:
@@ -125,6 +149,71 @@ class AsyncPaginator(Generic[T]):
         async for page in self._iter_pages():
             for item in page.items:
                 yield item
+
+    async def to_arrow(self, *, limit: LimitArg) -> Any:
+        items, _truncated = await _drain_async_paginator(self, limit)
+        return _frames_func("to_arrow")(tuple(items))
+
+    async def to_pandas(
+        self,
+        *,
+        limit: LimitArg,
+        decimal: DecimalMode = "decimal",
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        items, truncated = await _drain_async_paginator(self, limit)
+        df = _frames_func("to_pandas")(tuple(items), decimal=decimal, explode=explode)
+        if truncated:
+            df.attrs["polymarket_truncated"] = True
+        return df
+
+    async def to_polars(
+        self,
+        *,
+        limit: LimitArg,
+        explode: Sequence[str] | None = None,
+    ) -> Any:
+        items, _truncated = await _drain_async_paginator(self, limit)
+        return _frames_func("to_polars")(tuple(items), explode=explode)
+
+
+def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T], bool]:
+    if limit is None:
+        return list(paginator.items()), False
+    if limit < 0:
+        from polymarket.errors import UserInputError
+
+        raise UserInputError(f"limit must be >= 0 or None; got {limit}.")
+    out: list[T] = []
+    truncated = False
+    for item in paginator.items():
+        if len(out) >= limit:
+            truncated = True
+            break
+        out.append(item)
+    return out, truncated
+
+
+async def _drain_async_paginator(
+    paginator: AsyncPaginator[T], limit: int | None
+) -> tuple[list[T], bool]:
+    if limit is None:
+        out: list[T] = []
+        async for item in paginator.items():
+            out.append(item)
+        return out, False
+    if limit < 0:
+        from polymarket.errors import UserInputError
+
+        raise UserInputError(f"limit must be >= 0 or None; got {limit}.")
+    out2: list[T] = []
+    truncated = False
+    async for item in paginator.items():
+        if len(out2) >= limit:
+            truncated = True
+            break
+        out2.append(item)
+    return out2, truncated
 
 
 class _EmptyPaginator(Paginator[object]):
@@ -157,7 +246,7 @@ class _EmptyAsyncPaginator(AsyncPaginator[object]):
 
     async def _iter_pages(self) -> AsyncIterator[Page[object]]:
         return
-        yield  # pragma: no cover - keeps the method an async generator
+        yield  # pragma: no cover - forces this method to be an async generator
 
 
 def _empty_sync_fetch(_cursor: str | None) -> Page[object]:
@@ -168,4 +257,4 @@ async def _empty_async_fetch(_cursor: str | None) -> Page[object]:
     return Page(items=(), has_more=False)
 
 
-__all__ = ["AsyncPaginator", "Page", "Paginator"]
+__all__ = ["AsyncPaginator", "DecimalMode", "LimitArg", "Page", "Paginator"]

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -184,6 +184,9 @@ def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T
         from polymarket.errors import UserInputError
 
         raise UserInputError(f"limit must be >= 0 or None; got {limit}.")
+    if limit == 0:
+        # Skip the fetch entirely; with no observation we can't claim truncation.
+        return [], False
     out: list[T] = []
     truncated = False
     for item in paginator.items():
@@ -206,6 +209,8 @@ async def _drain_async_paginator(
         from polymarket.errors import UserInputError
 
         raise UserInputError(f"limit must be >= 0 or None; got {limit}.")
+    if limit == 0:
+        return [], False
     out2: list[T] = []
     truncated = False
     async for item in paginator.items():

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -69,10 +69,6 @@ class Paginator(Generic[T]):
         for page in self._iter_pages():
             yield from page.items
 
-    def items(self) -> Iterator[T]:
-        # Deprecated alias for iter_items(); reads ambiguously like dict.items().
-        return self.iter_items()
-
     def _iter_pages(self) -> Iterator[Page[T]]:
         cursor = self._initial_cursor
         while True:
@@ -137,10 +133,6 @@ class AsyncPaginator(Generic[T]):
         return self._iter_pages()
 
     def iter_items(self) -> AsyncIterator[T]:
-        return self._iter_items()
-
-    def items(self) -> AsyncIterator[T]:
-        # Deprecated alias for iter_items(); reads ambiguously like dict.items().
         return self._iter_items()
 
     async def _iter_pages(self) -> AsyncIterator[Page[T]]:

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -198,14 +198,19 @@ def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T
     if limit == 0:
         # Skip the fetch entirely; with no observation we can't claim truncation.
         return [], False
+    # Drain page-by-page so that hitting `limit` exactly at a page boundary can
+    # read truncation from page.has_more instead of fetching the next page.
     out: list[T] = []
-    truncated = False
-    for item in paginator.iter_items():
+    for page in paginator:
+        for item in page.items:
+            if len(out) >= limit:
+                return out, True
+            out.append(item)
         if len(out) >= limit:
-            truncated = True
-            break
-        out.append(item)
-    return out, truncated
+            return out, page.has_more
+        if not page.has_more:
+            return out, False
+    return out, False
 
 
 async def _drain_async_paginator(
@@ -223,13 +228,16 @@ async def _drain_async_paginator(
     if limit == 0:
         return [], False
     out2: list[T] = []
-    truncated = False
-    async for item in paginator.iter_items():
+    async for page in paginator:
+        for item in page.items:
+            if len(out2) >= limit:
+                return out2, True
+            out2.append(item)
         if len(out2) >= limit:
-            truncated = True
-            break
-        out2.append(item)
-    return out2, truncated
+            return out2, page.has_more
+        if not page.has_more:
+            return out2, False
+    return out2, False
 
 
 class _EmptyPaginator(Paginator[object]):

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -65,9 +65,13 @@ class Paginator(Generic[T]):
     def __iter__(self) -> Iterator[Page[T]]:
         return self._iter_pages()
 
-    def items(self) -> Iterator[T]:
+    def iter_items(self) -> Iterator[T]:
         for page in self._iter_pages():
             yield from page.items
+
+    def items(self) -> Iterator[T]:
+        # Deprecated alias for iter_items(); reads ambiguously like dict.items().
+        return self.iter_items()
 
     def _iter_pages(self) -> Iterator[Page[T]]:
         cursor = self._initial_cursor
@@ -83,8 +87,9 @@ class Paginator(Generic[T]):
             cursor = page.next_cursor
 
     def to_arrow(self, *, limit: LimitArg) -> Any:
-        items, _truncated = _drain_paginator(self, limit)
-        return _frames_func("to_arrow")(tuple(items))
+        items, truncated = _drain_paginator(self, limit)
+        table = _frames_func("to_arrow")(tuple(items))
+        return _mark_arrow_truncated(table) if truncated else table
 
     def to_pandas(
         self,
@@ -105,6 +110,8 @@ class Paginator(Generic[T]):
         limit: LimitArg,
         explode: Sequence[str] | None = None,
     ) -> Any:
+        # Polars has no stable per-frame metadata surface in supported versions.
+        # Keep truncation markers to pandas attrs and Arrow schema metadata.
         items, _truncated = _drain_paginator(self, limit)
         return _frames_func("to_polars")(tuple(items), explode=explode)
 
@@ -129,7 +136,11 @@ class AsyncPaginator(Generic[T]):
     def __aiter__(self) -> AsyncIterator[Page[T]]:
         return self._iter_pages()
 
+    def iter_items(self) -> AsyncIterator[T]:
+        return self._iter_items()
+
     def items(self) -> AsyncIterator[T]:
+        # Deprecated alias for iter_items(); reads ambiguously like dict.items().
         return self._iter_items()
 
     async def _iter_pages(self) -> AsyncIterator[Page[T]]:
@@ -151,8 +162,9 @@ class AsyncPaginator(Generic[T]):
                 yield item
 
     async def to_arrow(self, *, limit: LimitArg) -> Any:
-        items, _truncated = await _drain_async_paginator(self, limit)
-        return _frames_func("to_arrow")(tuple(items))
+        items, truncated = await _drain_async_paginator(self, limit)
+        table = _frames_func("to_arrow")(tuple(items))
+        return _mark_arrow_truncated(table) if truncated else table
 
     async def to_pandas(
         self,
@@ -177,9 +189,16 @@ class AsyncPaginator(Generic[T]):
         return _frames_func("to_polars")(tuple(items), explode=explode)
 
 
+def _mark_arrow_truncated(table: Any) -> Any:
+    # Arrow has no df.attrs equivalent; stash the marker in schema metadata.
+    existing: dict[bytes, bytes] = dict(table.schema.metadata or {})
+    existing[b"polymarket_truncated"] = b"true"
+    return table.replace_schema_metadata(existing)
+
+
 def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T], bool]:
     if limit is None:
-        return list(paginator.items()), False
+        return list(paginator.iter_items()), False
     if limit < 0:
         from polymarket.errors import UserInputError
 
@@ -189,7 +208,7 @@ def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T
         return [], False
     out: list[T] = []
     truncated = False
-    for item in paginator.items():
+    for item in paginator.iter_items():
         if len(out) >= limit:
             truncated = True
             break
@@ -202,7 +221,7 @@ async def _drain_async_paginator(
 ) -> tuple[list[T], bool]:
     if limit is None:
         out: list[T] = []
-        async for item in paginator.items():
+        async for item in paginator.iter_items():
             out.append(item)
         return out, False
     if limit < 0:
@@ -213,7 +232,7 @@ async def _drain_async_paginator(
         return [], False
     out2: list[T] = []
     truncated = False
-    async for item in paginator.items():
+    async for item in paginator.iter_items():
         if len(out2) >= limit:
             truncated = True
             break

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -156,7 +156,7 @@ def test_list_open_orders_paginates_until_end_cursor() -> None:
         try:
             _install_secure_clob(client, httpx.MockTransport(handler))
             ids: list[str] = []
-            async for order in client.list_open_orders(market="0xMARKET").items():
+            async for order in client.list_open_orders(market="0xMARKET").iter_items():
                 ids.append(order.id)
             return ids
         finally:
@@ -220,7 +220,7 @@ def test_list_account_trades_paginates_and_passes_filters() -> None:
             collected: list[str] = []
             async for trade in client.list_account_trades(
                 market="0xMARKET", maker_address="0xMAKER"
-            ).items():
+            ).iter_items():
                 collected.append(trade.id)
             return collected
         finally:

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -316,7 +316,7 @@ class TestAsyncPublicClientListBuilderTrades:
                 ids: list[str] = []
                 async for trade in client.list_builder_trades(
                     builder_code=_VALID_BUILDER_CODE
-                ).items():
+                ).iter_items():
                     ids.append(trade.id)
                 return ids
 

--- a/tests/unit/test_frames_arrow.py
+++ b/tests/unit/test_frames_arrow.py
@@ -1,0 +1,474 @@
+"""Tests for the generic Arrow conversion engine."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from enum import Enum, StrEnum
+from typing import Any, NewType
+
+import pyarrow as pa
+import pytest
+from pydantic import BaseModel
+
+from polymarket.frames import to_arrow
+from polymarket.pagination import AsyncPaginator, Page, Paginator
+
+
+class _Side(StrEnum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class _Color(Enum):
+    RED = 1
+    GREEN = 2
+
+
+_MarketIdT = NewType("_MarketIdT", str)
+
+
+class _Scalar(BaseModel):
+    id: _MarketIdT
+    name: str
+    qty: int
+    ratio: float
+    is_active: bool
+    price: Decimal
+    side: _Side
+    color: _Color
+    ts: datetime
+    day: date
+
+
+class _Inner(BaseModel):
+    price: Decimal
+    size: Decimal
+
+
+class _WithNested(BaseModel):
+    id: str
+    children: tuple[_Inner, ...]
+
+
+class _Optional(BaseModel):
+    id: str
+    nullable_price: Decimal | None = None
+
+
+class _AnyPayload(BaseModel):
+    payload: Any = None
+
+
+def test_single_model_yields_one_row_table() -> None:
+    m = _Inner(price=Decimal("0.5"), size=Decimal("100"))
+    table = to_arrow(m)
+    assert table.num_rows == 1
+    assert table.column_names == ["price", "size"]
+
+
+def test_tuple_of_models_yields_n_row_table() -> None:
+    items = (
+        _Inner(price=Decimal("0.5"), size=Decimal("100")),
+        _Inner(price=Decimal("0.51"), size=Decimal("200")),
+        _Inner(price=Decimal("0.52"), size=Decimal("300")),
+    )
+    table = to_arrow(items)
+    assert table.num_rows == 3
+    assert table.to_pylist() == [
+        {"price": Decimal("0.5"), "size": Decimal("100")},
+        {"price": Decimal("0.51"), "size": Decimal("200")},
+        {"price": Decimal("0.52"), "size": Decimal("300")},
+    ]
+
+
+def test_list_of_models_also_works() -> None:
+    items = [
+        _Inner(price=Decimal("0.5"), size=Decimal("100")),
+        _Inner(price=Decimal("0.51"), size=Decimal("200")),
+    ]
+    assert to_arrow(items).num_rows == 2
+
+
+def test_page_delegates_to_its_items() -> None:
+    page: Page[_Inner] = Page(
+        items=(
+            _Inner(price=Decimal("0.5"), size=Decimal("100")),
+            _Inner(price=Decimal("0.51"), size=Decimal("200")),
+        ),
+        has_more=False,
+    )
+    table = to_arrow(page)
+    assert table.num_rows == 2
+
+
+def test_paginator_is_rejected_with_helpful_message() -> None:
+    paginator: Paginator[_Inner] = Paginator(fetch=lambda _c: Page(items=(), has_more=False))
+    with pytest.raises(TypeError, match="Paginator"):
+        to_arrow(paginator)
+
+
+def test_async_paginator_is_rejected_with_helpful_message() -> None:
+    async def _fetch(_c: str | None) -> Page[_Inner]:
+        return Page(items=(), has_more=False)
+
+    paginator: AsyncPaginator[_Inner] = AsyncPaginator(fetch=_fetch)
+    with pytest.raises(TypeError, match="AsyncPaginator"):
+        to_arrow(paginator)
+
+
+def test_mixed_sequence_is_rejected() -> None:
+    with pytest.raises(TypeError, match="mixed"):
+        to_arrow((_Inner(price=Decimal("0.5"), size=Decimal("100")), "not a model"))
+
+
+def test_unknown_type_is_rejected() -> None:
+    with pytest.raises(TypeError, match="does not know how to convert"):
+        to_arrow(42)
+
+
+def test_empty_tuple_returns_empty_table() -> None:
+    table = to_arrow(())
+    assert table.num_rows == 0
+    assert table.num_columns == 0
+
+
+def test_decimal_type_is_sized_to_actual_values() -> None:
+    """Regression: precision/scale used to be hardcoded to (38, 18)."""
+    m = _Inner(price=Decimal("0.123"), size=Decimal("1"))
+    schema = to_arrow(m).schema
+    assert pa.types.is_decimal(schema.field("price").type)
+    assert schema.field("price").type.precision == 3
+    assert schema.field("price").type.scale == 3
+
+
+def test_decimal_more_than_18_fractional_digits_preserved() -> None:
+    """Regression: hardcoded decimal128(38, 18) lost precision past 18 digits."""
+    high_precision = Decimal("0.1234567890123456789")
+    m = _Inner(price=high_precision, size=Decimal("1"))
+    table = to_arrow(m)
+    assert pa.types.is_decimal(table.schema.field("price").type)
+    assert table.schema.field("price").type.scale == 19
+    assert table["price"][0].as_py() == high_precision
+
+
+def test_decimal_scientific_notation_small_value_preserved() -> None:
+    """Regression: 1E-20 needs scale 20; old hardcoded 18 would truncate."""
+    m = _Inner(price=Decimal("1E-20"), size=Decimal("1"))
+    table = to_arrow(m)
+    assert table.schema.field("price").type.scale == 20
+    assert table["price"][0].as_py() == Decimal("1E-20")
+
+
+def test_decimal_promotes_to_decimal256_above_38_digits() -> None:
+    """Regression: 39+ digit integers exceeded decimal128's precision cap."""
+    big = Decimal("123456789012345678901234567890123456789")
+    m = _Inner(price=big, size=Decimal("1"))
+    table = to_arrow(m)
+    field_type = table.schema.field("price").type
+    assert pa.types.is_decimal256(field_type)
+    assert field_type.precision == 39
+    assert table["price"][0].as_py() == big
+
+
+def test_decimal_too_big_for_decimal256_raises_clean_error() -> None:
+    """77+ total digits exceed decimal256 — clear ValueError, not silent loss."""
+    too_big = Decimal("1" + "0" * 76)
+    m = _Inner(price=too_big, size=Decimal("1"))
+    with pytest.raises(ValueError, match="exceeds Arrow's decimal256 maximum"):
+        to_arrow(m)
+
+
+def test_decimal_column_with_mixed_precision_picks_widest() -> None:
+    items = (
+        _Inner(price=Decimal("0.001"), size=Decimal("1500")),
+        _Inner(price=Decimal("999.99999"), size=Decimal("2.5")),
+    )
+    schema = to_arrow(items).schema
+    price_type = schema.field("price").type
+    assert price_type.scale == 5
+    assert price_type.precision == 8
+
+
+def test_mixed_int_float_promotes_to_float64() -> None:
+    """Regression: int+float column was inferred as int64, truncating floats."""
+
+    class _IntX(BaseModel):
+        x: int
+
+    class _FloatX(BaseModel):
+        x: float
+
+    table = to_arrow((_IntX(x=1), _FloatX(x=2.2)))
+    assert pa.types.is_floating(table.schema.field("x").type)
+    assert table["x"].to_pylist() == [1.0, 2.2]
+
+
+def test_mixed_int_decimal_promotes_to_decimal() -> None:
+    class _IntX(BaseModel):
+        x: int
+
+    class _DecimalX(BaseModel):
+        x: Decimal
+
+    table = to_arrow((_IntX(x=10), _DecimalX(x=Decimal("3.14"))))
+    assert pa.types.is_decimal(table.schema.field("x").type)
+    assert table["x"].to_pylist() == [Decimal("10.00"), Decimal("3.14")]
+
+
+def test_mixed_bool_int_promotes_to_int() -> None:
+    class _BoolX(BaseModel):
+        x: bool
+
+    class _IntX(BaseModel):
+        x: int
+
+    table = to_arrow((_BoolX(x=True), _IntX(x=42)))
+    assert pa.types.is_integer(table.schema.field("x").type)
+    assert table["x"].to_pylist() == [1, 42]
+
+
+def test_mixed_float_decimal_rejected_as_ambiguous() -> None:
+    """No safe promotion — refuse rather than silently coerce."""
+
+    class _FloatX(BaseModel):
+        x: float
+
+    class _DecimalX(BaseModel):
+        x: Decimal
+
+    with pytest.raises(TypeError, match=r"`float` and `Decimal`"):
+        to_arrow((_FloatX(x=1.5), _DecimalX(x=Decimal("3.14"))))
+
+
+def test_mixed_str_int_rejected() -> None:
+    """No safe promotion across categories — refuse to guess."""
+
+    class _StrX(BaseModel):
+        x: str
+
+    class _IntX(BaseModel):
+        x: int
+
+    with pytest.raises(TypeError, match="incompatible scalar types"):
+        to_arrow((_StrX(x="abc"), _IntX(x=1)))
+
+
+def test_mixed_dict_and_non_dict_raises_clean_typeerror() -> None:
+    """Regression: raw pyarrow ArrowTypeError used to leak from the column build."""
+    with pytest.raises(TypeError, match=r"dict \(struct\).*str"):
+        to_arrow(
+            (
+                _AnyPayload(payload={"key": "value"}),
+                _AnyPayload(payload="just_a_string"),
+            )
+        )
+
+
+def test_mixed_dict_with_none_is_ok() -> None:
+    table = to_arrow(
+        (
+            _AnyPayload(payload={"k": "v"}),
+            _AnyPayload(payload=None),
+            _AnyPayload(payload={"k": "w"}),
+        )
+    )
+    assert table.num_rows == 3
+    assert pa.types.is_struct(table.schema.field("payload").type)
+
+
+def test_mixed_list_and_non_list_raises_clean_typeerror() -> None:
+    with pytest.raises(TypeError, match=r"list/tuple.*int"):
+        to_arrow(
+            (
+                _AnyPayload(payload=[1, 2, 3]),
+                _AnyPayload(payload=42),
+            )
+        )
+
+
+def test_mixed_list_with_none_is_ok() -> None:
+    table = to_arrow(
+        (
+            _AnyPayload(payload=[1, 2, 3]),
+            _AnyPayload(payload=None),
+            _AnyPayload(payload=[4, 5]),
+        )
+    )
+    assert table.num_rows == 3
+    assert pa.types.is_list(table.schema.field("payload").type)
+
+
+def test_tz_aware_datetime_becomes_utc_timestamp() -> None:
+    m = _Scalar(
+        id=_MarketIdT("m1"),
+        name="x",
+        qty=1,
+        ratio=1.0,
+        is_active=True,
+        price=Decimal("1"),
+        side=_Side.BUY,
+        color=_Color.RED,
+        ts=datetime(2026, 1, 1, tzinfo=UTC),
+        day=date(2026, 1, 1),
+    )
+    schema = to_arrow(m).schema
+    assert pa.types.is_timestamp(schema.field("ts").type)
+    assert str(schema.field("ts").type.tz) == "UTC"
+
+
+def test_naive_datetime_warns_but_works() -> None:
+    class _NaiveTs(BaseModel):
+        ts: datetime
+
+    m = _NaiveTs(ts=datetime(2026, 1, 1))  # noqa: DTZ001
+    with pytest.warns(UserWarning, match="naive datetime"):
+        table = to_arrow(m)
+    assert pa.types.is_timestamp(table.schema.field("ts").type)
+
+
+def test_date_becomes_date32() -> None:
+    class _OnlyDate(BaseModel):
+        day: date
+
+    m = _OnlyDate(day=date(2026, 1, 1))
+    assert pa.types.is_date32(to_arrow(m).schema.field("day").type)
+
+
+def test_bool_is_not_int() -> None:
+    """Regression: bool must check before int since bool is a subclass of int."""
+
+    class _Bool(BaseModel):
+        flag: bool
+
+    schema = to_arrow(_Bool(flag=True)).schema
+    assert pa.types.is_boolean(schema.field("flag").type)
+    assert not pa.types.is_integer(schema.field("flag").type)
+
+
+def test_str_enum_serializes_as_string_value() -> None:
+    class _Holder(BaseModel):
+        side: _Side
+
+    table = to_arrow(_Holder(side=_Side.BUY))
+    assert table.to_pylist() == [{"side": "BUY"}]
+    assert pa.types.is_string(table.schema.field("side").type)
+
+
+def test_int_enum_serializes_as_int_value() -> None:
+    class _Holder(BaseModel):
+        color: _Color
+
+    table = to_arrow(_Holder(color=_Color.GREEN))
+    assert table.to_pylist() == [{"color": 2}]
+    assert pa.types.is_integer(table.schema.field("color").type)
+
+
+def test_newtype_collapses_to_underlying_str() -> None:
+    """NewType is transparent at runtime; model_dump returns the str."""
+
+    class _Holder(BaseModel):
+        market_id: _MarketIdT
+
+    table = to_arrow(_Holder(market_id=_MarketIdT("m1")))
+    assert pa.types.is_string(table.schema.field("market_id").type)
+
+
+def test_nested_model_becomes_list_of_struct() -> None:
+    parent = _WithNested(
+        id="x",
+        children=(
+            _Inner(price=Decimal("0.5"), size=Decimal("100")),
+            _Inner(price=Decimal("0.51"), size=Decimal("200")),
+        ),
+    )
+    schema = to_arrow(parent).schema
+    children_type = schema.field("children").type
+    assert pa.types.is_list(children_type)
+    assert pa.types.is_struct(children_type.value_type)
+
+
+def test_late_list_inner_type_inferred_from_all_rows() -> None:
+    """First row has empty list; second row populated. Must still infer struct."""
+    items = (
+        _WithNested(id="a", children=()),
+        _WithNested(
+            id="b",
+            children=(_Inner(price=Decimal("1"), size=Decimal("1")),),
+        ),
+    )
+    schema = to_arrow(items).schema
+    children_type = schema.field("children").type
+    assert pa.types.is_list(children_type)
+    assert pa.types.is_struct(children_type.value_type)
+
+
+def test_all_empty_lists_falls_back_to_list_of_string() -> None:
+    """Fallback: empty-only lists become list<string> since null roundtrips poorly to pandas."""
+    items = (
+        _WithNested(id="a", children=()),
+        _WithNested(id="b", children=()),
+    )
+    schema = to_arrow(items).schema
+    assert pa.types.is_list(schema.field("children").type)
+
+
+def test_nullable_column_keeps_type_when_first_row_null() -> None:
+    items = (
+        _Optional(id="a", nullable_price=None),
+        _Optional(id="b", nullable_price=Decimal("1.5")),
+    )
+    schema = to_arrow(items).schema
+    assert pa.types.is_decimal(schema.field("nullable_price").type)
+
+
+def test_all_null_column_falls_back_to_string() -> None:
+    """Fallback: all-None column has no value to infer from; string round-trips."""
+    items = (_Optional(id="a"), _Optional(id="b"))
+    schema = to_arrow(items).schema
+    assert pa.types.is_string(schema.field("nullable_price").type)
+
+
+def test_heterogeneous_models_union_their_fields() -> None:
+    class _A(BaseModel):
+        type: str
+        a_value: int
+
+    class _B(BaseModel):
+        type: str
+        b_value: str
+
+    items = (_A(type="a", a_value=1), _B(type="b", b_value="x"))
+    table = to_arrow(items)
+    assert set(table.column_names) == {"type", "a_value", "b_value"}
+    rows = table.to_pylist()
+    assert rows[0] == {"type": "a", "a_value": 1, "b_value": None}
+    assert rows[1] == {"type": "b", "a_value": None, "b_value": "x"}
+
+
+def test_sdk_orderbooklevel_round_trips() -> None:
+    from polymarket.models import OrderBookLevel
+
+    items = (
+        OrderBookLevel.model_validate({"price": "0.5", "size": "100"}),
+        OrderBookLevel.model_validate({"price": "0.51", "size": "200"}),
+    )
+    table = to_arrow(items)
+    assert table.num_rows == 2
+    assert pa.types.is_decimal(table.schema.field("price").type)
+
+
+def test_sdk_price_history_point_round_trips() -> None:
+    from polymarket.models import PriceHistoryPoint
+
+    items = (
+        PriceHistoryPoint(t=1700000000, p=0.5),
+        PriceHistoryPoint(t=1700000060, p=0.51),
+    )
+    table = to_arrow(items)
+    assert table.num_rows == 2
+    assert set(table.column_names) == {"t", "p"}
+    assert pa.types.is_integer(table.schema.field("t").type)
+    assert pa.types.is_floating(table.schema.field("p").type)

--- a/tests/unit/test_frames_missing_deps.py
+++ b/tests/unit/test_frames_missing_deps.py
@@ -1,0 +1,87 @@
+"""Tests for graceful failure when optional dependencies are missing."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import BaseModel
+
+from polymarket.frames import (
+    MissingOptionalDependencyError,
+    to_arrow,
+    to_pandas,
+    to_polars,
+)
+
+
+class _Tiny(BaseModel):
+    n: int
+    v: Decimal
+
+
+def _raise_missing(name: str):  # noqa: ANN202
+    def go(*_args: object, **_kwargs: object) -> object:
+        raise MissingOptionalDependencyError(f"polymarket.frames test stub: {name} unavailable")
+
+    return go
+
+
+def test_error_class_is_importerror_subclass() -> None:
+    """Existing ``except ImportError:`` clauses must still catch it."""
+    assert issubclass(MissingOptionalDependencyError, ImportError)
+
+
+def test_to_arrow_raises_when_pyarrow_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polymarket.frames._arrow._require_pyarrow",
+        _raise_missing("pyarrow"),
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="pyarrow"):
+        to_arrow(_Tiny(n=1, v=Decimal("1")))
+
+
+def test_to_pandas_raises_when_pandas_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polymarket.frames._pandas._require_pandas_stack",
+        _raise_missing("pandas"),
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="pandas"):
+        to_pandas(_Tiny(n=1, v=Decimal("1")))
+
+
+def test_to_polars_raises_when_polars_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polymarket.frames._polars._require_polars",
+        _raise_missing("polars"),
+    )
+    with pytest.raises(MissingOptionalDependencyError, match="polars"):
+        to_polars(_Tiny(n=1, v=Decimal("1")))
+
+
+def test_error_message_includes_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "polymarket.frames._pandas._require_pandas_stack",
+        lambda: (_ for _ in ()).throw(
+            MissingOptionalDependencyError(
+                "polymarket.frames.to_pandas() requires pandas. Install via "
+                "`pip install polymarket-client[pandas]`."
+            )
+        ),
+    )
+    with pytest.raises(MissingOptionalDependencyError, match=r"polymarket-client\[pandas\]"):
+        to_pandas(_Tiny(n=1, v=Decimal("1")))
+
+
+def test_module_imports_without_any_extras_installed() -> None:
+    """``from polymarket.frames import to_pandas`` must succeed with no extras installed."""
+    import polymarket.frames as f
+
+    assert hasattr(f, "to_arrow")
+    assert hasattr(f, "to_pandas")
+    assert hasattr(f, "to_polars")
+    assert hasattr(f, "MissingOptionalDependencyError")

--- a/tests/unit/test_frames_order_book.py
+++ b/tests/unit/test_frames_order_book.py
@@ -1,0 +1,114 @@
+"""Tests for the OrderBook flatten override."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pyarrow as pa
+
+from polymarket.frames import to_arrow, to_pandas, to_polars
+from polymarket.models import OrderBook
+
+
+def _make_book(
+    bids: tuple[tuple[str, str], ...] = (("0.49", "100"), ("0.48", "50")),
+    asks: tuple[tuple[str, str], ...] = (("0.51", "80"),),
+) -> OrderBook:
+    return OrderBook.model_validate(
+        {
+            "market": "0xfoo",
+            "asset_id": "42",
+            "timestamp": None,
+            "bids": [{"price": p, "size": s} for p, s in bids],
+            "asks": [{"price": p, "size": s} for p, s in asks],
+            "min_order_size": "5",
+            "tick_size": "0.01",
+            "neg_risk": True,
+            "last_trade_price": "0.50",
+            "hash": "abc",
+        }
+    )
+
+
+def test_free_function_to_arrow_uses_flat_shape() -> None:
+    table = to_arrow(_make_book())
+    assert table.column_names == ["side", "level", "price", "size"]
+    assert table.num_rows == 3
+
+
+def test_free_function_to_pandas_uses_flat_shape() -> None:
+    df = to_pandas(_make_book())
+    assert list(df.columns) == ["side", "level", "price", "size"]
+    assert len(df) == 3
+
+
+def test_free_function_to_polars_uses_flat_shape() -> None:
+    df = to_polars(_make_book())
+    assert df.columns == ["side", "level", "price", "size"]
+    assert df.shape == (3, 4)
+
+
+def test_method_to_arrow_matches_free_function() -> None:
+    book = _make_book()
+    assert book.to_arrow().to_pylist() == to_arrow(book).to_pylist()
+
+
+def test_method_to_pandas_matches_free_function() -> None:
+    book = _make_book()
+    method_df = book.to_pandas()
+    func_df = to_pandas(book)
+    assert list(method_df.columns) == list(func_df.columns)
+    assert len(method_df) == len(func_df)
+
+
+def test_method_to_polars_matches_free_function() -> None:
+    book = _make_book()
+    assert book.to_polars().to_dict(as_series=False) == to_polars(book).to_dict(as_series=False)
+
+
+def test_bids_appear_first_then_asks_with_correct_level_indexing() -> None:
+    rows = _make_book().to_arrow().to_pylist()
+    bids = [r for r in rows if r["side"] == "bid"]
+    asks = [r for r in rows if r["side"] == "ask"]
+    assert [r["level"] for r in bids] == [0, 1]
+    assert [r["level"] for r in asks] == [0]
+
+
+def test_decimal_columns_use_decimal128_38_18() -> None:
+    schema = _make_book().to_arrow().schema
+    assert pa.types.is_decimal(schema.field("price").type)
+    assert pa.types.is_decimal(schema.field("size").type)
+
+
+def test_pandas_default_decimal_mode_preserves_precision() -> None:
+    book = OrderBook.model_validate(
+        {
+            "market": "0xfoo",
+            "asset_id": "42",
+            "timestamp": None,
+            "bids": [{"price": "0.123456789012345678", "size": "1"}],
+            "asks": [],
+            "min_order_size": "5",
+            "tick_size": "0.01",
+            "neg_risk": True,
+            "last_trade_price": None,
+            "hash": "x",
+        }
+    )
+    df = book.to_pandas()
+    assert df["price"][0] == Decimal("0.123456789012345678")
+
+
+def test_empty_bids_or_asks_still_produces_table() -> None:
+    book_no_asks = _make_book(asks=())
+    df = book_no_asks.to_pandas()
+    assert all(df["side"] == "bid")
+    assert len(df) == 2
+
+
+def test_completely_empty_book_yields_empty_table() -> None:
+    book = _make_book(bids=(), asks=())
+    table = book.to_arrow()
+    assert table.num_rows == 0

--- a/tests/unit/test_frames_order_book.py
+++ b/tests/unit/test_frames_order_book.py
@@ -10,16 +10,20 @@ import pyarrow as pa
 
 from polymarket.frames import to_arrow, to_pandas, to_polars
 from polymarket.models import OrderBook
+from polymarket.pagination import Page
 
 
 def _make_book(
     bids: tuple[tuple[str, str], ...] = (("0.49", "100"), ("0.48", "50")),
     asks: tuple[tuple[str, str], ...] = (("0.51", "80"),),
+    *,
+    market: str = "0xfoo",
+    asset_id: str = "42",
 ) -> OrderBook:
     return OrderBook.model_validate(
         {
-            "market": "0xfoo",
-            "asset_id": "42",
+            "market": market,
+            "asset_id": asset_id,
             "timestamp": None,
             "bids": [{"price": p, "size": s} for p, s in bids],
             "asks": [{"price": p, "size": s} for p, s in asks],
@@ -112,3 +116,46 @@ def test_completely_empty_book_yields_empty_table() -> None:
     book = _make_book(bids=(), asks=())
     table = book.to_arrow()
     assert table.num_rows == 0
+
+
+def test_sequence_of_books_includes_identity_columns() -> None:
+    b1 = _make_book(market="0xaaa", asset_id="1")
+    b2 = _make_book(market="0xbbb", asset_id="2", asks=(("0.55", "40"),))
+    table = to_arrow((b1, b2))
+    assert table.column_names == ["market", "token_id", "side", "level", "price", "size"]
+    assert table.num_rows == 6
+    markets = table["market"].to_pylist()
+    assert markets.count("0xaaa") == 3
+    assert markets.count("0xbbb") == 3
+
+
+def test_single_book_in_list_still_includes_identity_columns() -> None:
+    df = to_pandas((_make_book(market="0xaaa", asset_id="1"),))
+    assert list(df.columns) == ["market", "token_id", "side", "level", "price", "size"]
+    assert (df["market"] == "0xaaa").all()
+
+
+def test_page_of_books_uses_sequence_shape() -> None:
+    page: Page[OrderBook] = Page(
+        items=(
+            _make_book(market="0xaaa", asset_id="1"),
+            _make_book(market="0xbbb", asset_id="2"),
+        ),
+        has_more=False,
+    )
+    df = page.to_pandas()
+    assert list(df.columns) == ["market", "token_id", "side", "level", "price", "size"]
+    assert set(df["market"]) == {"0xaaa", "0xbbb"}
+
+
+def test_polars_sequence_of_books() -> None:
+    b1 = _make_book(market="0xaaa", asset_id="1")
+    b2 = _make_book(market="0xbbb", asset_id="2")
+    df = to_polars((b1, b2))
+    assert df.columns == ["market", "token_id", "side", "level", "price", "size"]
+    assert df.shape == (6, 6)
+
+
+def test_single_book_scalar_call_keeps_compact_shape() -> None:
+    table = _make_book().to_arrow()
+    assert table.column_names == ["side", "level", "price", "size"]

--- a/tests/unit/test_frames_order_book.py
+++ b/tests/unit/test_frames_order_book.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pyarrow as pa
@@ -19,19 +20,21 @@ def _make_book(
     *,
     market: str = "0xfoo",
     asset_id: str = "42",
+    timestamp_ms: int | None = None,
+    book_hash: str = "abc",
 ) -> OrderBook:
     return OrderBook.model_validate(
         {
             "market": market,
             "asset_id": asset_id,
-            "timestamp": None,
+            "timestamp": str(timestamp_ms) if timestamp_ms is not None else None,
             "bids": [{"price": p, "size": s} for p, s in bids],
             "asks": [{"price": p, "size": s} for p, s in asks],
             "min_order_size": "5",
             "tick_size": "0.01",
             "neg_risk": True,
             "last_trade_price": "0.50",
-            "hash": "abc",
+            "hash": book_hash,
         }
     )
 
@@ -118,20 +121,47 @@ def test_completely_empty_book_yields_empty_table() -> None:
     assert table.num_rows == 0
 
 
+_SEQ_COLS = ["market", "token_id", "timestamp", "hash", "side", "level", "price", "size"]
+
+
 def test_sequence_of_books_includes_identity_columns() -> None:
-    b1 = _make_book(market="0xaaa", asset_id="1")
-    b2 = _make_book(market="0xbbb", asset_id="2", asks=(("0.55", "40"),))
+    b1 = _make_book(market="0xaaa", asset_id="1", book_hash="h1")
+    b2 = _make_book(market="0xbbb", asset_id="2", asks=(("0.55", "40"),), book_hash="h2")
     table = to_arrow((b1, b2))
-    assert table.column_names == ["market", "token_id", "side", "level", "price", "size"]
+    assert table.column_names == _SEQ_COLS
     assert table.num_rows == 6
     markets = table["market"].to_pylist()
     assert markets.count("0xaaa") == 3
     assert markets.count("0xbbb") == 3
 
 
+def test_repeated_snapshots_of_same_token_stay_distinguishable() -> None:
+    """Same market/token across two snapshots — timestamp + hash disambiguate rows."""
+    s1 = _make_book(market="0xaaa", asset_id="1", timestamp_ms=1_700_000_000_000, book_hash="h1")
+    s2 = _make_book(market="0xaaa", asset_id="1", timestamp_ms=1_700_000_060_000, book_hash="h2")
+    df = to_pandas((s1, s2))
+    assert set(df["hash"]) == {"h1", "h2"}
+    assert df["timestamp"].nunique() == 2
+
+
+def test_sequence_timestamp_can_be_null() -> None:
+    b = _make_book(market="0xaaa", asset_id="1", timestamp_ms=None)
+    df = to_pandas((b,))
+    assert bool(df["timestamp"].isna().all())
+
+
+def test_sequence_timestamp_arrow_type_is_utc_timestamp() -> None:
+    b = _make_book(market="0xaaa", asset_id="1", timestamp_ms=1_700_000_000_000)
+    schema = to_arrow((b,)).schema
+    ts_type = schema.field("timestamp").type
+    assert pa.types.is_timestamp(ts_type)
+    assert str(ts_type.tz) == "UTC"
+    assert to_arrow((b,))["timestamp"][0].as_py() == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+
+
 def test_single_book_in_list_still_includes_identity_columns() -> None:
     df = to_pandas((_make_book(market="0xaaa", asset_id="1"),))
-    assert list(df.columns) == ["market", "token_id", "side", "level", "price", "size"]
+    assert list(df.columns) == _SEQ_COLS
     assert (df["market"] == "0xaaa").all()
 
 
@@ -144,7 +174,7 @@ def test_page_of_books_uses_sequence_shape() -> None:
         has_more=False,
     )
     df = page.to_pandas()
-    assert list(df.columns) == ["market", "token_id", "side", "level", "price", "size"]
+    assert list(df.columns) == _SEQ_COLS
     assert set(df["market"]) == {"0xaaa", "0xbbb"}
 
 
@@ -152,8 +182,8 @@ def test_polars_sequence_of_books() -> None:
     b1 = _make_book(market="0xaaa", asset_id="1")
     b2 = _make_book(market="0xbbb", asset_id="2")
     df = to_polars((b1, b2))
-    assert df.columns == ["market", "token_id", "side", "level", "price", "size"]
-    assert df.shape == (6, 6)
+    assert df.columns == _SEQ_COLS
+    assert df.shape == (6, 8)
 
 
 def test_single_book_scalar_call_keeps_compact_shape() -> None:

--- a/tests/unit/test_frames_overrides.py
+++ b/tests/unit/test_frames_overrides.py
@@ -1,0 +1,85 @@
+"""Tests for the override registry."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from polymarket.frames._overrides import (
+    clear_overrides,
+    lookup_override,
+    register_override,
+    registered_types,
+)
+from polymarket.models import OrderBook
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_overrides():  # pyright: ignore[reportUnusedFunction] # noqa: ANN202
+    """The OrderBook built-in override is registered at import time; restore it after each test."""
+    import polymarket.frames._builtin_overrides  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    yield
+
+    clear_overrides()
+    import importlib
+
+    import polymarket.frames._builtin_overrides as bo
+
+    importlib.reload(bo)
+
+
+def test_register_and_lookup() -> None:
+    class _Custom:
+        pass
+
+    @register_override(_Custom)
+    def _convert(value: Any) -> pa.Table:
+        return pa.table({"marker": ["custom"]})
+
+    assert lookup_override(_Custom) is _convert
+    assert _Custom in registered_types()
+
+
+def test_lookup_walks_mro_so_subclasses_inherit() -> None:
+    class _Base:
+        pass
+
+    class _Sub(_Base):
+        pass
+
+    @register_override(_Base)
+    def _convert(value: Any) -> pa.Table:
+        return pa.table({"x": [1]})
+
+    assert lookup_override(_Sub) is _convert
+
+
+def test_lookup_returns_none_for_unregistered_type() -> None:
+    class _NotRegistered:
+        pass
+
+    assert lookup_override(_NotRegistered) is None
+
+
+def test_clear_overrides_removes_all() -> None:
+    class _Tmp:
+        pass
+
+    @register_override(_Tmp)
+    def _convert(value: Any) -> pa.Table:
+        return pa.table({})
+
+    assert lookup_override(_Tmp) is _convert
+    clear_overrides()
+    assert lookup_override(_Tmp) is None
+
+
+def test_orderbook_override_is_registered_by_default() -> None:
+    import polymarket.frames  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    assert lookup_override(OrderBook) is not None

--- a/tests/unit/test_frames_paginator.py
+++ b/tests/unit/test_frames_paginator.py
@@ -126,11 +126,12 @@ def test_paginator_limit_int_larger_than_available() -> None:
     assert "polymarket_truncated" not in df.attrs
 
 
-def test_paginator_limit_zero_returns_empty_dataframe() -> None:
-    paginator, _ = _three_page_sync()
+def test_paginator_limit_zero_returns_empty_dataframe_without_fetching() -> None:
+    paginator, fetched = _three_page_sync()
     df = paginator.to_pandas(limit=0)
     assert len(df) == 0
-    assert df.attrs.get("polymarket_truncated") is True
+    assert "polymarket_truncated" not in df.attrs
+    assert fetched == []
 
 
 def test_paginator_negative_limit_rejected() -> None:
@@ -222,6 +223,17 @@ def test_async_paginator_negative_limit_rejected() -> None:
         paginator, _ = _three_page_async()
         with pytest.raises(UserInputError, match="limit must be >= 0"):
             await paginator.to_pandas(limit=-5)
+
+    _run(go())
+
+
+def test_async_paginator_limit_zero_does_not_fetch() -> None:
+    async def go() -> None:
+        paginator, fetched = _three_page_async()
+        df = await paginator.to_pandas(limit=0)
+        assert len(df) == 0
+        assert "polymarket_truncated" not in df.attrs
+        assert fetched == []
 
     _run(go())
 

--- a/tests/unit/test_frames_paginator.py
+++ b/tests/unit/test_frames_paginator.py
@@ -126,6 +126,24 @@ def test_paginator_limit_int_larger_than_available() -> None:
     assert "polymarket_truncated" not in df.attrs
 
 
+def test_paginator_limit_at_page_boundary_does_not_fetch_extra_page() -> None:
+    """limit landing exactly on a full page that reports has_more=True
+    must read truncation from page metadata, not by fetching the next page."""
+    paginator, fetched = _three_page_sync()
+    df = paginator.to_pandas(limit=2)
+    assert len(df) == 2
+    assert df.attrs.get("polymarket_truncated") is True
+    assert fetched == [None, "p2"]
+
+
+def test_paginator_limit_at_first_page_boundary_fetches_only_one_page() -> None:
+    paginator, fetched = _three_page_sync()
+    df = paginator.to_pandas(limit=1)
+    assert len(df) == 1
+    assert df.attrs.get("polymarket_truncated") is True
+    assert fetched == [None]
+
+
 def test_paginator_limit_zero_returns_empty_dataframe_without_fetching() -> None:
     paginator, fetched = _three_page_sync()
     df = paginator.to_pandas(limit=0)
@@ -205,6 +223,17 @@ def test_async_paginator_limit_int_truncated() -> None:
         df = await paginator.to_pandas(limit=2)
         assert len(df) == 2
         assert df.attrs.get("polymarket_truncated") is True
+
+    _run(go())
+
+
+def test_async_paginator_limit_at_page_boundary_does_not_fetch_extra_page() -> None:
+    async def go() -> None:
+        paginator, fetched = _three_page_async()
+        df = await paginator.to_pandas(limit=1)
+        assert len(df) == 1
+        assert df.attrs.get("polymarket_truncated") is True
+        assert fetched == [None]
 
     _run(go())
 

--- a/tests/unit/test_frames_paginator.py
+++ b/tests/unit/test_frames_paginator.py
@@ -172,6 +172,20 @@ def test_paginator_to_arrow_limit_none() -> None:
     assert table.num_rows == 3
 
 
+def test_paginator_to_arrow_truncated_sets_schema_metadata() -> None:
+    paginator, _ = _three_page_sync()
+    table = paginator.to_arrow(limit=2)
+    md = table.schema.metadata or {}
+    assert md.get(b"polymarket_truncated") == b"true"
+
+
+def test_paginator_to_arrow_not_truncated_omits_metadata() -> None:
+    paginator, _ = _three_page_sync()
+    table = paginator.to_arrow(limit=None)
+    md = table.schema.metadata or {}
+    assert b"polymarket_truncated" not in md
+
+
 def _run(coro: Coroutine[Any, Any, object]) -> object:
     return asyncio.run(coro)
 
@@ -201,6 +215,16 @@ def test_async_paginator_limit_none_drains() -> None:
         df = await paginator.to_pandas(limit=None)
         assert len(df) == 3
         assert fetched == [None, "p2", "p3"]
+
+    _run(go())
+
+
+def test_async_paginator_to_arrow_truncated_sets_schema_metadata() -> None:
+    async def go() -> None:
+        paginator, _ = _three_page_async()
+        table = await paginator.to_arrow(limit=1)
+        md = table.schema.metadata or {}
+        assert md.get(b"polymarket_truncated") == b"true"
 
     _run(go())
 

--- a/tests/unit/test_frames_paginator.py
+++ b/tests/unit/test_frames_paginator.py
@@ -1,0 +1,256 @@
+"""Tests for the frame methods on Page / Paginator / AsyncPaginator."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from polymarket.errors import UserInputError
+from polymarket.pagination import AsyncPaginator, Page, Paginator
+
+
+class _Item(BaseModel):
+    n: int
+    v: Decimal
+
+
+def _three_page_sync() -> tuple[Paginator[_Item], list[str | None]]:
+    fetched: list[str | None] = []
+
+    def fetch(cursor: str | None) -> Page[_Item]:
+        fetched.append(cursor)
+        if cursor is None:
+            return Page(
+                items=(_Item(n=1, v=Decimal("0.1")),),
+                has_more=True,
+                next_cursor="p2",
+            )
+        if cursor == "p2":
+            return Page(
+                items=(_Item(n=2, v=Decimal("0.2")),),
+                has_more=True,
+                next_cursor="p3",
+            )
+        return Page(items=(_Item(n=3, v=Decimal("0.3")),), has_more=False)
+
+    return Paginator(fetch=fetch), fetched
+
+
+def _three_page_async() -> tuple[AsyncPaginator[_Item], list[str | None]]:
+    fetched: list[str | None] = []
+
+    async def fetch(cursor: str | None) -> Page[_Item]:
+        fetched.append(cursor)
+        if cursor is None:
+            return Page(
+                items=(_Item(n=1, v=Decimal("0.1")),),
+                has_more=True,
+                next_cursor="p2",
+            )
+        if cursor == "p2":
+            return Page(
+                items=(_Item(n=2, v=Decimal("0.2")),),
+                has_more=True,
+                next_cursor="p3",
+            )
+        return Page(items=(_Item(n=3, v=Decimal("0.3")),), has_more=False)
+
+    return AsyncPaginator(fetch=fetch), fetched
+
+
+def test_page_to_pandas() -> None:
+    page: Page[_Item] = Page(
+        items=(_Item(n=1, v=Decimal("0.1")), _Item(n=2, v=Decimal("0.2"))),
+        has_more=False,
+    )
+    df = page.to_pandas()
+    assert len(df) == 2
+    assert list(df.columns) == ["n", "v"]
+
+
+def test_page_to_polars() -> None:
+    page: Page[_Item] = Page(items=(_Item(n=1, v=Decimal("0.1")),), has_more=False)
+    df = page.to_polars()
+    assert df.shape == (1, 2)
+
+
+def test_page_to_arrow() -> None:
+    page: Page[_Item] = Page(items=(_Item(n=1, v=Decimal("0.1")),), has_more=False)
+    table = page.to_arrow()
+    assert table.num_rows == 1
+
+
+def test_paginator_to_pandas_without_limit_raises_typeerror() -> None:
+    paginator, _ = _three_page_sync()
+    with pytest.raises(TypeError, match="missing.*required.*keyword.*argument.*limit"):
+        paginator.to_pandas()  # type: ignore[call-arg]
+
+
+def test_paginator_to_polars_without_limit_raises_typeerror() -> None:
+    paginator, _ = _three_page_sync()
+    with pytest.raises(TypeError, match="missing.*required.*keyword.*argument.*limit"):
+        paginator.to_polars()  # type: ignore[call-arg]
+
+
+def test_paginator_to_arrow_without_limit_raises_typeerror() -> None:
+    paginator, _ = _three_page_sync()
+    with pytest.raises(TypeError, match="missing.*required.*keyword.*argument.*limit"):
+        paginator.to_arrow()  # type: ignore[call-arg]
+
+
+def test_paginator_limit_int_bounded_sets_truncated_marker() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_pandas(limit=2)
+    assert len(df) == 2
+    assert df.attrs.get("polymarket_truncated") is True
+
+
+def test_paginator_limit_int_exact_no_truncation_marker() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_pandas(limit=3)
+    assert len(df) == 3
+    assert "polymarket_truncated" not in df.attrs
+
+
+def test_paginator_limit_int_larger_than_available() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_pandas(limit=100)
+    assert len(df) == 3
+    assert "polymarket_truncated" not in df.attrs
+
+
+def test_paginator_limit_zero_returns_empty_dataframe() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_pandas(limit=0)
+    assert len(df) == 0
+    assert df.attrs.get("polymarket_truncated") is True
+
+
+def test_paginator_negative_limit_rejected() -> None:
+    paginator, _ = _three_page_sync()
+    with pytest.raises(UserInputError, match="limit must be >= 0"):
+        paginator.to_pandas(limit=-1)
+
+
+def test_paginator_limit_none_drains_all() -> None:
+    paginator, fetched = _three_page_sync()
+    df = paginator.to_pandas(limit=None)
+    assert len(df) == 3
+    assert "polymarket_truncated" not in df.attrs
+    assert fetched == [None, "p2", "p3"]
+
+
+def test_paginator_to_polars_limit_int() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_polars(limit=2)
+    assert df.shape == (2, 2)
+
+
+def test_paginator_to_polars_limit_none() -> None:
+    paginator, _ = _three_page_sync()
+    df = paginator.to_polars(limit=None)
+    assert df.shape == (3, 2)
+
+
+def test_paginator_to_arrow_limit_int() -> None:
+    paginator, _ = _three_page_sync()
+    table = paginator.to_arrow(limit=1)
+    assert table.num_rows == 1
+
+
+def test_paginator_to_arrow_limit_none() -> None:
+    paginator, _ = _three_page_sync()
+    table = paginator.to_arrow(limit=None)
+    assert table.num_rows == 3
+
+
+def _run(coro: Coroutine[Any, Any, object]) -> object:
+    return asyncio.run(coro)
+
+
+def test_async_paginator_without_limit_raises_typeerror() -> None:
+    async def go() -> None:
+        paginator, _ = _three_page_async()
+        with pytest.raises(TypeError, match="missing.*required.*keyword.*argument.*limit"):
+            await paginator.to_pandas()  # type: ignore[call-arg]
+
+    _run(go())
+
+
+def test_async_paginator_limit_int_truncated() -> None:
+    async def go() -> None:
+        paginator, _ = _three_page_async()
+        df = await paginator.to_pandas(limit=2)
+        assert len(df) == 2
+        assert df.attrs.get("polymarket_truncated") is True
+
+    _run(go())
+
+
+def test_async_paginator_limit_none_drains() -> None:
+    async def go() -> None:
+        paginator, fetched = _three_page_async()
+        df = await paginator.to_pandas(limit=None)
+        assert len(df) == 3
+        assert fetched == [None, "p2", "p3"]
+
+    _run(go())
+
+
+def test_async_paginator_to_polars_and_arrow() -> None:
+    async def go() -> None:
+        paginator, _ = _three_page_async()
+        polars_df = await paginator.to_polars(limit=None)
+        assert polars_df.shape == (3, 2)
+
+        paginator2, _ = _three_page_async()
+        arrow_table = await paginator2.to_arrow(limit=None)
+        assert arrow_table.num_rows == 3
+
+    _run(go())
+
+
+def test_async_paginator_negative_limit_rejected() -> None:
+    async def go() -> None:
+        paginator, _ = _three_page_async()
+        with pytest.raises(UserInputError, match="limit must be >= 0"):
+            await paginator.to_pandas(limit=-5)
+
+    _run(go())
+
+
+def test_async_paginator_handles_cancellation_during_drain() -> None:
+    drained: list[int] = []
+
+    async def slow_fetch(cursor: str | None) -> Page[_Item]:
+        if cursor is None:
+            return Page(
+                items=(_Item(n=1, v=Decimal("0.1")),),
+                has_more=True,
+                next_cursor="p2",
+            )
+        await asyncio.sleep(10)
+        return Page(items=(), has_more=False)
+
+    async def go() -> None:
+        paginator: AsyncPaginator[_Item] = AsyncPaginator(fetch=slow_fetch)
+
+        async def drain() -> None:
+            df = await paginator.to_pandas(limit=None)
+            drained.append(len(df))
+
+        task = asyncio.create_task(drain())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert drained == []
+
+    _run(go())

--- a/tests/unit/test_frames_pandas.py
+++ b/tests/unit/test_frames_pandas.py
@@ -1,0 +1,90 @@
+"""Tests for the pandas adapter."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+from pydantic import BaseModel
+
+from polymarket.frames import to_pandas
+
+
+class _Trade(BaseModel):
+    id: str
+    price: Decimal
+    size: Decimal
+
+
+class _WithList(BaseModel):
+    id: str
+    children: tuple[dict[str, Decimal], ...] = ()
+
+
+def test_default_decimal_mode_preserves_precision() -> None:
+    trades = (
+        _Trade(id="t1", price=Decimal("0.123456789012345678"), size=Decimal("1")),
+        _Trade(id="t2", price=Decimal("0.987654321098765432"), size=Decimal("2")),
+    )
+    df = to_pandas(trades)
+    assert isinstance(df["price"].dtype, pd.ArrowDtype)
+    assert pa.types.is_decimal(df["price"].dtype.pyarrow_dtype)
+    assert df["price"][0] == Decimal("0.123456789012345678")
+    assert df["price"][1] == Decimal("0.987654321098765432")
+
+
+def test_float_decimal_mode_casts_to_float64() -> None:
+    trades = (_Trade(id="t1", price=Decimal("0.5"), size=Decimal("100")),)
+    df = to_pandas(trades, decimal="float")
+    assert df["price"].dtype == "float64"
+    assert df["size"].dtype == "float64"
+    assert df["price"][0] == pytest.approx(0.5)
+
+
+def test_float_mode_loses_precision_predictably() -> None:
+    """float64 holds ~15-17 sig digits, so opt-in precision loss is the whole point."""
+    high_precision = Decimal("0.123456789012345678")
+    trade = _Trade(id="t", price=high_precision, size=Decimal("1"))
+    df = to_pandas(trade, decimal="float")
+    assert df["price"][0] != float(high_precision) or float(high_precision) != float(
+        str(high_precision)
+    )
+
+
+def test_invalid_decimal_mode_raises_typeerror() -> None:
+    with pytest.raises(TypeError, match="decimal must be"):
+        to_pandas(_Trade(id="t", price=Decimal("1"), size=Decimal("1")), decimal="wrong")  # type: ignore[arg-type]
+
+
+def test_single_model_yields_one_row() -> None:
+    m = _Trade(id="t", price=Decimal("0.5"), size=Decimal("100"))
+    df = to_pandas(m)
+    assert len(df) == 1
+    assert list(df.columns) == ["id", "price", "size"]
+
+
+def test_empty_tuple_yields_empty_dataframe() -> None:
+    df = to_pandas(())
+    assert len(df) == 0
+
+
+def test_explode_row_multiplies_list_columns() -> None:
+    items = (
+        _WithList(
+            id="parent",
+            children=({"v": Decimal("1")}, {"v": Decimal("2")}, {"v": Decimal("3")}),
+        ),
+    )
+    df = to_pandas(items, explode=["children"])
+    assert len(df) == 3
+    assert all(df["id"] == "parent")
+
+
+def test_explode_unknown_column_raises_keyerror() -> None:
+    df_input = (_Trade(id="t", price=Decimal("0.5"), size=Decimal("100")),)
+    with pytest.raises(KeyError):
+        to_pandas(df_input, explode=["does_not_exist"])

--- a/tests/unit/test_frames_polars.py
+++ b/tests/unit/test_frames_polars.py
@@ -1,0 +1,97 @@
+"""Tests for the polars adapter."""
+
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+import pytest
+from pydantic import BaseModel
+
+from polymarket.frames import to_polars
+
+
+class _Trade(BaseModel):
+    id: str
+    price: Decimal
+    size: Decimal
+
+
+class _WithList(BaseModel):
+    id: str
+    children: tuple[dict[str, Decimal], ...] = ()
+
+
+def test_single_model_yields_one_row() -> None:
+    m = _Trade(id="t", price=Decimal("0.5"), size=Decimal("100"))
+    df = to_polars(m)
+    assert df.shape == (1, 3)
+    assert df.columns == ["id", "price", "size"]
+
+
+def test_native_decimal_dtype_preserves_precision() -> None:
+    high_precision = Decimal("0.123456789012345678")
+    trades = (
+        _Trade(id="t1", price=high_precision, size=Decimal("1")),
+        _Trade(id="t2", price=Decimal("0.987654321098765432"), size=Decimal("2")),
+    )
+    df = to_polars(trades)
+    assert isinstance(df["price"].dtype, pl.Decimal)
+    assert df["price"][0] == high_precision
+
+
+def test_tuple_of_models_yields_n_rows() -> None:
+    trades = tuple(_Trade(id=f"t{i}", price=Decimal(f"0.{i}"), size=Decimal("1")) for i in range(5))
+    df = to_polars(trades)
+    assert df.shape == (5, 3)
+
+
+def test_empty_tuple_yields_empty_dataframe() -> None:
+    df = to_polars(())
+    assert df.shape == (0, 0)
+
+
+def test_explode_row_multiplies_list_columns() -> None:
+    items = (
+        _WithList(
+            id="parent",
+            children=({"v": Decimal("1")}, {"v": Decimal("2")}),
+        ),
+    )
+    df = to_polars(items, explode=["children"])
+    assert df.shape == (2, 2)
+
+
+def test_explode_unknown_column_raises() -> None:
+    df_input = (_Trade(id="t", price=Decimal("0.5"), size=Decimal("100")),)
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        to_polars(df_input, explode=["nope"])
+
+
+def test_decimal256_column_raises_clean_error_not_rust_panic() -> None:
+    """Regression: ``pl.from_arrow`` panics in Rust on decimal256; the SDK should TypeError."""
+    from pydantic import BaseModel
+
+    class _Big(BaseModel):
+        v: Decimal
+
+    big = Decimal("123456789012345678901234567890123456789")
+    with pytest.raises(TypeError, match=r"decimal256"):
+        to_polars((_Big(v=big),))
+
+
+def test_decimal256_nested_in_struct_also_caught() -> None:
+    from pydantic import BaseModel
+
+    class _Inner(BaseModel):
+        v: Decimal
+
+    class _Outer(BaseModel):
+        id: str
+        inner: _Inner
+
+    big = Decimal("123456789012345678901234567890123456789")
+    with pytest.raises(TypeError, match=r"decimal256"):
+        to_polars((_Outer(id="x", inner=_Inner(v=big)),))

--- a/tests/unit/test_paginate_transport.py
+++ b/tests/unit/test_paginate_transport.py
@@ -164,7 +164,7 @@ def test_sync_paginate_offset_round_trip_next_cursor() -> None:
         _install_sync_data_transport(client, handler)
         spec = _spec(base_params={"user": "0xA"})
         paginator = sync_paginate_offset(client._ctx, spec, page_size=10)
-        all_items = list(paginator.items())
+        all_items = list(paginator.iter_items())
 
     assert all_items == list(range(13))
     assert len(captured) == 2

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -308,13 +308,20 @@ def test_paginator_is_reusable() -> None:
     assert fetch_count[0] == 2
 
 
-def test_paginator_items_flattens_pages() -> None:
+def test_paginator_iter_items_flattens_pages() -> None:
     pages = [
         Page(items=(1, 2), has_more=True, next_cursor="c1"),
         Page(items=(3, 4), has_more=False),
     ]
     paginator = Paginator[int](fetch=lambda cursor: pages[0] if cursor is None else pages[1])
-    assert list(paginator.items()) == [1, 2, 3, 4]
+    assert list(paginator.iter_items()) == [1, 2, 3, 4]
+
+
+def test_paginator_items_alias_matches_iter_items() -> None:
+    """``items()`` is a back-compat alias; behaviour must match ``iter_items()``."""
+    pages = [Page(items=(1, 2), has_more=False)]
+    paginator = Paginator[int](fetch=lambda _c: pages[0])
+    assert list(paginator.items()) == list(paginator.iter_items())
 
 
 def test_paginator_from_cursor_returns_new_paginator() -> None:
@@ -378,7 +385,7 @@ def test_async_paginator_raises_when_has_more_without_cursor() -> None:
         asyncio.run(run())
 
 
-def test_async_paginator_items_flattens_pages() -> None:
+def test_async_paginator_iter_items_flattens_pages() -> None:
     pages = [
         Page(items=(1, 2), has_more=True, next_cursor="c1"),
         Page(items=(3, 4), has_more=False),
@@ -390,11 +397,27 @@ def test_async_paginator_items_flattens_pages() -> None:
     async def run() -> list[int]:
         paginator = AsyncPaginator[int](fetch=fetch)
         collected: list[int] = []
-        async for item in paginator.items():
+        async for item in paginator.iter_items():
             collected.append(item)
         return collected
 
     assert asyncio.run(run()) == [1, 2, 3, 4]
+
+
+def test_async_paginator_items_alias_still_works() -> None:
+    pages = [Page(items=(1, 2), has_more=False)]
+
+    async def fetch(_cursor: str | None) -> Page[int]:
+        return pages[0]
+
+    async def run() -> list[int]:
+        paginator = AsyncPaginator[int](fetch=fetch)
+        collected: list[int] = []
+        async for item in paginator.items():
+            collected.append(item)
+        return collected
+
+    assert asyncio.run(run()) == [1, 2]
 
 
 def test_async_paginator_from_cursor_none_yields_empty() -> None:

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -397,8 +397,6 @@ def test_async_paginator_iter_items_flattens_pages() -> None:
     assert asyncio.run(run()) == [1, 2, 3, 4]
 
 
-
-
 def test_async_paginator_from_cursor_none_yields_empty() -> None:
     fetch_count = [0]
 

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -317,13 +317,6 @@ def test_paginator_iter_items_flattens_pages() -> None:
     assert list(paginator.iter_items()) == [1, 2, 3, 4]
 
 
-def test_paginator_items_alias_matches_iter_items() -> None:
-    """``items()`` is a back-compat alias; behaviour must match ``iter_items()``."""
-    pages = [Page(items=(1, 2), has_more=False)]
-    paginator = Paginator[int](fetch=lambda _c: pages[0])
-    assert list(paginator.items()) == list(paginator.iter_items())
-
-
 def test_paginator_from_cursor_returns_new_paginator() -> None:
     seen: list[str | None] = []
 
@@ -404,20 +397,6 @@ def test_async_paginator_iter_items_flattens_pages() -> None:
     assert asyncio.run(run()) == [1, 2, 3, 4]
 
 
-def test_async_paginator_items_alias_still_works() -> None:
-    pages = [Page(items=(1, 2), has_more=False)]
-
-    async def fetch(_cursor: str | None) -> Page[int]:
-        return pages[0]
-
-    async def run() -> list[int]:
-        paginator = AsyncPaginator[int](fetch=fetch)
-        collected: list[int] = []
-        async for item in paginator.items():
-            collected.append(item)
-        return collected
-
-    assert asyncio.run(run()) == [1, 2]
 
 
 def test_async_paginator_from_cursor_none_yields_empty() -> None:

--- a/tests/unit/test_secure_account_sync.py
+++ b/tests/unit/test_secure_account_sync.py
@@ -135,7 +135,7 @@ def test_list_open_orders_paginates_until_end_cursor() -> None:
 
     with _make_client() as client:
         _install_secure_clob(client, httpx.MockTransport(handler))
-        ids = [order.id for order in client.list_open_orders(market="0xMARKET").items()]
+        ids = [order.id for order in client.list_open_orders(market="0xMARKET").iter_items()]
 
     assert ids == ["order-1", "order-2"]
     assert len(captured) == 2
@@ -176,7 +176,9 @@ def test_list_account_trades_paginates_and_passes_filters() -> None:
         _install_secure_clob(client, httpx.MockTransport(handler))
         trades = [
             t.id
-            for t in client.list_account_trades(market="0xMARKET", maker_address="0xMAKER").items()
+            for t in client.list_account_trades(
+                market="0xMARKET", maker_address="0xMAKER"
+            ).iter_items()
         ]
 
     assert trades == ["trade-1"]

--- a/tests/unit/test_secure_rewards_sync.py
+++ b/tests/unit/test_secure_rewards_sync.py
@@ -90,7 +90,7 @@ def test_list_user_earnings_for_day_passes_signature_type_and_date() -> None:
 
     with _make_client() as client:
         _install_secure_clob(client, _capture(captured, 200, page_payload))
-        earnings = list(client.list_user_earnings_for_day(date="2026-01-01").items())
+        earnings = list(client.list_user_earnings_for_day(date="2026-01-01").iter_items())
 
     assert len(earnings) == 1
     request = captured[0]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -633,12 +637,145 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]
@@ -663,6 +800,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
+]
+
+[[package]]
 name = "polymarket-client"
 version = "0.1.0b3"
 source = { editable = "." }
@@ -675,8 +840,29 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+arrow = [
+    { name = "pyarrow" },
+]
+pandas = [
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+polars = [
+    { name = "polars" },
+    { name = "pyarrow" },
+]
+quant = [
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -692,12 +878,24 @@ requires-dist = [
     { name = "eth-account", specifier = ">=0.13,<1" },
     { name = "eth-utils", specifier = ">=4,<6" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27,<1" },
+    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2,<3" },
+    { name = "pandas", marker = "extra == 'quant'", specifier = ">=2,<3" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1,<2" },
+    { name = "polars", marker = "extra == 'quant'", specifier = ">=1,<2" },
+    { name = "pyarrow", marker = "extra == 'arrow'", specifier = ">=15,<22" },
+    { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=15,<22" },
+    { name = "pyarrow", marker = "extra == 'polars'", specifier = ">=15,<22" },
+    { name = "pyarrow", marker = "extra == 'quant'", specifier = ">=15,<22" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "websockets", specifier = ">=13,<16" },
 ]
+provides-extras = ["arrow", "pandas", "polars", "quant"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pandas", specifier = ">=2,<3" },
+    { name = "polars", specifier = ">=1,<2" },
+    { name = "pyarrow", specifier = ">=15,<22" },
     { name = "pyright", specifier = ">=1.1,<2" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=6,<7" },
@@ -705,6 +903,42 @@ dev = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "respx", specifier = ">=0.22,<1" },
     { name = "ruff", specifier = ">=0.11,<1" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", size = 1133487, upload-time = "2025-07-18T00:57:31.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/dc/80564a3071a57c20b7c32575e4a0120e8a330ef487c319b122942d665960/pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b", size = 31243234, upload-time = "2025-07-18T00:55:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/cc/3b51cb2db26fe535d14f74cab4c79b191ed9a8cd4cbba45e2379b5ca2746/pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10", size = 32714370, upload-time = "2025-07-18T00:55:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/a4431f36d5ad7d83b87146f515c063e4d07ef0b7240876ddb885e6b44f2e/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e", size = 41135424, upload-time = "2025-07-18T00:55:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/74/dc/035d54638fc5d2971cbf1e987ccd45f1091c83bcf747281cf6cc25e72c88/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569", size = 42823810, upload-time = "2025-07-18T00:55:16.301Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3b/89fced102448a9e3e0d4dded1f37fa3ce4700f02cdb8665457fcc8015f5b/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e", size = 43391538, upload-time = "2025-07-18T00:55:23.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/ea7f1bd08978d39debd3b23611c293f64a642557e8141c80635d501e6d53/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c", size = 45120056, upload-time = "2025-07-18T00:55:28.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0b/77ea0600009842b30ceebc3337639a7380cd946061b620ac1a2f3cb541e2/pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6", size = 26220568, upload-time = "2025-07-18T00:55:32.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d4/d4f817b21aacc30195cf6a46ba041dd1be827efa4a623cc8bf39a1c2a0c0/pyarrow-21.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd", size = 31160305, upload-time = "2025-07-18T00:55:35.373Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9c/dcd38ce6e4b4d9a19e1d36914cb8e2b1da4e6003dd075474c4cfcdfe0601/pyarrow-21.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876", size = 32684264, upload-time = "2025-07-18T00:55:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/2a2d9f8d7a59b639523454bec12dba35ae3d0a07d8ab529dc0809f74b23c/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d", size = 41108099, upload-time = "2025-07-18T00:55:42.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/90/2660332eeb31303c13b653ea566a9918484b6e4d6b9d2d46879a33ab0622/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e", size = 42829529, upload-time = "2025-07-18T00:55:47.069Z" },
+    { url = "https://files.pythonhosted.org/packages/33/27/1a93a25c92717f6aa0fca06eb4700860577d016cd3ae51aad0e0488ac899/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82", size = 43367883, upload-time = "2025-07-18T00:55:53.069Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d9/4d09d919f35d599bc05c6950095e358c3e15148ead26292dfca1fb659b0c/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623", size = 45133802, upload-time = "2025-07-18T00:55:57.714Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/f3795b6e192c3ab881325ffe172e526499eb3780e306a15103a2764916a2/pyarrow-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18", size = 26203175, upload-time = "2025-07-18T00:56:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ca/c7eaa8e62db8fb37ce942b1ea0c6d7abfe3786ca193957afa25e71b81b66/pyarrow-21.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e99310a4ebd4479bcd1964dff9e14af33746300cb014aa4a3781738ac63baf4a", size = 31154306, upload-time = "2025-07-18T00:56:04.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e8/e87d9e3b2489302b3a1aea709aaca4b781c5252fcb812a17ab6275a9a484/pyarrow-21.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d2fe8e7f3ce329a71b7ddd7498b3cfac0eeb200c2789bd840234f0dc271a8efe", size = 32680622, upload-time = "2025-07-18T00:56:07.505Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/79095d73a742aa0aba370c7942b1b655f598069489ab387fe47261a849e1/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f522e5709379d72fb3da7785aa489ff0bb87448a9dc5a75f45763a795a089ebd", size = 41104094, upload-time = "2025-07-18T00:56:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4b/7782438b551dbb0468892a276b8c789b8bbdb25ea5c5eb27faadd753e037/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:69cbbdf0631396e9925e048cfa5bce4e8c3d3b41562bbd70c685a8eb53a91e61", size = 42825576, upload-time = "2025-07-18T00:56:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/62/0f29de6e0a1e33518dec92c65be0351d32d7ca351e51ec5f4f837a9aab91/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:731c7022587006b755d0bdb27626a1a3bb004bb56b11fb30d98b6c1b4718579d", size = 43368342, upload-time = "2025-07-18T00:56:19.531Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c7/0fa1f3f29cf75f339768cc698c8ad4ddd2481c1742e9741459911c9ac477/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc56bc708f2d8ac71bd1dcb927e458c93cec10b98eb4120206a4091db7b67b99", size = 45131218, upload-time = "2025-07-18T00:56:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/01/63/581f2076465e67b23bc5a37d4a2abff8362d389d29d8105832e82c9c811c/pyarrow-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:186aa00bca62139f75b7de8420f745f2af12941595bbbfa7ed3870ff63e25636", size = 26087551, upload-time = "2025-07-18T00:56:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/357d0d9648bb8241ee7348e564f2479d206ebe6e1c47ac5027c2e31ecd39/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:a7a102574faa3f421141a64c10216e078df467ab9576684d5cd696952546e2da", size = 31290064, upload-time = "2025-07-18T00:56:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8a/5685d62a990e4cac2043fc76b4661bf38d06efed55cf45a334b455bd2759/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:1e005378c4a2c6db3ada3ad4c217b381f6c886f0a80d6a316fe586b90f77efd7", size = 32727837, upload-time = "2025-07-18T00:56:33.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/de/c0828ee09525c2bafefd3e736a248ebe764d07d0fd762d4f0929dbc516c9/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65f8e85f79031449ec8706b74504a316805217b35b6099155dd7e227eef0d4b6", size = 41014158, upload-time = "2025-07-18T00:56:37.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/26/a2865c420c50b7a3748320b614f3484bfcde8347b2639b2b903b21ce6a72/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3a81486adc665c7eb1a2bde0224cfca6ceaba344a82a971ef059678417880eb8", size = 42667885, upload-time = "2025-07-18T00:56:41.483Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f9/4ee798dc902533159250fb4321267730bc0a107d8c6889e07c3add4fe3a5/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503", size = 43276625, upload-time = "2025-07-18T00:56:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/da/e02544d6997037a4b0d22d8e5f66bc9315c3671371a8b18c79ade1cefe14/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79", size = 44951890, upload-time = "2025-07-18T00:56:52.568Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4e/519c1bc1876625fe6b71e9a28287c43ec2f20f73c658b9ae1d485c0c206e/pyarrow-21.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10", size = 26371006, upload-time = "2025-07-18T00:56:56.379Z" },
 ]
 
 [[package]]
@@ -919,12 +1153,33 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -1081,6 +1336,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1426,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renaming `items()` to `iter_items()` is a breaking change for pagination consumers; paginator frame drains also affect how much data is fetched from the API when `limit` is set.
> 
> **Overview**
> Adds **`polymarket.frames`** so SDK models, `Page`, and bounded paginator drains can export to **PyArrow**, **pandas**, or **polars** via `to_arrow` / `to_pandas` / `to_polars`, with optional extras (`[arrow]`, `[pandas]`, `[polars]`, `[quant]`) and `MissingOptionalDependencyError` when deps are missing.
> 
> **`OrderBook`** gets a built-in flatten override (per-level bid/ask rows; identity columns when converting sequences). **`Page`**, **`Paginator`**, and **`AsyncPaginator`** expose the same frame helpers; paginator methods require an explicit **`limit`** (drain all with `None`) and set truncation markers on Arrow schema metadata / pandas `attrs` when capped.
> 
> **Breaking:** paginator flat iteration is renamed from **`items()`** to **`iter_items()`** (docs and tests updated). Core pagination types no longer accept a bare `Paginator` in `to_arrow()`—callers must use **`paginator.to_* (limit=...)`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff38c8f3c05177b8a1673fcdf3dc8a81f7638970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->