### PR TITLE
fix(gamma): default list_events to open events

### DIFF
--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -364,7 +364,7 @@ __all__ = [
 def list_events_spec(
     *,
     ascending: bool | None = None,
-    closed: bool | None = None,
+    closed: bool = False,
     cyom: bool | None = None,
     end_date_max: TimestampFilter | None = None,
     end_date_min: TimestampFilter | None = None,

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -696,7 +696,7 @@ class AsyncPublicClient:
         self,
         *,
         ascending: bool | None = None,
-        closed: bool | None = None,
+        closed: bool = False,
         cyom: bool | None = None,
         end_date_max: TimestampFilter | None = None,
         end_date_min: TimestampFilter | None = None,
@@ -736,6 +736,8 @@ class AsyncPublicClient:
         page_size: int = 20,
     ) -> AsyncPaginator[Event]:
         """List events.
+
+        Defaults to open events. Pass ``closed=True`` to list settled events.
 
         Returns:
             An async paginator over matching events.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1026,7 +1026,7 @@ class AsyncSecureClient:
         self,
         *,
         ascending: bool | None = None,
-        closed: bool | None = None,
+        closed: bool = False,
         cyom: bool | None = None,
         end_date_max: TimestampFilter | None = None,
         end_date_min: TimestampFilter | None = None,
@@ -1066,6 +1066,8 @@ class AsyncSecureClient:
         page_size: int = 20,
     ) -> AsyncPaginator[Event]:
         """List events.
+
+        Defaults to open events. Pass ``closed=True`` to list settled events.
 
         Returns:
             An async paginator over matching events.

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -540,7 +540,7 @@ class PublicClient:
         self,
         *,
         ascending: bool | None = None,
-        closed: bool | None = None,
+        closed: bool = False,
         cyom: bool | None = None,
         end_date_max: TimestampFilter | None = None,
         end_date_min: TimestampFilter | None = None,
@@ -580,6 +580,8 @@ class PublicClient:
         page_size: int = 20,
     ) -> Paginator[Event]:
         """List events.
+
+        Defaults to open events. Pass ``closed=True`` to list settled events.
 
         Returns:
             A paginator over matching events.

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -858,7 +858,7 @@ class SecureClient:
         self,
         *,
         ascending: bool | None = None,
-        closed: bool | None = None,
+        closed: bool = False,
         cyom: bool | None = None,
         end_date_max: TimestampFilter | None = None,
         end_date_min: TimestampFilter | None = None,
@@ -898,6 +898,8 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[Event]:
         """List events.
+
+        Defaults to open events. Pass ``closed=True`` to list settled events.
 
         Returns:
             A paginator over matching events.

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -9,13 +9,13 @@ from polymarket._internal.request import (
 from polymarket.errors import UserInputError
 
 
-def test_list_events_spec_default_has_no_params() -> None:
+def test_list_events_spec_defaults_to_open_events() -> None:
     spec = gamma_actions.list_events_spec()
 
     assert isinstance(spec, KeysetPaginatedSpec)
     assert spec.service == "gamma"
     assert spec.path == "/events/keyset"
-    assert spec.base_params is None
+    assert spec.base_params == {"closed": False}
 
 
 def test_list_events_spec_collects_filter_params() -> None:
@@ -44,7 +44,7 @@ def test_list_events_spec_rejects_invalid_tag_match() -> None:
 def test_list_events_spec_omits_empty_sequences() -> None:
     spec = gamma_actions.list_events_spec(ids=[])
 
-    assert spec.base_params is None
+    assert spec.base_params == {"closed": False}
 
 
 def test_list_markets_spec_default_has_no_params() -> None:
@@ -206,7 +206,7 @@ def test_list_markets_spec_accepts_list_of_slugs() -> None:
 def test_list_events_spec_treats_bare_int_id_as_single_item() -> None:
     spec = gamma_actions.list_events_spec(ids=10)
 
-    assert spec.base_params == {"id": (10,)}
+    assert spec.base_params == {"closed": False, "id": (10,)}
 
 
 def test_list_events_spec_rejects_bytes_param() -> None:


### PR DESCRIPTION
## Summary
- default `list_events` requests to `closed=False` when callers omit `closed`
- document the default on sync/async public and secure clients
- update existing gamma request-construction expectations

Fixes #59
Linear: DEV-170

## Verification
- uv run pytest tests/unit/test_gamma_paginated_specs.py tests/unit/test_date_filter_params.py
- make lint
- make format-check
- make typecheck
- make test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default query filter is a behavioral breaking change for integrations that previously omitted `closed` and received unfiltered event lists.
> 
> **Overview**
> **`list_events`** now defaults to **open events** by sending `closed=False` on Gamma `/events/keyset` requests when callers do not override the flag. The `closed` parameter changes from optional (`None`, omitted from query) to **`closed: bool = False`** in `list_events_spec` and on sync/async **public** and **secure** clients.
> 
> Client docstrings note that **`closed=True`** is required to list settled events. Unit tests in `test_gamma_paginated_specs.py` expect `base_params` to always include `{"closed": False}` for default and partial filter specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d92d4f0d11d8ef6af901bbaea0c145082cc712c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->