### PR TITLE
fix(orders): map unknown builder code to user input error

### DIFF
--- a/src/polymarket/_internal/actions/orders/market_data.py
+++ b/src/polymarket/_internal/actions/orders/market_data.py
@@ -5,7 +5,7 @@ from typing import cast
 from polymarket._internal.actions.orders.types import BYTES32_ZERO
 from polymarket._internal.context import AsyncClientContext, SyncClientContext
 from polymarket._internal.validation import require_nonempty, validate_builder_code
-from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.errors import RequestRejectedError, UnexpectedResponseError, UserInputError
 from polymarket.models.clob.builder import BuilderFeeRates
 from polymarket.models.types import ConditionId, TokenId
 
@@ -78,7 +78,12 @@ async def fetch_builder_fee_rates(ctx: AsyncClientContext, *, builder_code: str)
         raise UserInputError(
             "builder_code must be a real builder; zero (0x000…000) represents no attribution."
         )
-    data = await ctx.clob.get_json(f"/fees/builder-fees/{validated}")
+    try:
+        data = await ctx.clob.get_json(f"/fees/builder-fees/{validated}")
+    except RequestRejectedError as error:
+        if error.status == 404:
+            raise UserInputError(f"Unknown builder code: {validated}") from error
+        raise
     return BuilderFeeRates.parse_response(data)
 
 
@@ -88,7 +93,12 @@ def fetch_builder_fee_rates_sync(ctx: SyncClientContext, *, builder_code: str) -
         raise UserInputError(
             "builder_code must be a real builder; zero (0x000…000) represents no attribution."
         )
-    data = ctx.clob.get_json(f"/fees/builder-fees/{validated}")
+    try:
+        data = ctx.clob.get_json(f"/fees/builder-fees/{validated}")
+    except RequestRejectedError as error:
+        if error.status == 404:
+            raise UserInputError(f"Unknown builder code: {validated}") from error
+        raise
     return BuilderFeeRates.parse_response(data)
 
 

--- a/tests/integration/test_clob_orders.py
+++ b/tests/integration/test_clob_orders.py
@@ -11,9 +11,10 @@ from polymarket import (
     Market,
     Position,
 )
-from polymarket.errors import InsufficientLiquidityError
+from polymarket.errors import InsufficientLiquidityError, UserInputError
 
 pytestmark = pytest.mark.anyio
+UNKNOWN_BUILDER_CODE = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
 
 
 def _minimum_order_size(market: Market) -> Decimal:
@@ -131,6 +132,23 @@ async def test_estimate_market_price_fok_raises_on_insufficient_liquidity(
             side="BUY",
             amount=Decimal("1000000000"),
             order_type="FOK",
+        )
+
+
+@pytest.mark.integration
+async def test_create_market_order_reports_unknown_builder_code_as_user_input(
+    deposit_wallet_client: AsyncSecureClient,
+    tradable_market: Market,
+) -> None:
+    amount = _minimum_order_size(tradable_market)
+
+    with pytest.raises(UserInputError, match="Unknown builder code"):
+        await deposit_wallet_client.create_market_order(
+            token_id=_yes_token_id(tradable_market),
+            side="BUY",
+            amount=amount,
+            max_spend=amount,
+            builder_code=UNKNOWN_BUILDER_CODE,
         )
 
 


### PR DESCRIPTION
## Summary
- map builder-fee 404 responses to `UserInputError` for invalid/stale builder codes
- keep other builder-fee request failures as `RequestRejectedError`
- add integration coverage through `create_market_order(..., builder_code, max_spend)`

This mirrors the TS SDK decision without adding a one-off exception type or silently dropping builder attribution.

Fixes #56
Linear: DEV-167

## Verification
- `uv run pytest tests/integration/test_clob_orders.py -k unknown_builder_code` (skipped locally: wallet env not set)
- `uv run pytest -m "not integration"`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-mapping change on builder fee lookup; non-404 failures behave as before.
> 
> **Overview**
> When the CLOB returns **404** for `/fees/builder-fees/{builder_code}`, both async and sync `fetch_builder_fee_rates` now raise **`UserInputError`** with an "Unknown builder code" message instead of surfacing **`RequestRejectedError`**. Other HTTP failures from that endpoint are unchanged.
> 
> An integration test asserts that **`create_market_order`** with a bogus `builder_code` (and `max_spend`) fails with that **`UserInputError`**, covering the market-order fee lookup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cace4fa7e28853d21b287eea9a2168a862bc02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->