### PR TITLE
fix(gamma): accept event market URLs

### DIFF
--- a/src/polymarket/_internal/gamma_paths.py
+++ b/src/polymarket/_internal/gamma_paths.py
@@ -91,6 +91,9 @@ def _parse_polymarket_url(raw_url: str, kind: str) -> str:
         raise UserInputError("Expected a valid Polymarket URL.")
 
     segments = [segment for segment in parsed.path.split("/") if segment]
+    if kind == "market" and 2 <= len(segments) <= 3 and segments[0] == "event":
+        return segments[-1]
+
     if len(segments) != 2 or segments[0] != kind:
         raise UserInputError(f"Expected a Polymarket {kind} URL.")
 

--- a/tests/unit/test_gamma_paths.py
+++ b/tests/unit/test_gamma_paths.py
@@ -28,9 +28,20 @@ def test_build_market_path_by_url() -> None:
         build_market_path(
             id=None,
             slug=None,
-            url="https://polymarket.com/market/some-slug",
+            url="https://polymarket.com/event/some-slug",
         )
         == "/markets/slug/some-slug"
+    )
+
+
+def test_build_market_path_by_selected_market_event_url() -> None:
+    assert (
+        build_market_path(
+            id=None,
+            slug=None,
+            url="https://polymarket.com/event/event-slug/market-slug",
+        )
+        == "/markets/slug/market-slug"
     )
 
 
@@ -74,9 +85,9 @@ def test_build_market_path_rejects_other_domain() -> None:
         build_market_path(id=None, slug=None, url="https://evil.com/market/some-slug")
 
 
-def test_build_market_path_rejects_event_url() -> None:
+def test_build_market_path_rejects_unsupported_polymarket_url() -> None:
     with pytest.raises(UserInputError, match="Polymarket market URL"):
-        build_market_path(id=None, slug=None, url="https://polymarket.com/event/some-slug")
+        build_market_path(id=None, slug=None, url="https://polymarket.com/tag/politics")
 
 
 def test_build_market_path_rejects_url_with_extra_segments() -> None:


### PR DESCRIPTION
## Summary
- accept copied market URLs shaped like `/event/{slug}` in `get_market(url=...)`
- also support selected-market URLs shaped like `/event/{event_slug}/{market_slug}` by using the final slug
- keep unsupported Polymarket URL resources rejected as input errors

## Verification
- `uv run pytest tests/unit/test_gamma_paths.py`
- `uv run ruff check .`
- `uv run pyright`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to URL parsing for market lookups with existing validation for unsupported paths; no auth or data-layer impact.
> 
> **Overview**
> **Market lookup by URL** now accepts Polymarket links users copy from the site, not only `/market/{slug}`.
> 
> `_parse_polymarket_url` treats **`/event/{slug}`** and **`/event/{event_slug}/{market_slug}`** as valid market URLs and resolves them to **`/markets/slug/{last segment}`**. Standard `/market/...` behavior and HTTPS/host checks are unchanged; unrelated paths (e.g. `/tag/...`) still raise **`UserInputError`**.
> 
> Unit tests were updated to cover event-shaped URLs and renamed rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e9893e8f35a603d2166f9bcdaa19c95bcaae10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->