### PR TITLE
ci: publish releases from release please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,17 +4,28 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - name: Create release PR
+        id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    name: Publish to PyPI
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## Summary
- expose Release Please release creation as a job output
- call the reusable PyPI publish workflow when Release Please creates a release
- keep the existing manual fallback where publishing a GitHub release triggers PyPI publish

## Verification
- actionlint .github/workflows/release-please.yml .github/workflows/publish.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release automation and PyPI publishing triggers; misconfigured `releases_created` gating could skip or duplicate publishes.
> 
> **Overview**
> **Automates PyPI publishing when Release Please cuts a release**, while keeping the existing path where manually publishing a GitHub release still triggers `publish.yml`.
> 
> `publish.yml` now accepts **`workflow_call`**, so other workflows can reuse the same PyPI build/publish job. `release-please.yml` exposes **`releases_created`** from the Release Please step and adds a dependent **`publish`** job that calls the reusable workflow only when that output is `'true'`. Workflow-level permissions were narrowed to the **release-please** job; the publish job sets **`contents: read`** and **`id-token: write`** for trusted publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e879146bcaebb4b7c3882b95df1e392d7d55c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->