### PR TITLE
fix(gamma): preserve event published timestamp

### DIFF
--- a/src/polymarket/models/gamma/event.py
+++ b/src/polymarket/models/gamma/event.py
@@ -319,7 +319,9 @@ class Event(BaseModel):
             "featured_image": data.get("featuredImage"),
             "created_at": data.get("createdAt"),
             "updated_at": data.get("updatedAt"),
-            "published_at": data.get("publishedAt"),
+            "published_at": data.get("published_at")
+            if "published_at" in data
+            else data.get("publishedAt"),
             "state": {
                 "active": data.get("active"),
                 "closed": data.get("closed"),

--- a/src/polymarket/models/gamma/event.py
+++ b/src/polymarket/models/gamma/event.py
@@ -319,7 +319,7 @@ class Event(BaseModel):
             "featured_image": data.get("featuredImage"),
             "created_at": data.get("createdAt"),
             "updated_at": data.get("updatedAt"),
-            "published_at": data.get("published_at"),
+            "published_at": data.get("publishedAt"),
             "state": {
                 "active": data.get("active"),
                 "closed": data.get("closed"),

--- a/tests/unit/test_gamma_models.py
+++ b/tests/unit/test_gamma_models.py
@@ -239,6 +239,7 @@ def test_event_normalizes_groups_from_flat_payload() -> None:
         featuredImage="https://example.test/f.png",
         createdAt="2026-01-01T00:00:00Z",
         updatedAt="2026-02-01T00:00:00Z",
+        publishedAt="2026-03-01T00:00:00Z",
         active=True,
         closed=False,
         archived=False,
@@ -315,6 +316,7 @@ def test_event_normalizes_groups_from_flat_payload() -> None:
     assert event.title == "An Event"
     assert event.featured_image == "https://example.test/f.png"
     assert event.created_at == datetime(2026, 1, 1, tzinfo=UTC)
+    assert event.published_at == datetime(2026, 3, 1, tzinfo=UTC)
     assert event.state.featured is True
     assert event.schedule.start_date == datetime(2026, 5, 1, tzinfo=UTC)
     assert event.metrics.volume == Decimal("500")

--- a/tests/unit/test_gamma_models.py
+++ b/tests/unit/test_gamma_models.py
@@ -239,7 +239,7 @@ def test_event_normalizes_groups_from_flat_payload() -> None:
         featuredImage="https://example.test/f.png",
         createdAt="2026-01-01T00:00:00Z",
         updatedAt="2026-02-01T00:00:00Z",
-        publishedAt="2026-03-01T00:00:00Z",
+        published_at="2026-03-01T00:00:00Z",
         active=True,
         closed=False,
         archived=False,
@@ -340,6 +340,12 @@ def test_event_normalizes_groups_from_flat_payload() -> None:
     assert event.series[0].volume == Decimal("1000")
     assert event.tags[0].label == "Tag 1"
     assert event.metadata == {"k": "v"}
+
+
+def test_event_accepts_camel_case_published_at_from_flat_payload() -> None:
+    event = Event.parse_response(_minimal_event_payload(publishedAt="2026-03-01T00:00:00Z"))
+
+    assert event.published_at == datetime(2026, 3, 1, tzinfo=UTC)
 
 
 def test_event_skips_markets_with_non_binary_outcomes() -> None:


### PR DESCRIPTION
## Summary
- Preserve live Gamma event `published_at` values when normalizing flat event payloads.
- Accept `publishedAt` as a fallback for camelCase-shaped payloads.
- Add regression coverage for `Event.published_at` in both paths.

Fixes DEV-173
Fixes #62

## Cross-check
- Live `https://gamma-api.polymarket.com/events?limit=1` returns event-level `published_at`.
- TypeScript SDK `GammaEventSchema` reads `published_at` and `normalizeEvent` exposes it as `publishedAt`.

## Verification
- `uv run pytest tests/unit/test_gamma_models.py -k 'event_normalizes_groups_from_flat_payload or event_accepts_camel_case_published_at_from_flat_payload'`
- `uv run pytest tests/unit/test_gamma_models.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow model normalization and test-only changes; no auth, trading, or API surface impact.
> 
> **Overview**
> Fixes **Gamma flat event payload** parsing so `Event.published_at` is populated from either `published_at` or API-style **`publishedAt`**, with **`published_at` winning** when both keys are present.
> 
> Adds unit coverage for snake_case in the full flat normalization test and a dedicated regression test for camelCase-only `publishedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d91028469bc92d654eed4fcae2a81bbf81dd0d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->