### PR TITLE
fix(clob): align order book timestamp validation

### DIFF
--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import UTC, datetime
 from typing import Any, Literal
 
 from pydantic import Field, field_validator
@@ -9,6 +8,7 @@ from pydantic import Field, field_validator
 from polymarket._frames_bridge import frames_func as _frames_func
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
+    EpochMsTimestamp,
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import TokenId
@@ -24,7 +24,7 @@ class OrderBookLevel(BaseModel):
 class OrderBook(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    timestamp: datetime | None = None
+    timestamp: EpochMsTimestamp = None
     bids: tuple[OrderBookLevel, ...]
     """Ascending price order, lowest bid first."""
     asks: tuple[OrderBookLevel, ...]
@@ -34,27 +34,6 @@ class OrderBook(BaseModel):
     neg_risk: bool
     last_trade_price: _DecimalFromString | None = None
     hash: str
-
-    @field_validator("timestamp", mode="before")
-    @classmethod
-    def _parse_timestamp(cls, value: object) -> datetime | None:
-        if value in (None, ""):
-            return None
-        if isinstance(value, datetime):
-            return value
-        if isinstance(value, str):
-            try:
-                ms = int(value)
-            except ValueError as error:
-                msg = f"invalid epoch-ms timestamp: {value!r}"
-                raise ValueError(msg) from error
-            try:
-                return datetime.fromtimestamp(ms / 1000, tz=UTC)
-            except (OverflowError, OSError, ValueError) as error:
-                msg = f"invalid epoch-ms timestamp: {value!r}"
-                raise ValueError(msg) from error
-        msg = f"expected a string epoch-ms timestamp, got {type(value).__name__}"
-        raise ValueError(msg)
 
     @field_validator("last_trade_price", mode="before")
     @classmethod

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -298,6 +298,14 @@ def test_parse_order_book_rejects_malformed_timestamp() -> None:
         parse_order_book(payload)
 
 
+@pytest.mark.parametrize("bad_value", [" 1716000000000", "1716000000000 ", "+1", "-1"])
+def test_parse_order_book_rejects_loose_numeric_timestamp_strings(bad_value: str) -> None:
+    payload = {**_ORDER_BOOK_PAYLOAD, "timestamp": bad_value}
+
+    with pytest.raises(UnexpectedResponseError):
+        parse_order_book(payload)
+
+
 def test_parse_order_book_rejects_missing_required_field() -> None:
     payload = {k: v for k, v in _ORDER_BOOK_PAYLOAD.items() if k != "asset_id"}
 


### PR DESCRIPTION
## Summary
- Reuse the shared `EpochMsTimestamp` validator for `OrderBook.timestamp`.
- Reject whitespace-padded and sign-prefixed epoch-ms timestamp strings, matching sibling CLOB models and the TypeScript SDK schema.
- Add regression coverage for loose numeric order book timestamp strings.

Fixes DEV-174
Fixes #63

## Cross-check
- Live CLOB `/book` returns digit-only epoch-ms timestamp strings.
- TypeScript SDK `OrderBookSchema.timestamp` uses `EpochMillisecondsStringSchema`, which requires `^\d+$`.

## Verification
- `uv run pytest tests/unit/test_clob_actions.py -k 'parse_order_book'`
- `uv run pytest tests/unit/test_clob_actions.py tests/unit/test_streams_market_events.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parsing-only tightening for REST order books; live API returns digit-only timestamps, so behavior change mainly affects malformed inputs.
> 
> **Overview**
> **Order book timestamp parsing** now uses the shared `EpochMsTimestamp` validator instead of a local `_parse_timestamp` on `OrderBook`, so `/book` responses follow the same rules as other CLOB models and the TypeScript `^\d+$` epoch-ms schema.
> 
> **Stricter rejection:** whitespace-padded strings (e.g. `" 1716000000000"`), sign-prefixed values (`"+1"`, `"-1"`), and other non–digit-only forms that `int()` would have accepted are now rejected at parse time.
> 
> **Tests:** a parametrized unit test covers those loose numeric timestamp strings and expects `UnexpectedResponseError` from `parse_order_book`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4d4b680f61d6b3475f070bb6d4010ce3a3efd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->