### PR TITLE
ci: inline release please publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish
 on:
   release:
     types: [published]
-  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,27 @@ jobs:
     name: Publish to PyPI
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    uses: ./.github/workflows/publish.yml
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary
- inline the PyPI publish steps into the Release Please workflow
- remove `workflow_call` from the standalone publish workflow
- keep `publish.yml` as the manual fallback for human-published GitHub releases

## Notes
- PyPI Trusted Publishing needs a publisher entry for `.github/workflows/release-please.yml` with environment `release` for the automated Release Please path.
- The existing `.github/workflows/publish.yml` trusted publisher can remain for the manual release-published fallback.

## Verification
- `actionlint .github/workflows/release-please.yml .github/workflows/publish.yml`