### PR TITLE
feat(jupyter): notebook-friendly models

### DIFF
--- a/src/polymarket/_jupyter.py
+++ b/src/polymarket/_jupyter.py
@@ -1,0 +1,72 @@
+"""Internal HTML helpers for ``_repr_html_`` on SDK models and containers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from functools import wraps
+from html import escape
+from typing import Any, TypeVar
+
+_CARD_STYLE = (
+    "font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+    "font-size: 12px;"
+    "border: 1px solid #d0d7de;"
+    "border-radius: 4px;"
+    "padding: 6px 10px;"
+    "display: inline-block;"
+    "background: #f6f8fa;"
+    "color: #1f2328;"
+)
+_TITLE_STYLE = "font-weight: 600; margin-bottom: 4px;"
+_TABLE_STYLE = "border-collapse: collapse;"
+_KEY_STYLE = "color: #57606a; padding-right: 8px; vertical-align: top;"
+_VALUE_STYLE = "vertical-align: top;"
+_HINT_STYLE = "color: #57606a; margin-top: 4px; font-style: italic;"
+
+
+def card(
+    title: str,
+    rows: Iterable[tuple[str, str]] | None = None,
+    *,
+    hint: str | None = None,
+) -> str:
+    """Render a small HTML card; all strings are HTML-escaped here."""
+    title_html = f'<div style="{_TITLE_STYLE}">{escape(title)}</div>'
+    rows_html = ""
+    if rows:
+        cells = "".join(
+            f'<tr><td style="{_KEY_STYLE}">{escape(k)}</td>'
+            f'<td style="{_VALUE_STYLE}">{escape(v)}</td></tr>'
+            for k, v in rows
+        )
+        if cells:
+            rows_html = f'<table style="{_TABLE_STYLE}">{cells}</table>'
+    hint_html = f'<div style="{_HINT_STYLE}">{escape(hint)}</div>' if hint else ""
+    return f'<div style="{_CARD_STYLE}">{title_html}{rows_html}{hint_html}</div>'
+
+
+def truncate_mid(s: str | None, *, head: int = 6, tail: int = 4) -> str:
+    if s is None:
+        return "—"
+    if len(s) <= head + tail + 1:
+        return s
+    return f"{s[:head]}…{s[-tail:]}"
+
+
+F = TypeVar("F", bound=Callable[..., str])
+
+
+def safe_html_repr(fn: F) -> F:
+    """Decorator: on exception, fall back to ``repr(self)`` so cells never crash."""
+
+    @wraps(fn)
+    def wrapper(self: Any) -> str:
+        try:
+            return fn(self)
+        except Exception:  # noqa: BLE001
+            return escape(repr(self))
+
+    return wrapper  # type: ignore[return-value]
+
+
+__all__ = ["card", "safe_html_repr", "truncate_mid"]

--- a/src/polymarket/auth.py
+++ b/src/polymarket/auth.py
@@ -18,6 +18,14 @@ class BuilderApiKey:
     def __repr__(self) -> str:
         return "BuilderApiKey(key=<redacted>, secret=<redacted>, passphrase=<redacted>)"
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card
+
+        return card(
+            "BuilderApiKey  ·  redacted",
+            rows=[("key", "***"), ("secret", "***"), ("passphrase", "***")],
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class RelayerApiKey:
@@ -34,6 +42,14 @@ class RelayerApiKey:
 
     def __repr__(self) -> str:
         return f"RelayerApiKey(key=<redacted>, address={self.address!r})"
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card
+
+        return card(
+            f"RelayerApiKey  ·  {self.address}",
+            rows=[("key", "***"), ("address", self.address)],
+        )
 
 
 ApiKey: TypeAlias = BuilderApiKey | RelayerApiKey

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -332,7 +332,7 @@ class PublicClient:
         """List builder-attributed trades.
 
         Returns:
-            A paginator. Use ``first_page()``, iterate over pages, or call ``items()``
+            A paginator. Use ``first_page()``, iterate over pages, or call ``iter_items()``
             to stream individual trades.
         """
 

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -80,6 +80,23 @@ class OpenOrder(BaseModel):
     def _parse_expires_at(cls, value: object) -> datetime | None:
         return _parse_optional_epoch(value)
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: OpenOrder) -> str:
+            title = f"OpenOrder  ·  {self.side}  ·  {self.status}"
+            rows: list[tuple[str, str]] = [
+                ("id", truncate_mid(self.id)),
+                ("price", str(self.price)),
+                ("size", str(self.original_size)),
+                ("matched", str(self.size_matched)),
+                ("market", truncate_mid(self.market)),
+            ]
+            return card(title, rows=rows)
+
+        return render(self)
+
 
 class MakerOrder(BaseModel):
     """Maker-side fill information attached to a trade."""
@@ -126,6 +143,22 @@ class ClobTrade(BaseModel):
     @classmethod
     def _parse_epoch_field(cls, value: object) -> datetime:
         return _parse_epoch(value)
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: ClobTrade) -> str:
+            title = f"Trade  ·  {self.side}  ·  {self.matched_at.isoformat()}"
+            rows: list[tuple[str, str]] = [
+                ("price", str(self.price)),
+                ("size", str(self.size)),
+                ("market", truncate_mid(self.market)),
+                ("id", truncate_mid(self.id)),
+            ]
+            return card(title, rows=rows)
+
+        return render(self)
 
 
 class Notification(BaseModel):

--- a/src/polymarket/models/clob/api_key.py
+++ b/src/polymarket/models/clob/api_key.py
@@ -6,9 +6,20 @@ from polymarket.models.base import BaseModel
 
 
 class ApiKeyCreds(BaseModel):
-    key: str = Field(validation_alias="apiKey")
+    key: str = Field(validation_alias="apiKey", repr=False)
     passphrase: str = Field(repr=False)
     secret: str = Field(repr=False)
+
+    def __repr__(self) -> str:
+        return "ApiKeyCreds(key=<redacted>, passphrase=<redacted>, secret=<redacted>)"
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card
+
+        return card(
+            "ApiKeyCreds  ·  redacted",
+            rows=[("key", "***"), ("passphrase", "***"), ("secret", "***")],
+        )
 
 
 __all__ = ["ApiKeyCreds"]

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -61,6 +61,32 @@ class OrderBook(BaseModel):
     def _parse_last_trade_price(cls, value: object) -> object:
         return None if value in (None, "") else value
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: OrderBook) -> str:
+            best_bid = self.bids[-1].price if self.bids else None
+            best_ask = self.asks[-1].price if self.asks else None
+            spread = best_ask - best_bid if best_bid is not None and best_ask is not None else None
+            title = (
+                f"OrderBook  ·  {truncate_mid(self.market)}  ·  token {truncate_mid(self.token_id)}"
+            )
+            rows: list[tuple[str, str]] = [
+                (
+                    "bid / ask",
+                    f"{best_bid if best_bid is not None else '—'} / "
+                    f"{best_ask if best_ask is not None else '—'}",
+                ),
+                ("spread", str(spread) if spread is not None else "—"),
+                ("depth", f"{len(self.bids)} bids / {len(self.asks)} asks"),
+            ]
+            if self.timestamp is not None:
+                rows.append(("timestamp", self.timestamp.isoformat()))
+            return card(title, rows=rows, hint="Call .to_pandas() for level data.")
+
+        return render(self)
+
     def to_arrow(self) -> Any:
         """Flatten this book into ``[side, level, price, size]`` rows."""
         return _frames_func("to_arrow")(self)

--- a/src/polymarket/models/clob/order_response.py
+++ b/src/polymarket/models/clob/order_response.py
@@ -67,11 +67,38 @@ class AcceptedOrder(BaseModel):
     trade_ids: tuple[str, ...]
     transactions_hashes: tuple[TransactionHash, ...]
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: AcceptedOrder) -> str:
+            title = f"OrderResponse  ·  accepted  ·  {self.status}"
+            rows: list[tuple[str, str]] = [
+                ("order_id", truncate_mid(self.order_id)),
+                ("making_amount", str(self.making_amount)),
+                ("taking_amount", str(self.taking_amount)),
+                ("trades", str(len(self.trade_ids))),
+                ("tx hashes", str(len(self.transactions_hashes))),
+            ]
+            return card(title, rows=rows)
+
+        return render(self)
+
 
 class RejectedOrder(BaseModel):
     ok: Literal[False] = False
     code: OrderResponseErrorCode
     message: str
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr
+
+        @safe_html_repr
+        def render(self: RejectedOrder) -> str:
+            title = f"OrderResponse  ·  rejected  ·  {self.code}"
+            return card(title, rows=[("message", self.message)])
+
+        return render(self)
 
 
 OrderResponse: TypeAlias = AcceptedOrder | RejectedOrder

--- a/src/polymarket/models/clob/price_history.py
+++ b/src/polymarket/models/clob/price_history.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Literal, TypeAlias
 
 from pydantic import Field
@@ -12,6 +13,16 @@ PriceHistoryInterval: TypeAlias = Literal["max", "1w", "1d", "6h", "1h"]
 class PriceHistoryPoint(BaseModel):
     t: int = Field(strict=True)
     p: float = Field(strict=True)
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr
+
+        @safe_html_repr
+        def render(self: PriceHistoryPoint) -> str:
+            ts = datetime.fromtimestamp(self.t, tz=UTC).isoformat()
+            return card("PriceHistoryPoint", rows=[("t", ts), ("p", str(self.p))])
+
+        return render(self)
 
 
 __all__ = ["PriceHistoryInterval", "PriceHistoryPoint"]

--- a/src/polymarket/models/data/activity.py
+++ b/src/polymarket/models/data/activity.py
@@ -79,6 +79,25 @@ class _KnownActivityBase(BaseModel):
     def _parse_timestamp(cls, value: object) -> datetime | None:
         return parse_epoch_seconds_optional(value)
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: _KnownActivityBase) -> str:
+            title = type(self).__name__
+            rows: list[tuple[str, str]] = [
+                ("timestamp", self.timestamp.isoformat()),
+                ("tx", truncate_mid(self.transaction_hash)),
+                ("wallet", truncate_mid(self.wallet)),
+            ]
+            for attr in ("amount", "shares", "price", "side", "outcome", "title"):
+                value = getattr(self, attr, None)
+                if value is not None:
+                    rows.append((attr, str(value)))
+            return card(title, rows=rows)
+
+        return render(self)
+
 
 class TradeActivity(_KnownActivityBase):
     type: Literal["TRADE"]
@@ -176,6 +195,22 @@ class UnknownActivity(BaseModel):
     @classmethod
     def _parse_timestamp(cls, value: object) -> datetime | None:
         return parse_epoch_seconds_optional(value)
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: UnknownActivity) -> str:
+            title = f"UnknownActivity  ·  {self.type or '(no type)'}"
+            rows: list[tuple[str, str]] = []
+            if self.timestamp is not None:
+                rows.append(("timestamp", self.timestamp.isoformat()))
+            if self.transaction_hash is not None:
+                rows.append(("tx", truncate_mid(self.transaction_hash)))
+            rows.append(("raw fields", str(len(self.raw))))
+            return card(title, rows=rows)
+
+        return render(self)
 
 
 Activity = (

--- a/src/polymarket/models/data/portfolio.py
+++ b/src/polymarket/models/data/portfolio.py
@@ -84,6 +84,28 @@ class Position(BaseModel):
     def _parse_end_date(cls, value: object) -> date | None:
         return parse_optional_date(value)
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: Position) -> str:
+            label = self.title or truncate_mid(self.condition_id)
+            title = f"Position  ·  {label}"
+            rows: list[tuple[str, str]] = []
+            if self.outcome:
+                rows.append(("side", self.outcome))
+            if self.size is not None:
+                rows.append(("size", str(self.size)))
+            if self.avg_price is not None:
+                rows.append(("avg_price", str(self.avg_price)))
+            if self.cur_price is not None:
+                rows.append(("current", str(self.cur_price)))
+            if self.cash_pnl is not None:
+                rows.append(("pnl", str(self.cash_pnl)))
+            return card(title, rows=rows)
+
+        return render(self)
+
 
 class ClosedPosition(BaseModel):
     """Closed market position for a wallet."""

--- a/src/polymarket/models/gamma/event.py
+++ b/src/polymarket/models/gamma/event.py
@@ -285,6 +285,30 @@ class Event(BaseModel):
     tags: tuple[EventTag, ...]
     creators: tuple[EventCreator, ...]
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr
+
+        @safe_html_repr
+        def render(self: Event) -> str:
+            if self.state.closed or self.state.ended:
+                status = "closed"
+            elif self.state.active:
+                status = "open"
+            elif self.state.archived:
+                status = "archived"
+            else:
+                status = "unknown"
+            title = f"{self.title or '(no title)'}  ·  {status}"
+            rows: list[tuple[str, str]] = []
+            if self.slug:
+                rows.append(("slug", self.slug))
+            rows.append(("markets", str(len(self.markets))))
+            if self.schedule.end_date is not None:
+                rows.append(("end", self.schedule.end_date.date().isoformat()))
+            return card(title, rows=rows)
+
+        return render(self)
+
     @field_validator("id", mode="before")
     @classmethod
     def _coerce_id(cls, value: object) -> object:

--- a/src/polymarket/models/gamma/market.py
+++ b/src/polymarket/models/gamma/market.py
@@ -389,6 +389,35 @@ class Market(BaseModel):
     events: tuple[MarketEvent, ...]
     tags: tuple[MarketTag, ...]
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: Market) -> str:
+            if self.state.closed:
+                status = "closed"
+            elif self.state.active:
+                status = "open"
+            elif self.state.archived:
+                status = "archived"
+            else:
+                status = "unknown"
+            title = f"{self.question or '(no question)'}  ·  {status}"
+            rows: list[tuple[str, str]] = []
+            if self.slug:
+                rows.append(("slug", self.slug))
+            if self.condition_id:
+                rows.append(("condition", truncate_mid(self.condition_id)))
+            if self.state.end_date is not None:
+                rows.append(("end", self.state.end_date.date().isoformat()))
+            yes = self.outcomes.yes.price
+            no = self.outcomes.no.price
+            if yes is not None and no is not None:
+                rows.append(("yes / no", f"{yes} / {no}"))
+            return card(title, rows=rows)
+
+        return render(self)
+
     @model_validator(mode="before")
     @classmethod
     def _normalize_market(cls, value: object) -> object:

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -26,6 +26,21 @@ class Page(Generic[T]):
     next_cursor: str | None = None
     total_count: int | None = None
 
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card, safe_html_repr, truncate_mid
+
+        @safe_html_repr
+        def render(self: Page[T]) -> str:
+            rows: list[tuple[str, str]] = []
+            if self.next_cursor is not None:
+                rows.append(("next_cursor", truncate_mid(self.next_cursor)))
+            if self.total_count is not None:
+                rows.append(("total_count", str(self.total_count)))
+            title = f"Page  ·  {len(self.items)} item(s)  ·  has_more={self.has_more}"
+            return card(title, rows=rows)
+
+        return render(self)
+
     def to_arrow(self) -> Any:
         return _frames_func("to_arrow")(self)
 
@@ -53,6 +68,14 @@ class Paginator(Generic[T]):
     ) -> None:
         self._fetch = fetch
         self._initial_cursor = initial_cursor
+
+    def __repr__(self) -> str:
+        return "Paginator(unfetched — call .first_page() or iterate)"
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card
+
+        return card("Paginator (unfetched — call .first_page() or iterate)")
 
     def first_page(self) -> Page[T]:
         return self._fetch(self._initial_cursor)
@@ -120,6 +143,14 @@ class AsyncPaginator(Generic[T]):
     ) -> None:
         self._fetch = fetch
         self._initial_cursor = initial_cursor
+
+    def __repr__(self) -> str:
+        return "AsyncPaginator(unfetched — call await .first_page() or async-iterate)"
+
+    def _repr_html_(self) -> str:
+        from polymarket._jupyter import card
+
+        return card("AsyncPaginator (unfetched — call await .first_page() or async-iterate)")
 
     async def first_page(self) -> Page[T]:
         return await self._fetch(self._initial_cursor)

--- a/tests/unit/test_api_key_creds.py
+++ b/tests/unit/test_api_key_creds.py
@@ -1,22 +1,23 @@
 from polymarket import ApiKeyCreds
 
 
-def test_api_key_creds_repr_does_not_leak_secret_or_passphrase() -> None:
+def test_api_key_creds_repr_does_not_leak_any_field() -> None:
     creds = ApiKeyCreds(key="visible-key", passphrase="sneaky-passphrase", secret="sneaky-secret")
 
     rendered = repr(creds)
 
-    assert "visible-key" in rendered
+    assert "visible-key" not in rendered
     assert "sneaky-passphrase" not in rendered
     assert "sneaky-secret" not in rendered
+    assert "redacted" in rendered
 
 
-def test_api_key_creds_str_does_not_leak_secret_or_passphrase() -> None:
+def test_api_key_creds_str_does_not_leak_any_field() -> None:
     creds = ApiKeyCreds(key="visible-key", passphrase="sneaky-passphrase", secret="sneaky-secret")
 
     rendered = str(creds)
 
-    assert "visible-key" in rendered
+    assert "visible-key" not in rendered
     assert "sneaky-passphrase" not in rendered
     assert "sneaky-secret" not in rendered
 

--- a/tests/unit/test_jupyter_repr.py
+++ b/tests/unit/test_jupyter_repr.py
@@ -1,0 +1,453 @@
+"""Tests for ``_repr_html_`` on SDK models, containers, and auth types."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from polymarket._jupyter import card, safe_html_repr, truncate_mid
+from polymarket.auth import BuilderApiKey, RelayerApiKey
+from polymarket.models import OrderBook
+from polymarket.models.clob.account import ClobTrade, OpenOrder
+from polymarket.models.clob.api_key import ApiKeyCreds
+from polymarket.models.clob.order_response import AcceptedOrder, RejectedOrder
+from polymarket.models.clob.price_history import PriceHistoryPoint
+from polymarket.models.data.activity import TradeActivity, UnknownActivity
+from polymarket.models.data.portfolio import Position
+from polymarket.models.gamma import Event, Market
+from polymarket.pagination import AsyncPaginator, Page, Paginator
+
+
+def _make_market(**overrides: object) -> Market:
+    payload: dict[str, object] = {
+        "id": "MARKET-1",
+        "question": "Will X happen?",
+        "slug": "will-x-happen",
+        "conditionId": "0xabcdef0123456789",
+        "outcomes": ["Yes", "No"],
+        "outcomePrices": ["0.6", "0.4"],
+        "clobTokenIds": ["TOKEN-YES", "TOKEN-NO"],
+        "active": True,
+        "closed": False,
+        "endDate": "2026-12-31T00:00:00Z",
+    }
+    payload.update(overrides)
+    return Market.parse_response(payload)
+
+
+def _make_event(**overrides: object) -> Event:
+    payload: dict[str, object] = {
+        "id": "EVENT-1",
+        "title": "Some Event",
+        "slug": "some-event",
+        "active": True,
+        "endDate": "2026-12-31T00:00:00Z",
+    }
+    payload.update(overrides)
+    return Event.parse_response(payload)
+
+
+def _make_book(**overrides: object) -> OrderBook:
+    payload: dict[str, object] = {
+        "market": "0xfooBar123456789",
+        "asset_id": "8501497",
+        "timestamp": "1700000000000",
+        "bids": [{"price": "0.48", "size": "50"}, {"price": "0.49", "size": "100"}],
+        "asks": [{"price": "0.52", "size": "70"}, {"price": "0.51", "size": "80"}],
+        "min_order_size": "5",
+        "tick_size": "0.01",
+        "neg_risk": True,
+        "last_trade_price": "0.50",
+        "hash": "abc",
+    }
+    payload.update(overrides)
+    return OrderBook.model_validate(payload)
+
+
+def _make_position(**overrides: object) -> Position:
+    payload: dict[str, object] = {
+        "conditionId": "0xabcdef0123456789",
+        "proxyWallet": "0x" + "ab" * 20,
+        "asset": "TOKEN-YES",
+        "size": "100",
+        "avgPrice": "0.55",
+        "curPrice": "0.60",
+        "cashPnl": "5.00",
+        "outcome": "Yes",
+        "title": "Will X happen?",
+    }
+    payload.update(overrides)
+    return Position.model_validate(payload)
+
+
+_OPEN_ORDER_PAYLOAD: dict[str, Any] = {
+    "asset_id": "8501497",
+    "associate_trades": ["trade-1"],
+    "created_at": 1700000000000,
+    "expiration": 1800000000000,
+    "id": "order-abcdef0123456789",
+    "maker_address": "0xMAKER",
+    "market": "0xMARKET01234567890",
+    "order_type": "GTC",
+    "original_size": "100",
+    "outcome": "Yes",
+    "owner": "0xOWNER",
+    "price": "0.5",
+    "side": "BUY",
+    "size_matched": "50",
+    "status": "LIVE",
+}
+
+_CLOB_TRADE_PAYLOAD: dict[str, Any] = {
+    "asset_id": "8501497",
+    "bucket_index": 7,
+    "fee_rate_bps": "10",
+    "id": "trade-abcdef0123456789",
+    "last_update": 1700000010000,
+    "maker_address": "0xMAKER",
+    "maker_orders": [],
+    "market": "0xMARKET01234567890",
+    "match_time": 1700000000000,
+    "outcome": "Yes",
+    "owner": "0xOWNER",
+    "price": "0.5",
+    "side": "BUY",
+    "size": "5",
+    "status": "MINED",
+    "taker_order_id": "order-2",
+    "trader_side": "TAKER",
+    "transaction_hash": "0xTX",
+}
+
+
+def test_card_renders_title_and_rows() -> None:
+    html = card("Some Title", rows=[("k", "v")])
+    assert "Some Title" in html
+    assert "k" in html and "v" in html
+    assert html.startswith("<div")
+    assert html.endswith("</div>")
+
+
+def test_card_escapes_title_and_values() -> None:
+    html = card("Hi <script>alert(1)</script>", rows=[("k", "<b>v</b>")])
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "<b>v</b>" not in html
+    assert "&lt;b&gt;v&lt;/b&gt;" in html
+
+
+def test_card_with_no_rows_omits_table() -> None:
+    html = card("Just a title")
+    assert "<table" not in html
+
+
+def test_card_with_hint() -> None:
+    html = card("T", rows=[("k", "v")], hint="hint text")
+    assert "hint text" in html
+
+
+def test_truncate_mid_short_string_passthrough() -> None:
+    assert truncate_mid("short") == "short"
+
+
+def test_truncate_mid_long_string_truncates() -> None:
+    out = truncate_mid("0xabcdef1234567890fedcba")
+    assert "…" in out
+    assert out.startswith("0xabcd")
+    assert out.endswith("dcba")
+
+
+def test_truncate_mid_none() -> None:
+    assert truncate_mid(None) == "—"
+
+
+def test_safe_html_repr_falls_back_on_exception() -> None:
+    class _Boom:
+        def __repr__(self) -> str:
+            return "<Boom>"
+
+        @safe_html_repr
+        def _repr_html_(self) -> str:
+            raise RuntimeError("boom")
+
+    out = _Boom()._repr_html_()
+    assert "&lt;Boom&gt;" in out
+
+
+def test_market_repr_html_contains_key_fields() -> None:
+    m = _make_market()
+    html = m._repr_html_()
+    assert "Will X happen?" in html
+    assert "will-x-happen" in html
+    assert "open" in html
+    assert "2026-12-31" in html
+    assert "0.6" in html and "0.4" in html
+
+
+def test_market_repr_html_status_closed() -> None:
+    m = _make_market(active=False, closed=True)
+    assert "closed" in m._repr_html_()
+
+
+def test_market_repr_html_escapes_question() -> None:
+    m = _make_market(question="Hi <script>alert(1)</script>?")
+    html = m._repr_html_()
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_event_repr_html_contains_key_fields() -> None:
+    e = _make_event()
+    html = e._repr_html_()
+    assert "Some Event" in html
+    assert "some-event" in html
+    assert "open" in html
+
+
+def test_orderbook_repr_html_contains_best_bid_ask_and_spread() -> None:
+    book = _make_book()
+    html = book._repr_html_()
+    assert "OrderBook" in html
+    assert "0.49" in html
+    assert "0.51" in html
+    assert "spread" in html
+    assert "2 bids / 2 asks" in html
+
+
+def test_orderbook_repr_html_handles_empty_sides() -> None:
+    book = _make_book(bids=[], asks=[])
+    html = book._repr_html_()
+    assert "—" in html
+    assert "0 bids / 0 asks" in html
+
+
+def test_position_repr_html_contains_market_and_pnl() -> None:
+    p = _make_position()
+    html = p._repr_html_()
+    assert "Will X happen?" in html
+    assert "Yes" in html
+    assert "100" in html
+    assert "5.00" in html
+
+
+def test_open_order_repr_html_contains_id_and_side() -> None:
+    order = OpenOrder.model_validate(_OPEN_ORDER_PAYLOAD)
+    html = order._repr_html_()
+    assert "OpenOrder" in html
+    assert "BUY" in html
+    assert "LIVE" in html
+    assert "0.5" in html
+
+
+def test_clob_trade_repr_html_contains_price_and_side() -> None:
+    trade = ClobTrade.model_validate(_CLOB_TRADE_PAYLOAD)
+    html = trade._repr_html_()
+    assert "Trade" in html
+    assert "BUY" in html
+    assert "0.5" in html
+    assert "5" in html
+
+
+def test_price_history_point_repr_html_formats_timestamp() -> None:
+    pt = PriceHistoryPoint(t=1700000000, p=0.62)
+    html = pt._repr_html_()
+    assert "PriceHistoryPoint" in html
+    assert "0.62" in html
+    assert "2023-11-14" in html
+
+
+def test_accepted_order_repr_html() -> None:
+    o = AcceptedOrder(
+        order_id="order-abc123def456",
+        status="live",
+        making_amount=Decimal("100"),
+        taking_amount=Decimal("200"),
+        trade_ids=("t1", "t2"),
+        transactions_hashes=(),
+    )
+    html = o._repr_html_()
+    assert "OrderResponse" in html
+    assert "accepted" in html
+    assert "live" in html
+    assert "2" in html
+
+
+def test_rejected_order_repr_html() -> None:
+    r = RejectedOrder(code="not_enough_balance", message="insufficient pUSD balance")
+    html = r._repr_html_()
+    assert "rejected" in html
+    assert "not_enough_balance" in html
+    assert "insufficient pUSD balance" in html
+
+
+def test_trade_activity_repr_html_uses_variant_class_name() -> None:
+    activity = TradeActivity.model_validate(
+        {
+            "type": "TRADE",
+            "proxyWallet": "0x" + "ab" * 20,
+            "timestamp": 1700000000,
+            "transactionHash": "0xTX1234567890",
+            "conditionId": "0xCOND",
+            "asset": "TOKEN-1",
+            "side": "BUY",
+            "size": "5",
+            "amount": "2.5",
+            "price": "0.5",
+            "outcome": "Yes",
+            "outcomeIndex": 0,
+            "title": "Some Market",
+            "slug": "some-market",
+            "icon": "i.png",
+            "eventSlug": "evt",
+        }
+    )
+    html = activity._repr_html_()
+    assert "TradeActivity" in html
+    assert "Some Market" in html
+    assert "BUY" in html
+    assert "Yes" in html
+
+
+def test_unknown_activity_repr_html_shows_type_tag() -> None:
+    unknown = UnknownActivity.model_validate(
+        {
+            "type": "WEIRD_NEW_TYPE",
+            "proxyWallet": "0x" + "ab" * 20,
+            "timestamp": 1700000000,
+            "transactionHash": "0xTX",
+            "raw": {"a": 1, "b": 2, "c": 3},
+        }
+    )
+    html = unknown._repr_html_()
+    assert "UnknownActivity" in html
+    assert "WEIRD_NEW_TYPE" in html
+    assert "3" in html
+
+
+def test_paginator_repr_replaces_default_object_repr() -> None:
+    p = Paginator[int](fetch=lambda _c: Page(items=(), has_more=False))
+    text = repr(p)
+    assert "object at" not in text
+    assert "Paginator" in text
+    assert "unfetched" in text
+
+
+def test_paginator_repr_html_no_fetch() -> None:
+    fetched: list[str | None] = []
+
+    def fetch(cursor: str | None) -> Page[int]:
+        fetched.append(cursor)
+        return Page(items=(), has_more=False)
+
+    p = Paginator[int](fetch=fetch)
+    _ = repr(p)
+    html = p._repr_html_()
+    assert "Paginator" in html
+    assert fetched == []
+
+
+def test_async_paginator_repr_no_fetch() -> None:
+    fetched: list[str | None] = []
+
+    async def fetch(cursor: str | None) -> Page[int]:
+        fetched.append(cursor)
+        return Page(items=(), has_more=False)
+
+    p = AsyncPaginator[int](fetch=fetch)
+    text = repr(p)
+    html = p._repr_html_()
+    assert "AsyncPaginator" in text
+    assert "AsyncPaginator" in html
+    assert fetched == []
+
+
+def test_page_repr_html_shows_count_and_has_more() -> None:
+    page: Page[int] = Page(items=(1, 2, 3), has_more=True, next_cursor="abc123def456")
+    html = page._repr_html_()
+    assert "Page" in html
+    assert "3" in html
+    assert "True" in html
+    assert "next_cursor" in html
+
+
+def test_page_repr_html_with_total_count() -> None:
+    page: Page[int] = Page(items=(1,), has_more=False, total_count=42)
+    html = page._repr_html_()
+    assert "42" in html
+
+
+def test_api_key_creds_repr_redacts_key() -> None:
+    """Regression: api key was exposed via pydantic's default __repr__."""
+    creds = ApiKeyCreds.model_validate(
+        {"apiKey": "real-api-key", "passphrase": "real-pass", "secret": "real-secret"}
+    )
+    text = repr(creds)
+    assert "real-api-key" not in text
+    assert "real-pass" not in text
+    assert "real-secret" not in text
+    assert "redacted" in text
+
+
+def test_api_key_creds_repr_html_redacts_all_fields() -> None:
+    creds = ApiKeyCreds.model_validate(
+        {"apiKey": "real-api-key", "passphrase": "real-pass", "secret": "real-secret"}
+    )
+    html = creds._repr_html_()
+    assert "real-api-key" not in html
+    assert "real-pass" not in html
+    assert "real-secret" not in html
+    assert "***" in html
+
+
+def test_builder_api_key_repr_html_redacts() -> None:
+    key = BuilderApiKey(key="real-key", secret="real-secret", passphrase="real-pass")
+    html = key._repr_html_()
+    assert "real-key" not in html
+    assert "real-secret" not in html
+    assert "real-pass" not in html
+    assert "***" in html
+
+
+def test_builder_api_key_repr_redacts() -> None:
+    key = BuilderApiKey(key="real-key", secret="real-secret", passphrase="real-pass")
+    text = repr(key)
+    assert "real-key" not in text
+    assert "real-secret" not in text
+    assert "real-pass" not in text
+
+
+def test_relayer_api_key_repr_html_redacts_key_but_shows_address() -> None:
+    key = RelayerApiKey(key="real-relayer-key", address="0x" + "ab" * 20)
+    html = key._repr_html_()
+    assert "real-relayer-key" not in html
+    assert "***" in html
+    assert "0x" in html
+
+
+def test_relayer_api_key_repr_redacts() -> None:
+    key = RelayerApiKey(key="real-relayer-key", address="0x" + "ab" * 20)
+    assert "real-relayer-key" not in repr(key)
+
+
+def test_repr_html_methods_render_pure_html_strings() -> None:
+    rendered: list[str] = [
+        _make_market()._repr_html_(),
+        _make_event()._repr_html_(),
+        _make_book()._repr_html_(),
+        _make_position()._repr_html_(),
+        OpenOrder.model_validate(_OPEN_ORDER_PAYLOAD)._repr_html_(),
+        ClobTrade.model_validate(_CLOB_TRADE_PAYLOAD)._repr_html_(),
+        PriceHistoryPoint(t=1, p=0.5)._repr_html_(),
+    ]
+    assert all(isinstance(s, str) and s for s in rendered)
+
+
+def test_async_paginator_repr_runs_without_event_loop() -> None:
+    async def fetch(_c: str | None) -> Page[int]:
+        return Page(items=(), has_more=False)
+
+    p = AsyncPaginator[int](fetch=fetch)
+    assert "AsyncPaginator" in repr(p)
+    assert "AsyncPaginator" in p._repr_html_()


### PR DESCRIPTION
adding a small, scoped jupyter integration: select SDK models, paginators, and auth types now render as formatted html cards in notebooks instead of raw pydantic output. pure stdlib - no new dependencies, no `[jupyter]` extra.

also fixes a pre-existing leak where `ApiKeyCreds.key` was exposed by pydantic's default `__repr__`; all three credential fields are now redacted in both `__repr__` and `_repr_html_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly display-layer and tests; the ApiKeyCreds repr change improves credential safety with minor debugging visibility tradeoff.
> 
> **Overview**
> Adds **notebook-friendly HTML display** for common SDK types via a new internal `polymarket._jupyter` helper (`card`, HTML escaping, mid-string truncation, and `safe_html_repr` so render failures fall back to escaped `repr`).
> 
> **`_repr_html_`** is implemented on markets/events, order books, positions, CLOB orders/trades/responses, activity variants, pagination (`Page`, unfetched `Paginator`/`AsyncPaginator`), and auth/credential types so Jupyter shows compact summary cards instead of raw Pydantic dumps. Paginator reprs explicitly avoid triggering fetches.
> 
> **Security fix:** `ApiKeyCreds.key` is no longer shown in default `repr`/`str` (now fully redacted like secret/passphrase), with matching redacted HTML cards for `ApiKeyCreds`, `BuilderApiKey`, and `RelayerApiKey`.
> 
> Docs for `list_builder_trades` now reference `iter_items()` instead of `items()`. Broad unit coverage in `test_jupyter_repr.py`; no new runtime dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2725c2dbb006efcf360d4dc6f60d5a62b8601f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->