### PR TITLE
fix(data): accept global open interest rows

### DIFF
--- a/src/polymarket/models/data/analytics.py
+++ b/src/polymarket/models/data/analytics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Literal
 
 from pydantic import Field, field_validator
 
@@ -8,6 +9,8 @@ from polymarket.models.base import BaseModel
 from polymarket.models.gamma.common import parse_optional_decimal
 from polymarket.models.types import CtfConditionId, TokenId, validate_optional_ctf_condition_id
 from polymarket.types import EvmAddress
+
+OpenInterestMarket = CtfConditionId | Literal["GLOBAL"]
 
 
 class MarketVolume(BaseModel):
@@ -36,12 +39,14 @@ class LiveVolume(BaseModel):
 
 
 class OpenInterest(BaseModel):
-    market: CtfConditionId | None = None
+    market: OpenInterestMarket | None = None
     value: Decimal | None = None
 
     @field_validator("market", mode="before")
     @classmethod
-    def _validate_market(cls, value: object) -> CtfConditionId | None:
+    def _validate_market(cls, value: object) -> OpenInterestMarket | None:
+        if value == "GLOBAL":
+            return "GLOBAL"
         return validate_optional_ctf_condition_id(value)
 
     @field_validator("value", mode="before")

--- a/tests/unit/test_data_models.py
+++ b/tests/unit/test_data_models.py
@@ -101,6 +101,13 @@ def test_open_interest_parses_payload() -> None:
     assert interest.value == Decimal("1500")
 
 
+def test_open_interest_accepts_global_market() -> None:
+    interest = OpenInterest.parse_response({"market": "GLOBAL", "value": "1500"})
+
+    assert interest.market == "GLOBAL"
+    assert interest.value == Decimal("1500")
+
+
 def test_holder_renames_proxy_wallet_and_asset() -> None:
     holder = Holder.parse_response(
         {


### PR DESCRIPTION
## Summary
- Accept the Data API open-interest aggregate row where `market` is `GLOBAL`.
- Keep CTF condition ID validation for normal market rows.
- Add unit coverage for the aggregate sentinel.

## Verification
- `uv run pytest tests/unit/test_data_models.py -q`
- `uv run pytest tests/integration/test_data.py -q`
- `uv run ruff check src/polymarket/models/data/analytics.py tests/unit/test_data_models.py`
- `uv run pyright`
- `uv run ruff check src tests`

Note: full local `uv run pytest tests/unit -q` hit an unrelated RPC connect timeout in `test_secure_client_defaults_wallet_to_current_deposit_wallet`; main CI unit jobs had already passed.
