### PR TITLE
test(clob): extend order visibility polling

### DIFF
--- a/tests/integration/test_clob_orders.py
+++ b/tests/integration/test_clob_orders.py
@@ -38,8 +38,8 @@ async def _wait_for_order_visible(
     *,
     token_id: str,
     order_id: str,
-    attempts: int = 8,
-    delay_s: float = 0.25,
+    attempts: int = 16,
+    delay_s: float = 0.5,
 ) -> bool:
     for _ in range(attempts):
         page = await client.list_open_orders(token_id=token_id).first_page()


### PR DESCRIPTION
## Summary
- extend metered CLOB order visibility polling from ~2s to ~8s
- keeps the existing open-orders read-path assertion while allowing for transient CLOB read latency

## Verification
- POLYMARKET_RUN_METERED_TESTS=1 uv run pytest tests/integration/test_clob_orders.py -q
- uv run ruff check tests/integration/test_clob_orders.py
- uv run pyright tests/integration/test_clob_orders.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only default timing change with no production or API behavior impact.
> 
> **Overview**
> Relaxes **open-order visibility polling** in metered CLOB integration tests by changing `_wait_for_order_visible` defaults from **8 × 0.25s (~2s)** to **16 × 0.5s (~8s)**.
> 
> The helper still polls `list_open_orders` until the placed order appears; only the timeout window grows so flaky failures from transient CLOB read latency are less likely. **Not-visible** and **empty open orders** helpers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60548d5f970d78b8412e829bd13e98c2b1aabf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->