### PR TITLE
fix(client): point Combos RFQ endpoints at polymarket.com domains

### DIFF
--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -43,7 +43,7 @@ class Environment:
     protocol_v2_router: str = "0x12121212006e4CD160D18e3f00711DA5c3372600"
     combinatorial_module: str = "0x30000034706c7d8e12009dab006be20000c031a8"
     position_manager: str = "0x006F54F7f9A22e0000CC2AB60031000000ae9fEF"
-    rfq_quoter_ws_url: str = "wss://combos-rfq-gateway-quoter.polymarket.sh/ws/rfq"
+    rfq_quoter_ws_url: str = "wss://combos-rfq-gateway-quoter.polymarket.com/ws/rfq"
     rfq_quoter_ws_headers: dict[str, str] | None = None
     relayer_max_polls: int = 100
     relayer_poll_frequency_ms: int = 2000
@@ -77,7 +77,7 @@ PRODUCTION = Environment(
     relayer_url="https://relayer-v2.polymarket.com",
     gamma_url="https://gamma-api.polymarket.com",
     data_url="https://data-api.polymarket.com",
-    rfq_url="https://combos-rfq-api.polymarket.sh",
+    rfq_url="https://combos-rfq-api.polymarket.com",
     rtds_ws_url="wss://ws-live-data.polymarket.com",
     sports_ws_url="wss://sports-api.polymarket.com/ws",
     rpc_url="https://polygon.drpc.org",


### PR DESCRIPTION
## Summary

Switch the Combos RFQ production endpoints from the temporary `.sh` domains to the new `.com` domains:

- REST: `https://combos-rfq-api.polymarket.sh` -> `https://combos-rfq-api.polymarket.com`
- Quoter WS: `wss://combos-rfq-gateway-quoter.polymarket.sh/ws/rfq` -> `wss://combos-rfq-gateway-quoter.polymarket.com/ws/rfq`

## Verification

- `uv run pytest tests/unit`: 1694 passed
- Live smoke: `PublicClient().list_combo_markets()` against `combos-rfq-api.polymarket.com` returns combo markets
- WS handshake on `combos-rfq-gateway-quoter.polymarket.com/ws/rfq` returns `101 Switching Protocols`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only hostname swap for RFQ API and WS; behavior unchanged aside from which host clients connect to.
> 
> **Overview**
> Updates **production Combos RFQ** configuration in `environments.py` so clients use the permanent `.com` hosts instead of temporary `.sh` URLs.
> 
> **REST** `rfq_url` on `PRODUCTION` is now `https://combos-rfq-api.polymarket.com`. The default **quoter WebSocket** on `Environment` is now `wss://combos-rfq-gateway-quoter.polymarket.com/ws/rfq`. No other endpoints or contract addresses change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea94a3ae906d317c9285fa6fdd335005390d49fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->