### PR TITLE
fix(models): expose missing activity market icons as None

### DIFF
--- a/src/polymarket/models/data/activity.py
+++ b/src/polymarket/models/data/activity.py
@@ -121,7 +121,7 @@ class TradeActivity(_KnownActivityBase):
     outcome_index: int = Field(validation_alias="outcomeIndex")
     title: str
     slug: str
-    icon: str
+    icon: str | None = None
     event_slug: str = Field(validation_alias="eventSlug")
 
     @field_validator("condition_id", mode="before")
@@ -140,7 +140,7 @@ class _MarketEventActivity(_KnownActivityBase):
     amount: Decimal
     title: str
     slug: str
-    icon: str
+    icon: str | None = None
     event_slug: str = Field(validation_alias="eventSlug")
 
     @field_validator("condition_id", mode="before")
@@ -284,7 +284,7 @@ def _normalize_activity_payload(data: dict[str, Any]) -> dict[str, Any]:
     if normalized.get("outcomeIndex") == 999:
         normalized.pop("outcomeIndex", None)
 
-    for sentinel_key in ("conditionId", "asset", "side", "outcome"):
+    for sentinel_key in ("conditionId", "asset", "side", "outcome", "icon"):
         if normalized.get(sentinel_key) == "":
             normalized.pop(sentinel_key, None)
 

--- a/tests/unit/test_data_activity.py
+++ b/tests/unit/test_data_activity.py
@@ -125,6 +125,18 @@ def test_empty_string_sentinels_drop_to_none_on_trade_raises() -> None:
         parse_activity(payload)
 
 
+def test_trade_empty_icon_normalizes_to_none() -> None:
+    activity = parse_activity(_trade_payload(icon=""))
+    assert isinstance(activity, TradeActivity)
+    assert activity.icon is None
+
+
+def test_market_event_empty_icon_normalizes_to_none() -> None:
+    activity = parse_activity(_market_event_payload("SPLIT", icon=""))
+    assert isinstance(activity, SplitActivity)
+    assert activity.icon is None
+
+
 def test_market_event_variants_parse() -> None:
     for activity_type, expected_class in [
         ("SPLIT", SplitActivity),


### PR DESCRIPTION
Sparse historical activity rows come back with an empty-string `icon`. The strict activity models (`TradeActivity` and the split/merge/redeem/conversion variants) currently surface that `""` as-is, while the TypeScript SDK exposes missing icons as `null`.

This aligns the contract: `icon` is now `str | None` on the strict activity models, and empty-string icons are normalized to `None` during activity payload normalization (same sentinel handling already used for `conditionId`/`asset`/`side`/`outcome`).

Note: the API serializes `icon` as a string and never emits `null` (verified against the payload source and live responses), so this is a parity/ergonomics fix rather than a parse-failure fix.

## Verification

- Added unit tests: TRADE and SPLIT payloads with `icon: ""` parse with `icon is None`.
- `uv run pytest tests/unit -q`: 1698 passed.
- `uv run ruff check .`, `uv run ruff format --check .`: clean.
- `uv run pyright`: 0 errors.
- Live smoke: parsed 500 activity rows from a wallet with 129 sparse rows; all sparse icons surface as `None`, populated icons unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small model and normalization change for an optional display field; no auth, payments, or persistence logic.
> 
> **Overview**
> **Activity `icon` parity with the TypeScript SDK:** sparse API rows send `icon` as `""`. `TradeActivity` and market-event activities (`Split`, `Merge`, `Redeem`, `Conversion`) now type `icon` as `str | None` (default `None`) instead of required `str`.
> 
> **Normalization:** `_normalize_activity_payload` treats empty `icon` like other sentinels (`conditionId`, `asset`, etc.)—the key is dropped so parsing yields `None` rather than `""`.
> 
> Unit tests cover TRADE and SPLIT payloads with `icon: ""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b41f1c77a846804ac468bc8301550736a1188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->