### PR TITLE
feat(models): add parent_event_id to Event

### DIFF
--- a/src/polymarket/models/gamma/event.py
+++ b/src/polymarket/models/gamma/event.py
@@ -257,6 +257,7 @@ class Event(BaseModel):
     """A Polymarket event."""
 
     id: EventId
+    parent_event_id: EventId | None = Field(default=None, validation_alias="parentEventId")
     ticker: str | None = None
     slug: str | None = None
     title: str | None = None
@@ -309,7 +310,7 @@ class Event(BaseModel):
 
         return render(self)
 
-    @field_validator("id", mode="before")
+    @field_validator("id", "parent_event_id", mode="before")
     @classmethod
     def _coerce_id(cls, value: object) -> object:
         return coerce_string_id(value)
@@ -331,6 +332,7 @@ class Event(BaseModel):
 
         return {
             "id": data.get("id"),
+            "parent_event_id": data.get("parentEventId"),
             "ticker": data.get("ticker"),
             "slug": data.get("slug"),
             "title": data.get("title"),

--- a/tests/unit/test_gamma_models.py
+++ b/tests/unit/test_gamma_models.py
@@ -414,6 +414,17 @@ def test_event_accepts_integer_id_per_ts_schema() -> None:
     assert event.id == "902661"
 
 
+def test_event_parent_event_id_coerces_integer_to_event_id() -> None:
+    event = Event.parse_response(_minimal_event_payload(parentEventId=570146))
+
+    assert event.parent_event_id == "570146"
+
+
+def test_event_parent_event_id_defaults_to_none() -> None:
+    assert Event.parse_response(_minimal_event_payload()).parent_event_id is None
+    assert Event.parse_response(_minimal_event_payload(parentEventId=None)).parent_event_id is None
+
+
 def test_event_nested_series_accepts_integer_id() -> None:
     event = Event.parse_response(
         _minimal_event_payload(series=[{"id": 7, "slug": "s1", "title": "Series 1"}])


### PR DESCRIPTION
## Summary

Adds `parent_event_id` to the `Event` model so sports "more markets" events can be linked to their parent game event.

- Exposed as `EventId | None` (not `int`): upstream returns `parentEventId` as an integer while event ids are strings, so the value is coerced through the existing `coerce_string_id` validator to stay comparable with `Event.id`.
- Defaults to `None`; the field is absent on many events and `null` on parents.
- Mapped in both the flat-payload normalizer and the alias path.

## Verification

- `make check` (ruff, format, pyright, pytest) passes. One unrelated network-flaky test (`test_secure_client_defaults_wallet_to_current_deposit_wallet`) timed out once and passed on rerun.
- New unit tests cover int-to-string coercion and absent/null defaults.
- Live smoke: `get_event(id='570555')` returns `parent_event_id == '570146'`, and `get_event(id=child.parent_event_id)` round-trips to the parent event, which itself has `parent_event_id is None`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on the Event parser with existing coercion patterns; no client or API behavior changes in this diff.
> 
> **Overview**
> Adds optional **`parent_event_id`** on the gamma **`Event`** model so child events (e.g. sports “more markets”) can point at their parent game event.
> 
> The API’s **`parentEventId`** is wired through the **`parentEventId`** alias and the flat-payload **`_normalize_event`** path, and integers are coerced to string **`EventId`** via the same **`_coerce_id`** validator used for **`id`**. The field defaults to **`None`** when missing or null.
> 
> Unit tests cover integer coercion and absent/null defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c966aec4368d6f037869385b79efac5c209d48fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->