### PR TITLE
fix(models): normalize empty-string trade and position icons to None

### DIFF
--- a/src/polymarket/models/data/activity.py
+++ b/src/polymarket/models/data/activity.py
@@ -8,7 +8,11 @@ from pydantic import Field, field_validator
 
 from polymarket.errors import UnexpectedResponseError
 from polymarket.models.base import BaseModel
-from polymarket.models.gamma.common import parse_epoch_seconds_optional, parse_optional_decimal
+from polymarket.models.gamma.common import (
+    empty_string_to_none,
+    parse_epoch_seconds_optional,
+    parse_optional_decimal,
+)
 from polymarket.models.types import (
     CtfConditionId,
     TokenId,
@@ -57,6 +61,11 @@ class Trade(BaseModel):
     @classmethod
     def _parse_timestamp(cls, value: object) -> datetime | None:
         return parse_epoch_seconds_optional(value)
+
+    @field_validator("icon", mode="before")
+    @classmethod
+    def _normalize_icon(cls, value: object) -> object | None:
+        return empty_string_to_none(value)
 
 
 ActivityType = Literal[

--- a/src/polymarket/models/data/portfolio.py
+++ b/src/polymarket/models/data/portfolio.py
@@ -8,6 +8,7 @@ from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.gamma.common import (
+    empty_string_to_none,
     parse_epoch_seconds_optional,
     parse_optional_date,
     parse_optional_decimal,
@@ -100,6 +101,11 @@ class Position(BaseModel):
     def _parse_end_date(cls, value: object) -> date | None:
         return parse_optional_date(value)
 
+    @field_validator("icon", mode="before")
+    @classmethod
+    def _normalize_icon(cls, value: object) -> object | None:
+        return empty_string_to_none(value)
+
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid
 
@@ -169,6 +175,11 @@ class ClosedPosition(BaseModel):
     @classmethod
     def _parse_end_date(cls, value: object) -> date | None:
         return parse_optional_date(value)
+
+    @field_validator("icon", mode="before")
+    @classmethod
+    def _normalize_icon(cls, value: object) -> object | None:
+        return empty_string_to_none(value)
 
 
 class ComboPositionMarketEvent(BaseModel):

--- a/tests/unit/test_data_activity.py
+++ b/tests/unit/test_data_activity.py
@@ -15,7 +15,7 @@ from polymarket import (
     YieldActivity,
 )
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.data.activity import parse_activities, parse_activity
+from polymarket.models.data.activity import Trade, parse_activities, parse_activity
 
 _CONDITION_ID = "0x5c19f205507ce03ff5f3be08a8090a5969ea6870cc07b902a4ca2e61dfe48fdd"
 
@@ -135,6 +135,16 @@ def test_market_event_empty_icon_normalizes_to_none() -> None:
     activity = parse_activity(_market_event_payload("SPLIT", icon=""))
     assert isinstance(activity, SplitActivity)
     assert activity.icon is None
+
+
+def test_trade_model_empty_icon_normalizes_to_none() -> None:
+    trade = Trade.parse_response({"icon": ""})
+    assert trade.icon is None
+
+
+def test_trade_model_keeps_populated_icon() -> None:
+    trade = Trade.parse_response({"icon": "https://example.test/icon.png"})
+    assert trade.icon == "https://example.test/icon.png"
 
 
 def test_market_event_variants_parse() -> None:

--- a/tests/unit/test_data_models.py
+++ b/tests/unit/test_data_models.py
@@ -7,12 +7,14 @@ import pytest
 from polymarket.errors import UnexpectedResponseError
 from polymarket.models.data import (
     BuilderVolumeEntry,
+    ClosedPosition,
     ComboPosition,
     Holder,
     LiveVolume,
     MetaHolder,
     OpenInterest,
     PortfolioValue,
+    Position,
     TradedMarketCount,
 )
 
@@ -157,6 +159,26 @@ def test_traded_market_count_parses_payload() -> None:
 
     assert count.user == "0xWALLET"
     assert count.traded == 42
+
+
+def test_position_empty_icon_normalizes_to_none() -> None:
+    position = Position.parse_response({"conditionId": _CTF_CONDITION_ID, "icon": ""})
+
+    assert position.icon is None
+
+
+def test_position_keeps_populated_icon() -> None:
+    position = Position.parse_response(
+        {"conditionId": _CTF_CONDITION_ID, "icon": "https://example.test/icon.png"}
+    )
+
+    assert position.icon == "https://example.test/icon.png"
+
+
+def test_closed_position_empty_icon_normalizes_to_none() -> None:
+    position = ClosedPosition.parse_response({"conditionId": _CTF_CONDITION_ID, "icon": ""})
+
+    assert position.icon is None
 
 
 def test_builder_volume_entry_renames_dt_to_bucket_at() -> None:


### PR DESCRIPTION
Sparse historical rows serialize missing market icons as `""`. The activity models already normalize this to `None` (PR #94); the loose `Trade` model and the `Position`/`ClosedPosition` models still passed `""` through to the public `icon` fields.

This adds an `icon` before-validator using the existing `empty_string_to_none` helper on those three models, so missing icons consistently surface as `None` across the data surface.

Live evidence: 48/500 trades and 2/143 positions with `icon: ""` for a wallet with sparse historical rows.

Linear: DEV-264. Counterpart of ts-sdk PR #124 (DEV-263).

## Verification

- New unit tests: empty `icon` parses to `None` on `Trade`, `Position`, and `ClosedPosition`; populated icons unchanged.
- `uv run pytest tests/unit -q`: 1701 passed.
- `uv run ruff check .`, `uv run ruff format --check .`: clean.
- `uv run pyright`: 0 errors.
- Live smoke: 500 trades (48 sparse) and 143 positions (2 sparse) parse with sparse icons as `None`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parsing-only normalization on optional display fields; behavior change is limited to `""` → `None` with tests covering regressions.
> 
> **Overview**
> Aligns **missing market icon** handling on the loose **`Trade`** model and **`Position` / `ClosedPosition`** with activity parsing: API rows that send `icon: ""` now surface as **`None`** instead of empty strings.
> 
> Each model gets a **`before`** validator on **`icon`** that delegates to the shared **`empty_string_to_none`** helper (same pattern as activity models after PR #94). Non-empty icon URLs are unchanged.
> 
> Unit tests cover empty vs populated **`icon`** on **`Trade`**, **`Position`**, and **`ClosedPosition`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5949925393bb72260a86013c2cf1f37d5201421f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->