### PR TITLE
fix: omit user stream market filter for all markets

### DIFF
--- a/src/polymarket/_internal/streams/clob/user_protocol.py
+++ b/src/polymarket/_internal/streams/clob/user_protocol.py
@@ -35,15 +35,17 @@ def derive_state(subs: Iterable[UserSubscription]) -> UserServerState:
 
 
 def build_initial_frame(state: UserServerState, credentials: ApiKeyCreds) -> dict[str, Any]:
-    return {
+    frame: dict[str, Any] = {
         "type": "user",
         "auth": {
             "apiKey": credentials.key,
             "secret": credentials.secret,
             "passphrase": credentials.passphrase,
         },
-        "markets": list(state.markets),
     }
+    if not state.include_all_markets:
+        frame["markets"] = list(state.markets)
+    return frame
 
 
 def _build_subscribe_update(markets: Iterable[str]) -> dict[str, Any]:

--- a/tests/unit/test_streams_user_manager.py
+++ b/tests/unit/test_streams_user_manager.py
@@ -75,7 +75,7 @@ def test_initial_frame_contains_auth_and_markets() -> None:
     }
 
 
-def test_initial_frame_for_all_markets_uses_empty_markets() -> None:
+def test_initial_frame_for_all_markets_omits_market_filter() -> None:
     received: list[dict[str, Any]] = []
 
     async def handler(ws: ServerConnection) -> None:
@@ -95,7 +95,7 @@ def test_initial_frame_for_all_markets_uses_empty_markets() -> None:
                 await mgr.close()
 
     asyncio.run(run())
-    assert received[0]["markets"] == []
+    assert "markets" not in received[0]
 
 
 def test_credentials_resolved_fresh_per_connection() -> None:
@@ -204,7 +204,7 @@ def test_all_markets_demotion_resubscribes_remaining_narrow() -> None:
 
     asyncio.run(run())
     assert received[0]["type"] == "user"
-    assert received[0]["markets"] == []
+    assert "markets" not in received[0]
     assert {"operation": "subscribe", "markets": ["m1"]} in received
 
 

--- a/tests/unit/test_streams_user_protocol.py
+++ b/tests/unit/test_streams_user_protocol.py
@@ -63,9 +63,12 @@ def test_initial_frame_shape() -> None:
     }
 
 
-def test_initial_frame_all_markets_sends_empty_markets() -> None:
+def test_initial_frame_all_markets_omits_market_filter() -> None:
     state = UserServerState(include_all_markets=True, markets=())
-    assert build_initial_frame(state, _CREDS)["markets"] == []
+    assert build_initial_frame(state, _CREDS) == {
+        "type": "user",
+        "auth": {"apiKey": "K", "secret": "S", "passphrase": "P"},
+    }
 
 
 def test_diff_no_change() -> None:


### PR DESCRIPTION
## Summary
- Omit the user stream `markets` filter when subscribing to all markets
- Keep narrowed user stream subscriptions sending `markets: [...]`
- Update protocol and manager tests for the all-market frame shape

## Verification
- `uv run pytest tests/unit/test_streams_user_protocol.py tests/unit/test_streams_user_manager.py tests/unit/test_streams_user_events.py -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -q`

## Notes
- Compared with the TypeScript SDK. Its user stream builder currently appears to send `markets: []` for broad subscriptions too, so the same behavior likely needs a follow-up there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small WebSocket protocol shape change with focused tests; risk is mainly if a server required `markets: []` rather than a missing field.
> 
> **Overview**
> Fixes the CLOB **user** WebSocket initial subscribe frame when the client wants **all markets**: it no longer sends `markets: []` and instead **omits** the `markets` field entirely. Narrow subscriptions are unchanged and still send `markets` with the explicit market list.
> 
> `build_initial_frame` in `user_protocol.py` gates `markets` on `include_all_markets`. Unit and manager tests were updated to expect no `markets` key for broad subscriptions (including all-markets demotion/promotion flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f3ece018800da5f245dd5bc400e1920718ef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->