### PR TITLE
feat(rfq): support confirmed trade broadcasts

### DIFF
--- a/src/polymarket/__init__.py
+++ b/src/polymarket/__init__.py
@@ -152,6 +152,7 @@ from polymarket.rfq import (
     RfqRequestorPublicId,
     RfqSession,
     RfqSide,
+    RfqTradeEvent,
 )
 from polymarket.transactions import (
     EoaTransactionHandle,
@@ -290,6 +291,7 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
+    "RfqTradeEvent",
     "SearchResults",
     "SearchTag",
     "SecureClient",

--- a/src/polymarket/_internal/rfq.py
+++ b/src/polymarket/_internal/rfq.py
@@ -59,6 +59,7 @@ from polymarket.rfq import (
     RfqRequestedSize,
     RfqRequestedSizeUnit,
     RfqSide,
+    RfqTradeEvent,
 )
 from polymarket.types import EvmAddress, HexString, TransactionHash
 
@@ -434,6 +435,8 @@ class RfqQuoterSession:
                         tx_hash=TransactionHash(tx_hash) if isinstance(tx_hash, str) else None,
                     )
                 )
+            elif message_type == "RFQ_TRADE":
+                self._push(_parse_trade(message))
             elif message_type == "RFQ_ERROR":
                 self._handle_rfq_error(message)
         except BaseException as error:
@@ -631,6 +634,24 @@ def _parse_confirmation_request(
         price=_e6_to_decimal(_expect_str(raw, "price_e6")),
         confirm_by=_expect_int(raw, "confirm_by"),
         _session=session,
+    )
+
+
+def _parse_trade(raw: dict[str, object]) -> RfqTradeEvent:
+    return RfqTradeEvent(
+        type="trade",
+        rfq_id=_expect_str(raw, "rfq_id"),
+        requestor_public_id=_expect_str(raw, "requestor_public_id"),
+        condition_id=_expect_combo_condition_id(raw, "condition_id"),
+        leg_position_ids=tuple(
+            PositionId(item) for item in _expect_str_list(raw, "leg_position_ids")
+        ),
+        direction=RfqDirection(_expect_str(raw, "direction")),
+        side=RfqSide(_expect_str(raw, "side")),
+        price=_e6_to_decimal(_expect_str(raw, "price_e6")),
+        size=_e6_to_decimal(_expect_str(raw, "size_e6")),
+        tx_hash=TransactionHash(_expect_str(raw, "tx_hash")),
+        executed_at=_expect_int(raw, "executed_at"),
     )
 
 

--- a/src/polymarket/rfq.py
+++ b/src/polymarket/rfq.py
@@ -112,6 +112,21 @@ class RfqExecutionUpdateEvent:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class RfqTradeEvent:
+    type: Literal["trade"]
+    rfq_id: RfqId
+    requestor_public_id: RfqRequestorPublicId
+    condition_id: ComboConditionId
+    leg_position_ids: tuple[PositionId, ...]
+    direction: RfqDirection
+    side: RfqSide
+    price: Decimal
+    size: Decimal
+    tx_hash: TransactionHash
+    executed_at: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class RfqQuoteRequestEvent:
     type: Literal["quote_request"]
     rfq_id: RfqId
@@ -166,7 +181,9 @@ class RfqConfirmationRequestEvent:
         )
 
 
-RfqEvent = RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent
+RfqEvent = (
+    RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent | RfqTradeEvent
+)
 
 
 class RfqQuoteRejectedError(PolymarketError):
@@ -259,4 +276,5 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
+    "RfqTradeEvent",
 ]

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -16,10 +16,12 @@ from polymarket.rfq import (
     RfqConfirmationRequestEvent,
     RfqErrorCode,
     RfqExecutionStatus,
+    RfqExecutionUpdateEvent,
     RfqQuoteRejectedError,
     RfqQuoteRequestEvent,
     RfqQuoteSource,
     RfqRequestedSizeUnit,
+    RfqTradeEvent,
 )
 
 pytestmark = pytest.mark.anyio
@@ -118,6 +120,7 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                         }
                     )
                 )
+                await ws.send(json.dumps(_trade_message()))
 
     async with (
         _ws_server(handler) as ws_url,
@@ -135,7 +138,7 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                 ack = await event.confirm()
                 assert ack.rfq_id == RFQ_ID
                 assert ack.quote_id == QUOTE_ID
-            else:
+            elif isinstance(event, RfqExecutionUpdateEvent):
                 assert event.status is RfqExecutionStatus.MINED
                 assert event.tx_hash == TX_HASH
                 break
@@ -164,6 +167,39 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
         "quote_id": QUOTE_ID,
         "decision": "CONFIRM",
     }
+
+
+@pytest.mark.integration
+async def test_rfq_session_receives_confirmed_trade_broadcast(
+    require_env: Callable[[str], str],
+) -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            assert isinstance(raw, str)
+            frame = json.loads(raw)
+            if frame["type"] == "auth":
+                await ws.send(json.dumps({"type": "auth", "success": True}))
+                await ws.send(json.dumps(_trade_message()))
+
+    async with (
+        _ws_server(handler) as ws_url,
+        _rfq_client(require_env, ws_url) as client,
+        client.open_rfq_session() as session,
+    ):
+        async for event in session:
+            assert isinstance(event, RfqTradeEvent)
+            assert event.type == "trade"
+            assert event.rfq_id == RFQ_ID
+            assert event.requestor_public_id == "requestor-abc"
+            assert event.condition_id == CONDITION_ID
+            assert event.leg_position_ids == (YES_POSITION_ID, NO_POSITION_ID)
+            assert event.direction == "BUY"
+            assert event.side == "YES"
+            assert event.price == Decimal("0.125")
+            assert event.size == Decimal("0.8")
+            assert event.tx_hash == TX_HASH
+            assert event.executed_at == 1780854786039
+            break
 
 
 @pytest.mark.integration
@@ -814,6 +850,22 @@ def _manual_quote_frame() -> dict[str, Any]:
             "signer": "0x0000000000000000000000000000000000000001",
             "signatureType": 0,
         },
+    }
+
+
+def _trade_message() -> dict[str, object]:
+    return {
+        "type": "RFQ_TRADE",
+        "rfq_id": RFQ_ID,
+        "requestor_public_id": "requestor-abc",
+        "condition_id": CONDITION_ID,
+        "leg_position_ids": [YES_POSITION_ID, NO_POSITION_ID],
+        "direction": "BUY",
+        "side": "YES",
+        "price_e6": "125000",
+        "size_e6": "800000",
+        "tx_hash": TX_HASH,
+        "executed_at": 1780854786039,
     }
 
 


### PR DESCRIPTION
## Summary
- parse RFQ_TRADE quoter websocket frames
- expose confirmed RFQ trades as typed RfqTradeEvent session events
- convert price_e6 and size_e6 into Decimal values
- re-export RfqTradeEvent from the public package entry point

## Verification
- uv run ruff format && uv run ruff check
- uv run pyright
- uv run pytest tests/integration/test_rfq.py
- uv run pytest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RFQ websocket handling and types only; no changes to quoting, signing, or execution flows.
> 
> **Overview**
> RFQ quoter websocket sessions now handle **`RFQ_TRADE`** frames and surface them as typed **`RfqTradeEvent`** items on the existing async event stream (alongside quote, confirmation, and execution updates).
> 
> The new event carries RFQ id, requestor, combo condition and legs, direction/side, **`price`** and **`size`** as `Decimal` (from `price_e6` / `size_e6`), **`tx_hash`**, and **`executed_at`**. **`RfqTradeEvent`** is included in the **`RfqEvent`** union and re-exported from the public package. Integration tests cover a standalone trade broadcast and wire parsing via a shared **`_trade_message()`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ba05b249cbbff4f22b27e45cd4d1645aaa89f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->