### PR TITLE
revert(rfq): remove confirmed trade broadcasts

### DIFF
--- a/src/polymarket/__init__.py
+++ b/src/polymarket/__init__.py
@@ -152,7 +152,6 @@ from polymarket.rfq import (
     RfqRequestorPublicId,
     RfqSession,
     RfqSide,
-    RfqTradeEvent,
 )
 from polymarket.transactions import (
     EoaTransactionHandle,
@@ -291,7 +290,6 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
-    "RfqTradeEvent",
     "SearchResults",
     "SearchTag",
     "SecureClient",

--- a/src/polymarket/_internal/rfq.py
+++ b/src/polymarket/_internal/rfq.py
@@ -59,7 +59,6 @@ from polymarket.rfq import (
     RfqRequestedSize,
     RfqRequestedSizeUnit,
     RfqSide,
-    RfqTradeEvent,
 )
 from polymarket.types import EvmAddress, HexString, TransactionHash
 
@@ -435,8 +434,6 @@ class RfqQuoterSession:
                         tx_hash=TransactionHash(tx_hash) if isinstance(tx_hash, str) else None,
                     )
                 )
-            elif message_type == "RFQ_TRADE":
-                self._push(_parse_trade(message))
             elif message_type == "RFQ_ERROR":
                 self._handle_rfq_error(message)
         except BaseException as error:
@@ -634,24 +631,6 @@ def _parse_confirmation_request(
         price=_e6_to_decimal(_expect_str(raw, "price_e6")),
         confirm_by=_expect_int(raw, "confirm_by"),
         _session=session,
-    )
-
-
-def _parse_trade(raw: dict[str, object]) -> RfqTradeEvent:
-    return RfqTradeEvent(
-        type="trade",
-        rfq_id=_expect_str(raw, "rfq_id"),
-        requestor_public_id=_expect_str(raw, "requestor_public_id"),
-        condition_id=_expect_combo_condition_id(raw, "condition_id"),
-        leg_position_ids=tuple(
-            PositionId(item) for item in _expect_str_list(raw, "leg_position_ids")
-        ),
-        direction=RfqDirection(_expect_str(raw, "direction")),
-        side=RfqSide(_expect_str(raw, "side")),
-        price=_e6_to_decimal(_expect_str(raw, "price_e6")),
-        size=_e6_to_decimal(_expect_str(raw, "size_e6")),
-        tx_hash=TransactionHash(_expect_str(raw, "tx_hash")),
-        executed_at=_expect_int(raw, "executed_at"),
     )
 
 

--- a/src/polymarket/rfq.py
+++ b/src/polymarket/rfq.py
@@ -112,21 +112,6 @@ class RfqExecutionUpdateEvent:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class RfqTradeEvent:
-    type: Literal["trade"]
-    rfq_id: RfqId
-    requestor_public_id: RfqRequestorPublicId
-    condition_id: ComboConditionId
-    leg_position_ids: tuple[PositionId, ...]
-    direction: RfqDirection
-    side: RfqSide
-    price: Decimal
-    size: Decimal
-    tx_hash: TransactionHash
-    executed_at: int
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
 class RfqQuoteRequestEvent:
     type: Literal["quote_request"]
     rfq_id: RfqId
@@ -181,9 +166,7 @@ class RfqConfirmationRequestEvent:
         )
 
 
-RfqEvent = (
-    RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent | RfqTradeEvent
-)
+RfqEvent = RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent
 
 
 class RfqQuoteRejectedError(PolymarketError):
@@ -276,5 +259,4 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
-    "RfqTradeEvent",
 ]

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -16,12 +16,10 @@ from polymarket.rfq import (
     RfqConfirmationRequestEvent,
     RfqErrorCode,
     RfqExecutionStatus,
-    RfqExecutionUpdateEvent,
     RfqQuoteRejectedError,
     RfqQuoteRequestEvent,
     RfqQuoteSource,
     RfqRequestedSizeUnit,
-    RfqTradeEvent,
 )
 
 pytestmark = pytest.mark.anyio
@@ -120,7 +118,6 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                         }
                     )
                 )
-                await ws.send(json.dumps(_trade_message()))
 
     async with (
         _ws_server(handler) as ws_url,
@@ -138,7 +135,7 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                 ack = await event.confirm()
                 assert ack.rfq_id == RFQ_ID
                 assert ack.quote_id == QUOTE_ID
-            elif isinstance(event, RfqExecutionUpdateEvent):
+            else:
                 assert event.status is RfqExecutionStatus.MINED
                 assert event.tx_hash == TX_HASH
                 break
@@ -167,39 +164,6 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
         "quote_id": QUOTE_ID,
         "decision": "CONFIRM",
     }
-
-
-@pytest.mark.integration
-async def test_rfq_session_receives_confirmed_trade_broadcast(
-    require_env: Callable[[str], str],
-) -> None:
-    async def handler(ws: ServerConnection) -> None:
-        async for raw in ws:
-            assert isinstance(raw, str)
-            frame = json.loads(raw)
-            if frame["type"] == "auth":
-                await ws.send(json.dumps({"type": "auth", "success": True}))
-                await ws.send(json.dumps(_trade_message()))
-
-    async with (
-        _ws_server(handler) as ws_url,
-        _rfq_client(require_env, ws_url) as client,
-        client.open_rfq_session() as session,
-    ):
-        async for event in session:
-            assert isinstance(event, RfqTradeEvent)
-            assert event.type == "trade"
-            assert event.rfq_id == RFQ_ID
-            assert event.requestor_public_id == "requestor-abc"
-            assert event.condition_id == CONDITION_ID
-            assert event.leg_position_ids == (YES_POSITION_ID, NO_POSITION_ID)
-            assert event.direction == "BUY"
-            assert event.side == "YES"
-            assert event.price == Decimal("0.125")
-            assert event.size == Decimal("0.8")
-            assert event.tx_hash == TX_HASH
-            assert event.executed_at == 1780854786039
-            break
 
 
 @pytest.mark.integration
@@ -850,22 +814,6 @@ def _manual_quote_frame() -> dict[str, Any]:
             "signer": "0x0000000000000000000000000000000000000001",
             "signatureType": 0,
         },
-    }
-
-
-def _trade_message() -> dict[str, object]:
-    return {
-        "type": "RFQ_TRADE",
-        "rfq_id": RFQ_ID,
-        "requestor_public_id": "requestor-abc",
-        "condition_id": CONDITION_ID,
-        "leg_position_ids": [YES_POSITION_ID, NO_POSITION_ID],
-        "direction": "BUY",
-        "side": "YES",
-        "price_e6": "125000",
-        "size_e6": "800000",
-        "tx_hash": TX_HASH,
-        "executed_at": 1780854786039,
     }
 
 


### PR DESCRIPTION
## Summary
- revert py-sdk PR #104 while the backend RFQ_TRADE broadcast is not deployed
- remove RFQ_TRADE parsing, RfqTradeEvent exports, and integration coverage

## Verification
- uv run ruff format --check && uv run ruff check
- uv run pyright
- uv run pytest tests/integration/test_rfq.py started but did not complete because live API key derivation was rate limited with HTTP 429 after 10 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API removal aligned with undeployed backend behavior; no changes to quote, confirm, or execution-update flows.
> 
> **Overview**
> Reverts RFQ **confirmed trade** websocket support until the backend `RFQ_TRADE` broadcast is deployed.
> 
> The public **`RfqTradeEvent`** type and its export from `polymarket` / `polymarket.rfq` are removed, and **`RfqEvent`** again only covers quote requests, confirmation requests, and execution updates. The quoter session no longer handles **`RFQ_TRADE`** messages or **`_parse_trade`**.
> 
> Integration tests drop the dedicated trade-broadcast case and the happy-path flow stops after **`RFQ_EXECUTION_UPDATE`** instead of also expecting a trade event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3eab9f706b14465557d68dcfcb47e22924ae16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->