### PR TITLE
feat(rfq): expose RFQ error IDs

### DIFF
--- a/src/polymarket/_internal/rfq.py
+++ b/src/polymarket/_internal/rfq.py
@@ -451,6 +451,9 @@ class RfqQuoterSession:
         request_type = raw.get("request_type")
         rfq_id = raw.get("rfq_id")
         quote_id = raw.get("quote_id")
+        error_id = raw.get("error_id")
+        if error_id is not None and not isinstance(error_id, str):
+            raise UnexpectedResponseError("Expected RFQ error_id to be a string.")
         code = _parse_error_code(raw.get("code"))
         message = raw.get("error")
         text = message if isinstance(message, str) else "RFQ request failed."
@@ -459,7 +462,7 @@ class RfqQuoterSession:
                 raise TransportError("Uncorrelated RFQ quoter error.")
             self._reject(
                 _quote_ack_key(rfq_id),
-                RfqQuoteRejectedError(text, rfq_id=rfq_id, code=code),
+                RfqQuoteRejectedError(text, rfq_id=rfq_id, code=code, error_id=error_id),
             )
         elif request_type == "RFQ_QUOTE_CANCEL":
             if not isinstance(rfq_id, str) or not isinstance(quote_id, str):
@@ -471,6 +474,7 @@ class RfqQuoterSession:
                     rfq_id=rfq_id,
                     quote_id=quote_id,
                     code=code,
+                    error_id=error_id,
                 ),
             )
         elif request_type == "RFQ_CONFIRMATION_RESPONSE":
@@ -483,6 +487,7 @@ class RfqQuoterSession:
                     rfq_id=rfq_id,
                     quote_id=quote_id,
                     code=code,
+                    error_id=error_id,
                 ),
             )
 

--- a/src/polymarket/rfq.py
+++ b/src/polymarket/rfq.py
@@ -63,6 +63,8 @@ class RfqErrorCode(StrEnum):
     INVALID_RFQ = "INVALID_RFQ"
     INVALID_RFQ_STATE = "INVALID_RFQ_STATE"
     INVALID_ROLE = "INVALID_ROLE"
+    INVALID_SIGNATURE = "INVALID_SIGNATURE"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
     LEG_METADATA_UNAVAILABLE = "LEG_METADATA_UNAVAILABLE"
     MAKER_ALREADY_RESPONDED = "MAKER_ALREADY_RESPONDED"
     MAKER_NOT_REQUIRED = "MAKER_NOT_REQUIRED"
@@ -170,10 +172,18 @@ RfqEvent = RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpda
 
 
 class RfqQuoteRejectedError(PolymarketError):
-    def __init__(self, message: str, *, rfq_id: RfqId, code: RfqErrorCode | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        rfq_id: RfqId,
+        code: RfqErrorCode | None = None,
+        error_id: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.rfq_id = rfq_id
         self.code = code
+        self.error_id = error_id
 
 
 class RfqCancelQuoteRejectedError(PolymarketError):
@@ -184,11 +194,13 @@ class RfqCancelQuoteRejectedError(PolymarketError):
         rfq_id: RfqId,
         quote_id: RfqQuoteId,
         code: RfqErrorCode | None = None,
+        error_id: str | None = None,
     ) -> None:
         super().__init__(message)
         self.rfq_id = rfq_id
         self.quote_id = quote_id
         self.code = code
+        self.error_id = error_id
 
 
 class RfqConfirmationRejectedError(PolymarketError):
@@ -199,11 +211,13 @@ class RfqConfirmationRejectedError(PolymarketError):
         rfq_id: RfqId,
         quote_id: RfqQuoteId,
         code: RfqErrorCode | None = None,
+        error_id: str | None = None,
     ) -> None:
         super().__init__(message)
         self.rfq_id = rfq_id
         self.quote_id = quote_id
         self.code = code
+        self.error_id = error_id
 
 
 @runtime_checkable

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -389,6 +389,7 @@ async def test_rfq_session_quote_rejection_raises_typed_error(
                         {
                             "type": "RFQ_ERROR",
                             "request_type": "RFQ_QUOTE",
+                            "error_id": "reqerr-1",
                             "rfq_id": RFQ_ID,
                             "code": code,
                             "error": "quote rejected",
@@ -406,6 +407,7 @@ async def test_rfq_session_quote_rejection_raises_typed_error(
             with pytest.raises(RfqQuoteRejectedError, match="quote rejected") as exc_info:
                 await event.quote(price=Decimal("0.45"))
             assert exc_info.value.code == code
+            assert exc_info.value.error_id == "reqerr-1"
             break
 
 


### PR DESCRIPTION
## Summary
- Parse RFQ error_id payloads.
- Expose error_id on RFQ rejection errors.
- Recognize INVALID_SIGNATURE and INTERNAL_ERROR.

## Validation
- make check
- RFQ integration tests require credentials and were skipped locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API on RFQ error types and stricter validation only when error_id is present; no auth or trading path changes.
> 
> **Overview**
> RFQ websocket **RFQ_ERROR** responses can include an **`error_id`** for support and correlation. The quoter session now reads that field (optional string), rejects malformed non-string values with **`UnexpectedResponseError`**, and attaches **`error_id`** on **`RfqQuoteRejectedError`**, **`RfqCancelQuoteRejectedError`**, and **`RfqConfirmationRejectedError`**.
> 
> **`RfqErrorCode`** adds **`INVALID_SIGNATURE`** and **`INTERNAL_ERROR`** so those server codes parse without unknown-code failures. Integration coverage asserts **`error_id`** on quote rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c907fc692a8bae9e970a96b5ec101e26e20e3b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->