### PR TITLE
feat(rfq): expose confirmed trade broadcasts

### DIFF
--- a/src/polymarket/__init__.py
+++ b/src/polymarket/__init__.py
@@ -152,6 +152,7 @@ from polymarket.rfq import (
     RfqRequestorPublicId,
     RfqSession,
     RfqSide,
+    RfqTradeEvent,
 )
 from polymarket.transactions import (
     EoaTransactionHandle,
@@ -290,6 +291,7 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
+    "RfqTradeEvent",
     "SearchResults",
     "SearchTag",
     "SecureClient",

--- a/src/polymarket/_internal/rfq.py
+++ b/src/polymarket/_internal/rfq.py
@@ -59,6 +59,7 @@ from polymarket.rfq import (
     RfqRequestedSize,
     RfqRequestedSizeUnit,
     RfqSide,
+    RfqTradeEvent,
 )
 from polymarket.types import EvmAddress, HexString, TransactionHash
 
@@ -434,6 +435,8 @@ class RfqQuoterSession:
                         tx_hash=TransactionHash(tx_hash) if isinstance(tx_hash, str) else None,
                     )
                 )
+            elif message_type == "RFQ_TRADE":
+                self._push(_parse_trade(message))
             elif message_type == "RFQ_ERROR":
                 self._handle_rfq_error(message)
         except BaseException as error:
@@ -631,6 +634,23 @@ def _parse_confirmation_request(
         price=_e6_to_decimal(_expect_str(raw, "price_e6")),
         confirm_by=_expect_int(raw, "confirm_by"),
         _session=session,
+    )
+
+
+def _parse_trade(raw: dict[str, object]) -> RfqTradeEvent:
+    return RfqTradeEvent(
+        type="trade",
+        rfq_id=_expect_str(raw, "rfq_id"),
+        requester_id=_expect_str(raw, "requester_id"),
+        condition_id=_expect_combo_condition_id(raw, "condition_id"),
+        leg_position_ids=tuple(
+            PositionId(item) for item in _expect_str_list(raw, "leg_position_ids")
+        ),
+        direction=RfqDirection(_expect_str(raw, "direction")),
+        side=RfqSide(_expect_str(raw, "side")),
+        price=_e6_to_decimal(_expect_str(raw, "price_e6")),
+        size=_e6_to_decimal(_expect_str(raw, "size_e6")),
+        executed_at=_expect_int(raw, "executed_at"),
     )
 
 

--- a/src/polymarket/rfq.py
+++ b/src/polymarket/rfq.py
@@ -112,6 +112,20 @@ class RfqExecutionUpdateEvent:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class RfqTradeEvent:
+    type: Literal["trade"]
+    rfq_id: RfqId
+    requester_id: RfqRequestorPublicId
+    condition_id: ComboConditionId
+    leg_position_ids: tuple[PositionId, ...]
+    direction: RfqDirection
+    side: RfqSide
+    price: Decimal
+    size: Decimal
+    executed_at: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class RfqQuoteRequestEvent:
     type: Literal["quote_request"]
     rfq_id: RfqId
@@ -166,7 +180,9 @@ class RfqConfirmationRequestEvent:
         )
 
 
-RfqEvent = RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent
+RfqEvent = (
+    RfqQuoteRequestEvent | RfqConfirmationRequestEvent | RfqExecutionUpdateEvent | RfqTradeEvent
+)
 
 
 class RfqQuoteRejectedError(PolymarketError):
@@ -259,4 +275,5 @@ __all__ = [
     "RfqRequestorPublicId",
     "RfqSession",
     "RfqSide",
+    "RfqTradeEvent",
 ]

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -16,10 +16,12 @@ from polymarket.rfq import (
     RfqConfirmationRequestEvent,
     RfqErrorCode,
     RfqExecutionStatus,
+    RfqExecutionUpdateEvent,
     RfqQuoteRejectedError,
     RfqQuoteRequestEvent,
     RfqQuoteSource,
     RfqRequestedSizeUnit,
+    RfqTradeEvent,
 )
 
 pytestmark = pytest.mark.anyio
@@ -96,6 +98,7 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                         }
                     )
                 )
+                await ws.send(json.dumps(_trade_message()))
                 await ws.send(json.dumps(_confirmation_request_message(frame)))
             elif frame["type"] == "RFQ_CONFIRMATION_RESPONSE":
                 await ws.send(
@@ -135,7 +138,7 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
                 ack = await event.confirm()
                 assert ack.rfq_id == RFQ_ID
                 assert ack.quote_id == QUOTE_ID
-            else:
+            elif isinstance(event, RfqExecutionUpdateEvent):
                 assert event.status is RfqExecutionStatus.MINED
                 assert event.tx_hash == TX_HASH
                 break
@@ -164,6 +167,39 @@ async def test_rfq_session_quotes_confirms_and_receives_execution_update(
         "quote_id": QUOTE_ID,
         "decision": "CONFIRM",
     }
+
+
+@pytest.mark.integration
+async def test_rfq_session_receives_confirmed_trade_broadcast(
+    require_env: Callable[[str], str],
+) -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            assert isinstance(raw, str)
+            frame = json.loads(raw)
+            if frame["type"] == "auth":
+                await ws.send(json.dumps({"type": "auth", "success": True}))
+                await ws.send(json.dumps(_trade_message()))
+
+    async with (
+        _ws_server(handler) as ws_url,
+        _rfq_client(require_env, ws_url) as client,
+        client.open_rfq_session() as session,
+    ):
+        async for event in session:
+            assert isinstance(event, RfqTradeEvent)
+            assert event.type == "trade"
+            assert event.rfq_id == RFQ_ID
+            assert event.requester_id == "requester-abc"
+            assert event.condition_id == CONDITION_ID
+            assert event.leg_position_ids == (YES_POSITION_ID, NO_POSITION_ID)
+            assert event.direction == "BUY"
+            assert event.side == "YES"
+            assert event.price == Decimal("0.125")
+            assert event.size == Decimal("0.8")
+            assert not hasattr(event, "tx_hash")
+            assert event.executed_at == 1780854786039
+            break
 
 
 @pytest.mark.integration
@@ -814,6 +850,21 @@ def _manual_quote_frame() -> dict[str, Any]:
             "signer": "0x0000000000000000000000000000000000000001",
             "signatureType": 0,
         },
+    }
+
+
+def _trade_message() -> dict[str, object]:
+    return {
+        "type": "RFQ_TRADE",
+        "rfq_id": RFQ_ID,
+        "requester_id": "requester-abc",
+        "condition_id": CONDITION_ID,
+        "leg_position_ids": [YES_POSITION_ID, NO_POSITION_ID],
+        "direction": "BUY",
+        "side": "YES",
+        "price_e6": "125000",
+        "size_e6": "800000",
+        "executed_at": 1780854786039,
     }
 
 


### PR DESCRIPTION
## Summary
- expose confirmed public `RFQ_TRADE` websocket frames as typed `RfqTradeEvent` session events
- use the finalized public wire contract: `requester_id`, combo `condition_id`, legs, direction, side, price, size, and execution timestamp
- intentionally omit the settlement transaction hash from public trade events; makers still receive it through their private `RFQ_EXECUTION_UPDATE`

## Scope
- implemented independently from `main`; no dependency on Cesare's reverted branch or commits
- follows the established RFQ SDK model, parser, export, and local-websocket integration-test conventions
- pairs with https://github.com/Polymarket/combos-rfq/pull/110

## Verification
- `ruff format --check .`
- `ruff check .`
- strict Pyright over changed RFQ files
- direct `RFQ_TRADE` parser smoke check
- GitHub Actions pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RFQ event type and websocket parsing with no changes to quoting, signing, or settlement paths.
> 
> **Overview**
> RFQ quoter websocket sessions now surface public **`RFQ_TRADE`** frames as typed **`RfqTradeEvent`** items on the existing event stream, alongside quote, confirmation, and execution-update events.
> 
> Each trade event carries the finalized public wire fields (`requester_id`, combo `condition_id`, legs, direction, side, price, size, `executed_at`) with e6 decimals converted to `Decimal`. **Settlement `tx_hash` is intentionally omitted** from the public trade shape; makers still get it via private **`RfqExecutionUpdateEvent`**.
> 
> The internal quoter parses `RFQ_TRADE` in `_on_message`, **`RfqTradeEvent` is exported** from the package, and integration tests cover standalone trade broadcast reception and trade frames interleaved in the quote/confirm flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c91ac89a0e5a0d05ec0ee8a86c0ab1ad6b09fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->