### PR TITLE
fix(gamma): type search sort fields

### DIFF
--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -43,6 +43,15 @@ from polymarket.models.gamma.common import parse_string_sequence
 CommentParentEntityType = Literal["Event", "Series"]
 TagMatch = Literal["any", "all"]
 Recurrence = Literal["daily", "weekly", "monthly"]
+SearchSort = Literal[
+    "volume",
+    "volume_24hr",
+    "liquidity",
+    "competitive",
+    "closed_time",
+    "start_date",
+    "end_date",
+]
 
 _T = TypeVar("_T")
 
@@ -172,6 +181,22 @@ def _add_optional_seq(
 def _check_recurrence(value: Recurrence | None) -> None:
     if value is not None and value not in {"daily", "weekly", "monthly"}:
         raise UserInputError("recurrence must be one of: daily, weekly, monthly")
+
+
+def _check_search_sort(value: SearchSort | None) -> None:
+    if value is not None and value not in {
+        "volume",
+        "volume_24hr",
+        "liquidity",
+        "competitive",
+        "closed_time",
+        "start_date",
+        "end_date",
+    }:
+        raise UserInputError(
+            "sort must be one of: volume, volume_24hr, liquidity, competitive, "
+            "closed_time, start_date, end_date"
+        )
 
 
 def _check_tag_match(value: TagMatch | None) -> None:
@@ -689,10 +714,11 @@ def search_spec(
     recurrence: Recurrence | None = None,
     search_profiles: bool | None = None,
     search_tags: bool | None = None,
-    sort: str | None = None,
+    sort: SearchSort | None = None,
 ) -> PageBasedSpec[SearchResults]:
     require_nonempty("q", q)
     _check_recurrence(recurrence)
+    _check_search_sort(sort)
 
     params: dict[str, QueryParamValue] = {"q": q}
     _add_optional(params, "ascending", ascending)

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -29,6 +29,7 @@ from polymarket._internal.actions.gamma import (
     CommentParentEntityType,
     DateFilter,
     Recurrence,
+    SearchSort,
     TagMatch,
     TimestampFilter,
 )
@@ -1061,10 +1062,17 @@ class AsyncPublicClient:
         recurrence: Recurrence | None = None,
         search_profiles: bool | None = None,
         search_tags: bool | None = None,
-        sort: str | None = None,
+        sort: SearchSort | None = None,
         page_size: int = 10,
     ) -> AsyncPaginator[SearchResults]:
         """Search Polymarket content.
+
+        Args:
+            keep_closed_markets: Include markets closed within this many hours when
+                searching active events.
+            sort: Event sort field. Supported values are ``volume``, ``volume_24hr``,
+                ``liquidity``, ``competitive``, ``closed_time``, ``start_date``, and
+                ``end_date``.
 
         Returns:
             An async paginator over search result pages.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -45,6 +45,7 @@ from polymarket._internal.actions.gamma import (
     CommentParentEntityType,
     DateFilter,
     Recurrence,
+    SearchSort,
     TagMatch,
     TimestampFilter,
 )
@@ -1489,10 +1490,17 @@ class AsyncSecureClient:
         recurrence: Recurrence | None = None,
         search_profiles: bool | None = None,
         search_tags: bool | None = None,
-        sort: str | None = None,
+        sort: SearchSort | None = None,
         page_size: int = 10,
     ) -> AsyncPaginator[SearchResults]:
         """Search Polymarket content.
+
+        Args:
+            keep_closed_markets: Include markets closed within this many hours when
+                searching active events.
+            sort: Event sort field. Supported values are ``volume``, ``volume_24hr``,
+                ``liquidity``, ``competitive``, ``closed_time``, ``start_date``, and
+                ``end_date``.
 
         Returns:
             An async paginator over search result pages.

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -28,6 +28,7 @@ from polymarket._internal.actions.gamma import (
     CommentParentEntityType,
     DateFilter,
     Recurrence,
+    SearchSort,
     TagMatch,
     TimestampFilter,
 )
@@ -915,10 +916,17 @@ class PublicClient:
         recurrence: Recurrence | None = None,
         search_profiles: bool | None = None,
         search_tags: bool | None = None,
-        sort: str | None = None,
+        sort: SearchSort | None = None,
         page_size: int = 10,
     ) -> Paginator[SearchResults]:
         """Search Polymarket content.
+
+        Args:
+            keep_closed_markets: Include markets closed within this many hours when
+                searching active events.
+            sort: Event sort field. Supported values are ``volume``, ``volume_24hr``,
+                ``liquidity``, ``competitive``, ``closed_time``, ``start_date``, and
+                ``end_date``.
 
         Returns:
             A paginator over search result pages.

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -35,6 +35,7 @@ from polymarket._internal.actions.gamma import (
     CommentParentEntityType,
     DateFilter,
     Recurrence,
+    SearchSort,
     TagMatch,
     TimestampFilter,
 )
@@ -1222,10 +1223,17 @@ class SecureClient:
         recurrence: Recurrence | None = None,
         search_profiles: bool | None = None,
         search_tags: bool | None = None,
-        sort: str | None = None,
+        sort: SearchSort | None = None,
         page_size: int = 10,
     ) -> Paginator[SearchResults]:
         """Search Polymarket content.
+
+        Args:
+            keep_closed_markets: Include markets closed within this many hours when
+                searching active events.
+            sort: Event sort field. Supported values are ``volume``, ``volume_24hr``,
+                ``liquidity``, ``competitive``, ``closed_time``, ``start_date``, and
+                ``end_date``.
 
         Returns:
             A paginator over search result pages.

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -221,7 +221,7 @@ def test_search_spec_builds_request_with_filters() -> None:
         ascending=True,
         events_tag=["politics"],
         exclude_tag_ids=[5, 6],
-        sort="recent",
+        sort="volume",
     )
 
     assert isinstance(spec, PageBasedSpec)
@@ -232,13 +232,18 @@ def test_search_spec_builds_request_with_filters() -> None:
         "ascending": True,
         "events_tag": ("politics",),
         "exclude_tag_id": (5, 6),
-        "sort": "recent",
+        "sort": "volume",
     }
 
 
 def test_search_spec_rejects_invalid_recurrence() -> None:
     with pytest.raises(UserInputError, match="recurrence must be one of"):
         gamma_actions.search_spec(q="x", recurrence="yearly")  # type: ignore[arg-type]
+
+
+def test_search_spec_rejects_invalid_sort() -> None:
+    with pytest.raises(UserInputError, match="sort must be one of"):
+        gamma_actions.search_spec(q="x", sort="recent")  # type: ignore[arg-type]
 
 
 def test_list_markets_spec_treats_bare_slug_string_as_single_item() -> None:


### PR DESCRIPTION
## Summary
- add a `SearchSort` literal for supported search sort fields
- validate unsupported search sort values instead of silently forwarding them
- clarify that `keep_closed_markets` is an hour window, not a boolean

## Verification
- `uv run pytest tests/unit/test_gamma_paginated_specs.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `make check`