### PR TITLE
fix(gamma): preserve market group item title

### DIFF
--- a/src/polymarket/models/gamma/market.py
+++ b/src/polymarket/models/gamma/market.py
@@ -382,6 +382,7 @@ class Market(BaseModel):
         validation_alias=AliasChoices("conditionId", "condition"),
     )
     question: str | None = None
+    group_item_title: str | None = Field(default=None, validation_alias="groupItemTitle")
     description: str | None = None
     category: str | None = None
     image: str | None = None
@@ -458,6 +459,7 @@ class Market(BaseModel):
             "slug": data.get("slug"),
             "condition_id": empty_string_to_none(data.get("conditionId")),
             "question": data.get("question"),
+            "group_item_title": data.get("groupItemTitle"),
             "description": data.get("description"),
             "category": data.get("category"),
             "image": data.get("image"),

--- a/tests/unit/test_gamma_models.py
+++ b/tests/unit/test_gamma_models.py
@@ -57,6 +57,7 @@ def test_market_normalizes_groups_from_flat_payload() -> None:
     payload = _minimal_market_payload(
         slug="my-market",
         question="Will it rain?",
+        groupItemTitle="Rain tomorrow",
         description="A market.",
         category="weather",
         image="https://example.test/i.png",
@@ -108,6 +109,7 @@ def test_market_normalizes_groups_from_flat_payload() -> None:
 
     assert market.slug == "my-market"
     assert market.condition_id == _CONDITION_ID
+    assert market.group_item_title == "Rain tomorrow"
     assert market.state.active is True
     assert market.state.start_date == datetime(2026, 5, 1, tzinfo=UTC)
     assert market.state.end_date == datetime(2026, 6, 1, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- add group_item_title to the Market model
- preserve groupItemTitle when parsing market responses
- cover the field in the existing gamma model test

## Verification
- uv run pytest tests/unit/test_gamma_models.py
- uv run ruff check
- uv run pyright

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional string field on a Pydantic model with a unit test; no auth, trading, or behavioral logic changes.
> 
> **Overview**
> Gamma `Market` parsing now keeps **`groupItemTitle`** from API payloads as **`group_item_title`**, matching how grouped markets label individual legs.
> 
> The new field is on the model (with a `groupItemTitle` alias) and is copied in **`_normalize_market`** when flattening raw responses. A unit test asserts the value survives **`Market.parse_response`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264ef6068aae49f69dfb9f826ede1f2b5ade58cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->