### PR TITLE
feat(clients): add typed overloads for mutually-exclusive lookup args

### DIFF
--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -348,6 +348,18 @@ class AsyncPublicClient:
                                     finally:
                                         await self._ctx.perps.close()
 
+    @overload
+    async def get_market(
+        self, *, id: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    async def get_market(
+        self, *, slug: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    async def get_market(
+        self, *, url: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
     async def get_market(
         self,
         *,
@@ -373,6 +385,36 @@ class AsyncPublicClient:
         """Get a market's tags."""
         return await async_dispatch(self._ctx, _gamma_actions.get_market_tags_spec(id))
 
+    @overload
+    async def get_event(
+        self,
+        *,
+        id: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    async def get_event(
+        self,
+        *,
+        slug: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    async def get_event(
+        self,
+        *,
+        url: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
     async def get_event(
         self,
         *,
@@ -414,6 +456,12 @@ class AsyncPublicClient:
             _gamma_actions.get_series_spec(id, locale=locale),
         )
 
+    @overload
+    async def get_tag(
+        self, *, id: str, include_template: bool | None = None, locale: str | None = None
+    ) -> Tag: ...
+    @overload
+    async def get_tag(self, *, slug: str, locale: str | None = None) -> Tag: ...
     async def get_tag(
         self,
         *,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -919,6 +919,18 @@ class AsyncSecureClient:
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user
 
+    @overload
+    async def get_market(
+        self, *, id: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    async def get_market(
+        self, *, slug: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    async def get_market(
+        self, *, url: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
     async def get_market(
         self,
         *,
@@ -944,6 +956,36 @@ class AsyncSecureClient:
         """Get a market's tags."""
         return await async_dispatch(self._ctx, _gamma_actions.get_market_tags_spec(id))
 
+    @overload
+    async def get_event(
+        self,
+        *,
+        id: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    async def get_event(
+        self,
+        *,
+        slug: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    async def get_event(
+        self,
+        *,
+        url: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
     async def get_event(
         self,
         *,
@@ -985,6 +1027,12 @@ class AsyncSecureClient:
             _gamma_actions.get_series_spec(id, locale=locale),
         )
 
+    @overload
+    async def get_tag(
+        self, *, id: str, include_template: bool | None = None, locale: str | None = None
+    ) -> Tag: ...
+    @overload
+    async def get_tag(self, *, slug: str, locale: str | None = None) -> Tag: ...
     async def get_tag(
         self,
         *,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -2685,6 +2685,18 @@ class AsyncSecureClient:
         )
         return await self.execute_transaction(calls=calls, metadata=resolved_metadata)
 
+    @overload
+    async def redeem_positions(
+        self, *, condition_id: str, metadata: str | None = None
+    ) -> TransactionHandle: ...
+    @overload
+    async def redeem_positions(
+        self, *, market_id: str, metadata: str | None = None
+    ) -> TransactionHandle: ...
+    @overload
+    async def redeem_positions(
+        self, *, position_id: str, metadata: str | None = None
+    ) -> TransactionHandle: ...
     async def redeem_positions(
         self,
         *,

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -145,6 +145,18 @@ class PublicClient:
                 finally:
                     self._ctx.clob.close()
 
+    @overload
+    def get_market(
+        self, *, id: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    def get_market(
+        self, *, slug: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    def get_market(
+        self, *, url: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
     def get_market(
         self,
         *,
@@ -170,6 +182,36 @@ class PublicClient:
         """Get a market's tags."""
         return sync_dispatch(self._ctx, _gamma_actions.get_market_tags_spec(id))
 
+    @overload
+    def get_event(
+        self,
+        *,
+        id: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    def get_event(
+        self,
+        *,
+        slug: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    def get_event(
+        self,
+        *,
+        url: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
     def get_event(
         self,
         *,
@@ -211,6 +253,12 @@ class PublicClient:
             _gamma_actions.get_series_spec(id, locale=locale),
         )
 
+    @overload
+    def get_tag(
+        self, *, id: str, include_template: bool | None = None, locale: str | None = None
+    ) -> Tag: ...
+    @overload
+    def get_tag(self, *, slug: str, locale: str | None = None) -> Tag: ...
     def get_tag(
         self,
         *,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -2398,6 +2398,18 @@ class SecureClient:
         )
         return self.execute_transaction(calls=calls, metadata=resolved_metadata)
 
+    @overload
+    def redeem_positions(
+        self, *, condition_id: str, metadata: str | None = None
+    ) -> SyncTransactionHandle: ...
+    @overload
+    def redeem_positions(
+        self, *, market_id: str, metadata: str | None = None
+    ) -> SyncTransactionHandle: ...
+    @overload
+    def redeem_positions(
+        self, *, position_id: str, metadata: str | None = None
+    ) -> SyncTransactionHandle: ...
     def redeem_positions(
         self,
         *,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -471,6 +471,18 @@ class SecureClient:
     def _user_or_wallet(self, user: str | None) -> str:
         return self._ctx.wallet if user is None else user
 
+    @overload
+    def get_market(
+        self, *, id: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    def get_market(
+        self, *, slug: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
+    @overload
+    def get_market(
+        self, *, url: str, include_tag: bool | None = None, locale: str | None = None
+    ) -> Market: ...
     def get_market(
         self,
         *,
@@ -496,6 +508,36 @@ class SecureClient:
         """Get a market's tags."""
         return sync_dispatch(self._ctx, _gamma_actions.get_market_tags_spec(id))
 
+    @overload
+    def get_event(
+        self,
+        *,
+        id: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    def get_event(
+        self,
+        *,
+        slug: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
+    @overload
+    def get_event(
+        self,
+        *,
+        url: str,
+        include_best_lines: bool | None = None,
+        include_chat: bool | None = None,
+        include_template: bool | None = None,
+        locale: str | None = None,
+    ) -> Event: ...
     def get_event(
         self,
         *,
@@ -537,6 +579,12 @@ class SecureClient:
             _gamma_actions.get_series_spec(id, locale=locale),
         )
 
+    @overload
+    def get_tag(
+        self, *, id: str, include_template: bool | None = None, locale: str | None = None
+    ) -> Tag: ...
+    @overload
+    def get_tag(self, *, slug: str, locale: str | None = None) -> Tag: ...
     def get_tag(
         self,
         *,

--- a/tests/unit/test_relayer_redeem_positions.py
+++ b/tests/unit/test_relayer_redeem_positions.py
@@ -103,7 +103,10 @@ def test_redeem_positions_rejects_both_condition_id_and_market_id() -> None:
         client = await make_deposit_client()
         try:
             with pytest.raises(UserInputError, match="exactly one"):
-                await client.redeem_positions(condition_id=_CONDITION_ID, market_id="123")
+                # Two selectors is intentionally invalid — exercises the runtime guard.
+                await client.redeem_positions(  # pyright: ignore[reportCallIssue]
+                    condition_id=_CONDITION_ID, market_id="123"
+                )
         finally:
             await client.close()
 
@@ -115,7 +118,8 @@ def test_redeem_positions_rejects_neither_argument() -> None:
         client = await make_deposit_client()
         try:
             with pytest.raises(UserInputError, match="exactly one"):
-                await client.redeem_positions()
+                # Zero selectors is intentionally invalid — exercises the runtime guard.
+                await client.redeem_positions()  # pyright: ignore[reportCallIssue]
         finally:
             await client.close()
 


### PR DESCRIPTION
Makes "exactly one of <selector>" visible to the type checker for the lookup methods that take all-optional keyword args, while keeping `get_market(id=...)` ergonomics, the public method names, and the existing runtime validation (DEV-115).

Adds keyword-only `@overload` stubs (one per selector) above each method's unchanged impl — mirroring the existing `estimate_market_price` / `create_market_order` pattern. Purely additive typing; impl bodies and the runtime "exactly one" guards are untouched.

- `get_market` / `get_event` — exactly one of `id` | `slug` | `url`
- `get_tag` — exactly one of `id` | `slug` (`include_template` offered only on the `id` overload, matching the runtime guard)
- `redeem_positions` — exactly one of `condition_id` | `market_id` | `position_id`. Note: the ticket mentioned `condition_id`/`market_id`, but the method actually takes a third selector (`position_id`, for combo positions), so this is a 3-way overload.

Applied across the sync + async public and secure clients (`get_*` on all four; `redeem_positions` on the two secure clients).

Verified: pyright (strict) now reports an error for zero-selector and multi-selector calls (and `get_tag(slug=..., include_template=...)`), while every valid single-selector shape type-checks clean. Runtime behavior unchanged — full unit suite green; ruff + pyright strict clean.

Refs DEV-115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive static typing and test pyright suppressions only; no changes to method implementations or runtime validation.
> 
> **Overview**
> Adds **keyword-only `@overload` stubs** above unchanged method implementations so pyright enforces **exactly one** lookup selector at compile time, matching existing runtime guards (DEV-115).
> 
> **`get_market` / `get_event`** — one of `id`, `slug`, or `url` (sync/async **public** and **secure**). **`get_tag`** — one of `id` or `slug`; `include_template` is typed only on the `id` overload. **`redeem_positions`** — one of `condition_id`, `market_id`, or `position_id` (**secure** clients only).
> 
> Implementation bodies and runtime validation are unchanged. Unit tests for invalid `redeem_positions` calls now use `# pyright: ignore[reportCallIssue]` so tests can still hit the runtime “exactly one” errors without type-check failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c38c6ef5e8230436182bd327ef2c796ea6893b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->