### PR TITLE
fix(client): clean up deposit wallet deployment

### DIFF
--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -125,7 +125,8 @@ from polymarket._internal.streams.handle import AsyncSubscriptionHandle, Subscri
 from polymarket._internal.wallet import (
     WalletType,
     classify_wallet_type,
-    derive_current_deposit_wallet_address,
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.auth import ApiKey
@@ -310,7 +311,7 @@ class AsyncSecureClient:
 
         Args:
             private_key: EVM private key used for signing.
-            wallet: Wallet address to act for. Defaults to the signer's current Deposit Wallet.
+            wallet: Wallet address to act for. Defaults to the signer's Deposit Wallet.
             credentials: Existing API credentials. When omitted, credentials are
                 derived during client creation.
             api_key: Optional key for gasless wallet and relayed transaction workflows.
@@ -2134,8 +2135,8 @@ class AsyncSecureClient:
 
     async def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
-        current_deposit_wallet = await derive_current_deposit_wallet_address(
-            ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+        current_deposit_wallet = derive_beacon_deposit_wallet_address(
+            ctx.signer.address, ctx.environment.wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2620,14 +2621,20 @@ async def _resolve_requested_wallet(
 ) -> str:
     if wallet is not None:
         return wallet
-    rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
-    rpc = JsonRpcClient(rpc_transport)
+    legacy_deposit_wallet = derive_uups_deposit_wallet_address(
+        signer.address, environment.wallet_derivation
+    )
+    relayer = AsyncTransport(base_url=environment.relayer_url, logger=logger)
     try:
-        return await derive_current_deposit_wallet_address(
-            rpc, signer.address, environment.wallet_derivation
-        )
+        if await fetch_deployed(
+            relayer,
+            address=legacy_deposit_wallet,
+            type=RelayerTransactionType.WALLET,
+        ):
+            return legacy_deposit_wallet
+        return derive_beacon_deposit_wallet_address(signer.address, environment.wallet_derivation)
     finally:
-        await rpc.close()
+        await relayer.close()
 
 
 def _relayer_transaction_type_for_wallet(

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -113,7 +113,8 @@ from polymarket._internal.l1_auth import sign_api_key_auth
 from polymarket._internal.wallet import (
     WalletType,
     classify_wallet_type,
-    derive_current_deposit_wallet_address_sync,
+    derive_beacon_deposit_wallet_address,
+    derive_uups_deposit_wallet_address,
     signature_type_for,
 )
 from polymarket.auth import ApiKey
@@ -256,7 +257,7 @@ class SecureClient:
 
         Args:
             private_key: EVM private key used for signing.
-            wallet: Wallet address to act for. Defaults to the signer's current Deposit Wallet.
+            wallet: Wallet address to act for. Defaults to the signer's Deposit Wallet.
             credentials: Existing API credentials. When omitted, credentials are
                 derived during client creation.
             api_key: Optional key for gasless wallet and relayed transaction workflows.
@@ -2286,8 +2287,8 @@ class SecureClient:
 
     def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
-        current_deposit_wallet = derive_current_deposit_wallet_address_sync(
-            ctx.rpc, ctx.signer.address, ctx.environment.wallet_derivation
+        current_deposit_wallet = derive_beacon_deposit_wallet_address(
+            ctx.signer.address, ctx.environment.wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2364,14 +2365,20 @@ def _resolve_requested_wallet_sync(
 ) -> str:
     if wallet is not None:
         return wallet
-    rpc_transport = SyncTransport(base_url=environment.rpc_url, logger=logger)
-    rpc = SyncJsonRpcClient(rpc_transport)
+    legacy_deposit_wallet = derive_uups_deposit_wallet_address(
+        signer.address, environment.wallet_derivation
+    )
+    relayer = SyncTransport(base_url=environment.relayer_url, logger=logger)
     try:
-        return derive_current_deposit_wallet_address_sync(
-            rpc, signer.address, environment.wallet_derivation
-        )
+        if fetch_deployed_sync(
+            relayer,
+            address=legacy_deposit_wallet,
+            type=RelayerTransactionType.WALLET,
+        ):
+            return legacy_deposit_wallet
+        return derive_beacon_deposit_wallet_address(signer.address, environment.wallet_derivation)
     finally:
-        rpc.close()
+        relayer.close()
 
 
 def _relayer_transaction_type_for_wallet(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -147,14 +147,62 @@ def test_secure_client_invalid_key_raises_user_input_error() -> None:
         SecureClient.create(private_key="not-a-valid-key", wallet=SIGNER_ADDRESS)
 
 
-def test_secure_client_wallet_defaults_to_current_deposit_wallet_when_omitted() -> None:
+def test_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from eth_account import Account
 
+    import polymarket.clients.secure as secure_module
+    from polymarket._internal.wallet import (
+        derive_beacon_deposit_wallet_address,
+        derive_uups_deposit_wallet_address,
+    )
+    from polymarket.environments import PRODUCTION
+    from polymarket.models.clob.relayer import RelayerTransactionType
+
+    signer = Account.from_key(PRIVATE_KEY)
+    legacy_wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_beacon_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+
+    def fake_fetch_deployed_sync(
+        *args: object, address: str, type: RelayerTransactionType | None
+    ) -> bool:
+        assert address == legacy_wallet
+        assert type == RelayerTransactionType.WALLET
+        return False
+
+    monkeypatch.setattr(secure_module, "fetch_deployed_sync", fake_fetch_deployed_sync)
+
+    with SecureClient._create(
+        private_key=PRIVATE_KEY,
+        credentials=FAKE_CREDS,
+        validate_credentials=False,
+    ) as client:
+        assert client.wallet_type == "DEPOSIT_WALLET"
+        assert str(client.wallet) == expected
+
+
+def test_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from eth_account import Account
+
+    import polymarket.clients.secure as secure_module
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
+    from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+
+    def fake_fetch_deployed_sync(
+        *args: object, address: str, type: RelayerTransactionType | None
+    ) -> bool:
+        assert address == expected
+        assert type == RelayerTransactionType.WALLET
+        return True
+
+    monkeypatch.setattr(secure_module, "fetch_deployed_sync", fake_fetch_deployed_sync)
 
     with SecureClient._create(
         private_key=PRIVATE_KEY,
@@ -173,14 +221,68 @@ def test_async_secure_client_invalid_key_raises_user_input_error() -> None:
     asyncio.run(run())
 
 
-def test_async_secure_client_wallet_defaults_to_current_deposit_wallet_when_omitted() -> None:
+def test_async_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from eth_account import Account
 
+    import polymarket.clients.async_secure as async_secure_module
+    from polymarket._internal.wallet import (
+        derive_beacon_deposit_wallet_address,
+        derive_uups_deposit_wallet_address,
+    )
+    from polymarket.environments import PRODUCTION
+    from polymarket.models.clob.relayer import RelayerTransactionType
+
+    signer = Account.from_key(PRIVATE_KEY)
+    legacy_wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_beacon_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+
+    async def fake_fetch_deployed(
+        *args: object, address: str, type: RelayerTransactionType | None
+    ) -> bool:
+        assert address == legacy_wallet
+        assert type == RelayerTransactionType.WALLET
+        return False
+
+    monkeypatch.setattr(async_secure_module, "fetch_deployed", fake_fetch_deployed)
+
+    async def run() -> str:
+        client = await AsyncSecureClient._create(
+            private_key=PRIVATE_KEY,
+            credentials=FAKE_CREDS,
+            validate_credentials=False,
+        )
+        try:
+            assert client.wallet_type == "DEPOSIT_WALLET"
+            return str(client.wallet)
+        finally:
+            await client.close()
+
+    assert asyncio.run(run()) == expected
+
+
+def test_async_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from eth_account import Account
+
+    import polymarket.clients.async_secure as async_secure_module
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
     from polymarket.environments import PRODUCTION
+    from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+
+    async def fake_fetch_deployed(
+        *args: object, address: str, type: RelayerTransactionType | None
+    ) -> bool:
+        assert address == expected
+        assert type == RelayerTransactionType.WALLET
+        return True
+
+    monkeypatch.setattr(async_secure_module, "fetch_deployed", fake_fetch_deployed)
 
     async def run() -> str:
         client = await AsyncSecureClient._create(


### PR DESCRIPTION
## Summary
- Clean up secure client Deposit Wallet resolution after the beacon factory upgrade
- Preserve deployed legacy UUPS Deposit Wallets when wallet is omitted
- Default new Deposit Wallet deployments to beacon wallets without runtime factory probing
- Apply the behavior consistently for sync and async clients

## Verification
- uv run pytest tests/unit/test_client.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright
- uv run pytest -m "not integration"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which on-chain address clients bind to at creation and deploy time; wrong resolution could mis-route funds or deploy the wrong wallet type, though behavior is covered by new unit tests.
> 
> **Overview**
> Updates **default Deposit Wallet resolution** when `wallet` is omitted on sync and async secure clients, replacing on-chain factory probing with a relayer-backed legacy check plus deterministic beacon derivation.
> 
> When no wallet is passed, the client derives the **legacy UUPS** address and asks the **relayer** whether that wallet is already deployed; if yes, it keeps using the legacy address so existing users are unchanged. If not, it defaults to the **beacon** Deposit Wallet address for new deployments.
> 
> **Deploy-on-create** (`_deploy_default_deposit_wallet`) now expects the resolved wallet to match the beacon-derived address only—no RPC `derive_current_deposit_wallet_*` calls in the client path.
> 
> Unit tests cover both branches (legacy deployed vs beacon default) for `SecureClient` and `AsyncSecureClient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c098c9bc0eb8ef34522f99b0dcbec92e84b1a4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->