### PR TITLE
fix(client): support new CLOB tick sizes

### DIFF
--- a/src/polymarket/_internal/actions/orders/context.py
+++ b/src/polymarket/_internal/actions/orders/context.py
@@ -16,6 +16,8 @@ class RoundingConfig:
 _ROUNDING_BY_TICK: dict[Decimal, RoundingConfig] = {
     Decimal("0.1"): RoundingConfig(amount=3, price=1, size=2),
     Decimal("0.01"): RoundingConfig(amount=4, price=2, size=2),
+    Decimal("0.005"): RoundingConfig(amount=5, price=3, size=2),
+    Decimal("0.0025"): RoundingConfig(amount=6, price=4, size=2),
     Decimal("0.001"): RoundingConfig(amount=5, price=3, size=2),
     Decimal("0.0001"): RoundingConfig(amount=6, price=4, size=2),
 }

--- a/src/polymarket/_internal/actions/orders/market_data.py
+++ b/src/polymarket/_internal/actions/orders/market_data.py
@@ -10,7 +10,14 @@ from polymarket.models.clob.builder import BuilderFeeRates
 from polymarket.models.types import CtfConditionId, TokenId, validate_ctf_condition_id
 
 _ALLOWED_TICK_SIZES: frozenset[Decimal] = frozenset(
-    {Decimal("0.1"), Decimal("0.01"), Decimal("0.001"), Decimal("0.0001")}
+    {
+        Decimal("0.1"),
+        Decimal("0.01"),
+        Decimal("0.005"),
+        Decimal("0.0025"),
+        Decimal("0.001"),
+        Decimal("0.0001"),
+    }
 )
 
 

--- a/src/polymarket/models/clob/orders.py
+++ b/src/polymarket/models/clob/orders.py
@@ -6,7 +6,7 @@ from polymarket.types import EvmAddress, HexString
 
 OrderType: TypeAlias = Literal["GTC", "GTD", "FAK", "FOK"]
 MarketOrderType: TypeAlias = Literal["FAK", "FOK"]
-TickSize: TypeAlias = Literal["0.1", "0.01", "0.001", "0.0001"]
+TickSize: TypeAlias = Literal["0.1", "0.01", "0.005", "0.0025", "0.001", "0.0001"]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/tests/unit/test_order_context.py
+++ b/tests/unit/test_order_context.py
@@ -13,6 +13,8 @@ from polymarket.errors import UnexpectedResponseError
 def test_resolve_rounding_config_supports_known_tick_sizes() -> None:
     assert resolve_rounding_config(Decimal("0.1")).price == 1
     assert resolve_rounding_config(Decimal("0.01")).price == 2
+    assert resolve_rounding_config(Decimal("0.005")).price == 3
+    assert resolve_rounding_config(Decimal("0.0025")).price == 4
     assert resolve_rounding_config(Decimal("0.001")).price == 3
     assert resolve_rounding_config(Decimal("0.0001")).price == 4
 
@@ -25,7 +27,7 @@ def test_resolve_rounding_config_amount_and_size_follow_table() -> None:
 
 def test_resolve_rounding_config_rejects_unsupported_tick_size() -> None:
     with pytest.raises(UnexpectedResponseError, match="Unsupported tick size"):
-        resolve_rounding_config(Decimal("0.005"))
+        resolve_rounding_config(Decimal("0.0005"))
 
 
 def test_resolve_exchange_address_selects_neg_risk_when_true() -> None:

--- a/tests/unit/test_order_market_data.py
+++ b/tests/unit/test_order_market_data.py
@@ -66,11 +66,23 @@ def test_fetch_tick_size_returns_decimal_for_valid_response() -> None:
     assert urlparse(str(captured[0].url)).path == "/tick-size"
 
 
-def test_fetch_tick_size_rejects_unsupported_value() -> None:
+def test_fetch_tick_size_accepts_new_supported_value() -> None:
     async def run() -> Decimal:
         client = await _make_client()
         try:
             _install_public_clob(client, _capture([], 200, {"minimum_tick_size": 0.005}))
+            return await fetch_tick_size(client._ctx, token_id="8501497")
+        finally:
+            await client.close()
+
+    assert asyncio.run(run()) == Decimal("0.005")
+
+
+def test_fetch_tick_size_rejects_unsupported_value() -> None:
+    async def run() -> Decimal:
+        client = await _make_client()
+        try:
+            _install_public_clob(client, _capture([], 200, {"minimum_tick_size": 0.0005}))
             return await fetch_tick_size(client._ctx, token_id="8501497")
         finally:
             await client.close()


### PR DESCRIPTION
## Summary
- accept 0.005 and 0.0025 as supported order tick sizes
- add matching Decimal rounding config and tick-size response allow-list entries
- align with Polymarket/clob-client-v2#84

## Verification
- uv run pytest tests/unit/test_order_context.py tests/unit/test_order_market_data.py
- uv run ruff check
- uv run pyright
- uv run pytest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order price/amount rounding paths used by limit and market orders; wrong config could reject or mis-round orders for affected markets, though the mapping mirrors upstream CLOB client behavior.
> 
> **Overview**
> Adds **0.005** and **0.0025** as first-class CLOB tick sizes so markets using the newer minimum tick from the API no longer fail validation or rounding.
> 
> `resolve_rounding_config` gains matching `RoundingConfig` entries (amount/price decimal limits), `_ALLOWED_TICK_SIZES` in tick-size parsing accepts the same values, and the public `TickSize` literal type is extended. Unit tests now assert rounding for the new ticks and that `fetch_tick_size` accepts **0.005** while still rejecting unsupported sizes (e.g. **0.0005**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a45aa1ecfaec242d85bf6b194d684d975bfa8f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->