### PR TITLE
fix(client): require 3 minute GTD expirations

### DIFF
--- a/src/polymarket/_internal/actions/orders/limit.py
+++ b/src/polymarket/_internal/actions/orders/limit.py
@@ -27,7 +27,7 @@ from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
 from polymarket.types import EvmAddress, HexString
 
-_MIN_EXPIRATION_BUFFER_S = 60
+_MIN_EXPIRATION_BUFFER_S = 180
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1775,7 +1775,7 @@ class AsyncSecureClient:
         :meth:`place_limit_order` to create and post in one call.
 
         When ``expiration`` is provided, it must be a Unix timestamp at least
-        60 seconds in the future. Use extra buffer for immediate submissions to
+        3 minutes in the future. Use extra buffer for immediate submissions to
         account for latency and clock skew.
         """
         params = validate_limit_order_params(
@@ -1885,7 +1885,7 @@ class AsyncSecureClient:
         """Create, sign, and post a limit order.
 
         When ``expiration`` is provided, it must be a Unix timestamp at least
-        60 seconds in the future. Use extra buffer for immediate submissions to
+        3 minutes in the future. Use extra buffer for immediate submissions to
         account for latency and clock skew.
         """
         signed = await self.create_limit_order(

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1542,7 +1542,7 @@ class SecureClient:
         :meth:`place_limit_order` to create and post in one call.
 
         When ``expiration`` is provided, it must be a Unix timestamp at least
-        60 seconds in the future. Use extra buffer for immediate submissions to
+        3 minutes in the future. Use extra buffer for immediate submissions to
         account for latency and clock skew.
 
         Raises:
@@ -1632,7 +1632,7 @@ class SecureClient:
         """Create, sign, and post a limit order.
 
         When ``expiration`` is provided, it must be a Unix timestamp at least
-        60 seconds in the future. Use extra buffer for immediate submissions to
+        3 minutes in the future. Use extra buffer for immediate submissions to
         account for latency and clock skew.
 
         Raises:

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -154,7 +154,7 @@ def test_validate_limit_order_params_rejects_negative_expiration() -> None:
 
 
 def test_validate_limit_order_params_rejects_near_expiration() -> None:
-    with pytest.raises(UserInputError, match="60 seconds"):
+    with pytest.raises(UserInputError, match="180 seconds"):
         validate_limit_order_params(
             token_id="8501497",
             price="0.5",
@@ -169,13 +169,13 @@ def test_validate_limit_order_params_rejects_expiration_below_minimum(
 ) -> None:
     now = 1_700_000_000
     monkeypatch.setattr("polymarket._internal.actions.orders.limit.time.time", lambda: now)
-    with pytest.raises(UserInputError, match="60 seconds"):
+    with pytest.raises(UserInputError, match="180 seconds"):
         validate_limit_order_params(
             token_id="8501497",
             price="0.5",
             size="10",
             side="BUY",
-            expiration=now + 59,
+            expiration=now + 179,
         )
 
 
@@ -189,9 +189,9 @@ def test_validate_limit_order_params_accepts_minimum_expiration_boundary(
         price="0.5",
         size="10",
         side="BUY",
-        expiration=now + 60,
+        expiration=now + 180,
     )
-    assert params.expiration == now + 60
+    assert params.expiration == now + 180
 
 
 def test_validate_limit_order_params_accepts_far_expiration() -> None:


### PR DESCRIPTION
## Summary
- update GTD limit order expiration validation from 60 seconds to 3 minutes
- refresh sync and async client docstrings
- update expiration boundary tests

## Verification
- `uv run pytest tests/unit/test_order_limit.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens trading input validation and may break integrations that relied on 60–179 second GTD expirations; behavior change is localized to limit orders with an explicit expiration.
> 
> **Overview**
> Raises the **minimum future expiration** for GTD limit orders from **60 seconds to 3 minutes (180s)** in `validate_limit_order_params` via `_MIN_EXPIRATION_BUFFER_S`.
> 
> Sync and async secure client docs for `create_limit_order` / `place_limit_order` now describe the **3-minute** rule. Unit tests were updated for rejection messages and the **180s** acceptance boundary.
> 
> **Note:** Callers passing `expiration` between ~60s and ~179s ahead of `time.time()` will now get `UserInputError` before sign/post.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c113cde698b7b5cfbc1c6162b2d534fda5e436a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->