### PR TITLE
fix(client): resolve closed markets for redeem

### DIFF
--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -2477,6 +2477,7 @@ class AsyncSecureClient:
         context = await self._resolve_market_position_context(
             condition_id=condition_id,
             market_id=market_id,
+            closed=True,
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
@@ -2495,19 +2496,32 @@ class AsyncSecureClient:
         *,
         condition_id: str | None = None,
         market_id: str | None = None,
+        closed: bool | None = None,
     ) -> MarketPositionContext:
         if (condition_id is None) == (market_id is None):
             raise UserInputError("Provide exactly one of condition_id or market_id")
         env = self._ctx.environment
         if condition_id is not None:
             context = f"condition {condition_id}"
-            page = await self.list_markets(condition_ids=[condition_id], page_size=1).first_page()
+            if closed is None:
+                page = await self.list_markets(
+                    condition_ids=[condition_id], page_size=1
+                ).first_page()
+            else:
+                page = await self.list_markets(
+                    condition_ids=[condition_id], closed=closed, page_size=1
+                ).first_page()
         else:
             assert market_id is not None
             context = f"market {market_id}"
-            page = await self.list_markets(
-                ids=[parse_market_id(market_id)], page_size=1
-            ).first_page()
+            if closed is None:
+                page = await self.list_markets(
+                    ids=[parse_market_id(market_id)], page_size=1
+                ).first_page()
+            else:
+                page = await self.list_markets(
+                    ids=[parse_market_id(market_id)], closed=closed, page_size=1
+                ).first_page()
         markets = page.items
         if not markets:
             raise UserInputError(f"No market found for {context}")

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -2370,6 +2370,7 @@ class SecureClient:
         context = self._resolve_market_position_context(
             condition_id=condition_id,
             market_id=market_id,
+            closed=True,
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
@@ -2449,17 +2450,28 @@ class SecureClient:
         *,
         condition_id: str | None = None,
         market_id: str | None = None,
+        closed: bool | None = None,
     ) -> MarketPositionContext:
         if (condition_id is None) == (market_id is None):
             raise UserInputError("Provide exactly one of condition_id or market_id")
         env = self._ctx.environment
         if condition_id is not None:
             context = f"condition {condition_id}"
-            page = self.list_markets(condition_ids=[condition_id], page_size=1).first_page()
+            if closed is None:
+                page = self.list_markets(condition_ids=[condition_id], page_size=1).first_page()
+            else:
+                page = self.list_markets(
+                    condition_ids=[condition_id], closed=closed, page_size=1
+                ).first_page()
         else:
             assert market_id is not None
             context = f"market {market_id}"
-            page = self.list_markets(ids=[parse_market_id(market_id)], page_size=1).first_page()
+            if closed is None:
+                page = self.list_markets(ids=[parse_market_id(market_id)], page_size=1).first_page()
+            else:
+                page = self.list_markets(
+                    ids=[parse_market_id(market_id)], closed=closed, page_size=1
+                ).first_page()
         markets = page.items
         if not markets:
             raise UserInputError(f"No market found for {context}")

--- a/tests/unit/test_relayer_position_workflows.py
+++ b/tests/unit/test_relayer_position_workflows.py
@@ -247,7 +247,7 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
 
     asyncio.run(run())
 
-    assert market_calls == [{"ids": [123], "page_size": 1}]
+    assert market_calls == [{"ids": [123], "closed": True, "page_size": 1}]
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
     assert calls[0]["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()

--- a/tests/unit/test_relayer_redeem_positions.py
+++ b/tests/unit/test_relayer_redeem_positions.py
@@ -72,13 +72,16 @@ def test_redeem_positions_uses_collateral_adapter_when_neg_risk_false() -> None:
 
 def test_redeem_positions_uses_neg_risk_collateral_adapter_when_neg_risk_true() -> None:
     captured: list[httpx.Request] = []
+    market_calls: list[dict[str, object]] = []
+
+    def list_markets_stub(**kwargs: object) -> _StubPaginator:
+        market_calls.append(kwargs)
+        return _StubPaginator((_market(neg_risk=True),))
 
     async def run() -> None:
         client = await make_deposit_client()
         _setup_relayer(client, captured, "tx-redeem-nr")
-        client.list_markets = lambda **_: _StubPaginator(  # type: ignore[method-assign]
-            (_market(neg_risk=True),)
-        )
+        client.list_markets = list_markets_stub  # type: ignore[method-assign]
         client.list_positions = _fail_list_positions  # type: ignore[method-assign]
         try:
             await client.redeem_positions(condition_id=_CONDITION_ID)
@@ -86,6 +89,7 @@ def test_redeem_positions_uses_neg_risk_collateral_adapter_when_neg_risk_true() 
             await client.close()
 
     asyncio.run(run())
+    assert market_calls == [{"condition_ids": [_CONDITION_ID], "closed": True, "page_size": 1}]
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
@@ -137,7 +141,7 @@ def test_redeem_positions_accepts_market_id() -> None:
             await client.close()
 
     asyncio.run(run())
-    assert market_calls == [{"ids": [123], "page_size": 1}]
+    assert market_calls == [{"ids": [123], "closed": True, "page_size": 1}]
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     assert len(submit_calls) == 1
 

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -553,13 +553,20 @@ def test_merge_positions_routes_through_collateral_adapter() -> None:
 
 def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
     captured: list[httpx.Request] = []
+    market_calls: list[dict[str, object]] = []
+    condition_id = "0x" + "11" * 32
+
+    def list_markets_stub(**kwargs: object):  # type: ignore[no-untyped-def]
+        market_calls.append(kwargs)
+        return _stub_page((_stub_market(_CONDITION_ID, neg_risk=True),))
 
     with make_sync_deposit_client() as client:
-        client.list_markets = lambda **_: _stub_page((_stub_market(_CONDITION_ID, neg_risk=True),))  # type: ignore[method-assign]
+        client.list_markets = list_markets_stub  # type: ignore[method-assign]
         client.list_positions = _fail_list_positions  # type: ignore[method-assign]
         install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
-        client.redeem_positions(condition_id="0x" + "11" * 32)
+        client.redeem_positions(condition_id=condition_id)
 
+    assert market_calls == [{"condition_ids": [condition_id], "closed": True, "page_size": 1}]
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
@@ -580,7 +587,7 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
         install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
         client.redeem_positions(market_id="123")
 
-    assert market_calls == [{"ids": [123], "page_size": 1}]
+    assert market_calls == [{"ids": [123], "closed": True, "page_size": 1}]
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]


### PR DESCRIPTION
## Summary
- Resolve market context for redeem calls with closed markets included.
- Keep split and merge market lookups unchanged.
- Update sync and async redeem workflow tests to assert closed-market lookup behavior.

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright
- uv run pytest tests/unit/test_relayer_redeem_positions.py tests/unit/test_sync_relayer_workflows.py tests/unit/test_relayer_position_workflows.py -q
- uv run pytest -q -m "not integration"

## Notes
- Full uv run pytest completed with one unrelated live sports stream integration failure: tests/integration/test_sports_stream.py::test_live_sports_stream_survives_past_heartbeat_stale_window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain redeem transaction routing (adapter selection) for resolved markets; wrong lookup could still submit redeem to the wrong contract, but scope is narrow and covered by updated unit tests.
> 
> **Overview**
> **Market redeems** now resolve Gamma market metadata with `closed=True` on `list_markets`, so settled markets are found instead of failing lookup when only open markets are returned by default.
> 
> `_resolve_market_position_context` gains an optional `closed` flag (async and sync secure clients) and forwards it to `list_markets` when set. **Only** `redeem_positions` passes `closed=True`; split, merge, and batch merge paths are unchanged.
> 
> Unit tests for async and sync redeem workflows were updated to expect `closed: True` in market lookup kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205f989b2aad6583edf3fb38ba110568ad67f79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->