### PR TITLE
fix(client): tighten Perps request typing

### DIFF
--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -187,6 +187,7 @@ class PerpsSession:
         return self._dropped_events
 
     async def open(self) -> Self:
+        """Connect and authenticate the session WebSocket."""
         await self._connect(emit_resync=False)
         return self
 
@@ -205,6 +206,7 @@ class PerpsSession:
             self._on_session_close(self)
 
     def __aiter__(self) -> Self:
+        """Iterate authenticated Perps account events emitted by this session."""
         return self
 
     async def __anext__(self) -> PerpsSessionEvent:
@@ -269,22 +271,36 @@ class PerpsSession:
         stop_loss: PerpsTpSlTrigger | None = None,
         expires_at: datetime | int | None = None,
     ) -> PerpsOrderPlacement:
-        """Place one order and resolve with its first orders-channel update.
+        """Place one order and resolve with its first orders update.
 
         ``gtc`` orders require ``price`` and may set ``post_only``; ``ioc`` and
         ``fok`` orders may omit ``price`` for market-style execution. Pass
         ``take_profit`` and/or ``stop_loss`` to place reduce-only trigger
-        orders together with the order.
+        orders together with the entry order. ``expires_at`` is an optional
+        command expiration timestamp, accepted as ``datetime`` or epoch
+        milliseconds.
         """
-        request = PerpsOrderRequest(
-            instrument_id=instrument_id,
-            side=side,
-            quantity=quantity,
-            time_in_force=time_in_force,
-            price=price,
-            post_only=post_only,
-            client_order_id=client_order_id,
-        )
+        if time_in_force == "gtc":
+            request = PerpsOrderRequest(
+                instrument_id=instrument_id,
+                side=side,
+                quantity=quantity,
+                time_in_force=time_in_force,
+                price=cast(DecimalInput, price),
+                post_only=post_only,
+                client_order_id=client_order_id,
+            )
+        else:
+            if post_only:
+                raise UserInputError("post_only is only supported for gtc orders")
+            request = PerpsOrderRequest(
+                instrument_id=instrument_id,
+                side=side,
+                quantity=quantity,
+                time_in_force=time_in_force,
+                price=price,
+                client_order_id=client_order_id,
+            )
         if take_profit is None and stop_loss is None:
             acks = await self._send_create_orders(
                 [to_raw_order(request)], group=None, expires_at=expires_at
@@ -340,7 +356,8 @@ class PerpsSession:
     ) -> tuple[PerpsPostOrderAck, ...]:
         """Post one or more orders and return queue-entry acknowledgements.
 
-        This is a low-level method; :meth:`place_order` is the common path.
+        This is a low-level method; :meth:`place_order` is the common path when
+        callers want to wait for the resulting order update.
         """
         if not orders:
             raise UserInputError("orders must be non-empty")
@@ -360,7 +377,8 @@ class PerpsSession:
         """Protect the current position with take-profit/stop-loss triggers.
 
         The exit side is inferred from the open position; a flat position
-        raises :class:`~polymarket.errors.UserInputError`.
+        raises :class:`~polymarket.errors.UserInputError`. Provide
+        ``take_profit``, ``stop_loss``, or both.
         """
         if take_profit is None and stop_loss is None:
             raise UserInputError("Provide take_profit, stop_loss, or both")
@@ -398,6 +416,22 @@ class PerpsSession:
             stop_loss_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
         return PerpsPlacedTpSlOrders(take_profit=take_profit_order, stop_loss=stop_loss_order)
 
+    @overload
+    async def cancel_order(
+        self,
+        *,
+        order_id: int,
+        client_order_id: None = None,
+        expires_at: datetime | int | None = None,
+    ) -> PerpsCancelOrderResult: ...
+    @overload
+    async def cancel_order(
+        self,
+        *,
+        client_order_id: str,
+        order_id: None = None,
+        expires_at: datetime | int | None = None,
+    ) -> PerpsCancelOrderResult: ...
     async def cancel_order(
         self,
         *,
@@ -407,7 +441,8 @@ class PerpsSession:
     ) -> PerpsCancelOrderResult:
         """Cancel one order by ``order_id`` or ``client_order_id``.
 
-        The returned status reflects whether the cancel happened.
+        Provide exactly one identifier. The returned status reflects whether
+        the cancel happened.
         """
         if (order_id is None) == (client_order_id is None):
             raise UserInputError("Provide exactly one of order_id or client_order_id")
@@ -420,6 +455,22 @@ class PerpsSession:
             )
         return results[0]
 
+    @overload
+    async def cancel_orders(
+        self,
+        *,
+        order_ids: Sequence[int],
+        client_order_ids: None = None,
+        expires_at: datetime | int | None = None,
+    ) -> tuple[PerpsCancelOrderResult, ...]: ...
+    @overload
+    async def cancel_orders(
+        self,
+        *,
+        client_order_ids: Sequence[str],
+        order_ids: None = None,
+        expires_at: datetime | int | None = None,
+    ) -> tuple[PerpsCancelOrderResult, ...]: ...
     async def cancel_orders(
         self,
         *,
@@ -427,7 +478,11 @@ class PerpsSession:
         client_order_ids: Sequence[str] | None = None,
         expires_at: datetime | int | None = None,
     ) -> tuple[PerpsCancelOrderResult, ...]:
-        """Cancel orders and return one result per requested order."""
+        """Cancel orders and return one result per requested order.
+
+        Provide exactly one identifier list: ``order_ids`` or
+        ``client_order_ids``.
+        """
         if (order_ids is None) == (client_order_ids is None):
             raise UserInputError("Provide exactly one of order_ids or client_order_ids")
         if order_ids is not None:
@@ -457,27 +512,27 @@ class PerpsSession:
         )
 
     async def fetch_balances(self) -> tuple[PerpsBalance, ...]:
-        """Fetch asset balances for the session account."""
+        """Fetch current Perps balances for the session account."""
         return await _account.fetch_balances(self._api)
 
     async def fetch_portfolio(self) -> PerpsPortfolio:
-        """Fetch the portfolio snapshot for the session account."""
+        """Fetch the current Perps portfolio for the session account."""
         return await _account.fetch_portfolio(self._api)
 
     async def fetch_stats(self) -> PerpsAccountStats:
-        """Fetch rolling trading statistics for the session account."""
+        """Fetch account-level Perps statistics for the session account."""
         return await _account.fetch_stats(self._api)
 
     async def fetch_account_config(
         self, *, instrument_id: int | None = None
     ) -> tuple[PerpsAccountConfig, ...]:
-        """Fetch per-instrument leverage configuration."""
+        """Fetch Perps account configuration, optionally filtered by instrument."""
         return await _account.fetch_account_config(self._api, instrument_id=instrument_id)
 
     async def fetch_open_orders(
         self, *, instrument_id: int | None = None
     ) -> tuple[PerpsOrder, ...]:
-        """Fetch open orders for the session account."""
+        """Fetch currently open Perps orders, optionally filtered by instrument."""
         return await _account.fetch_open_orders(self._api, instrument_id=instrument_id)
 
     async def fetch_orders(
@@ -489,7 +544,7 @@ class PerpsSession:
         start: datetime | int | None = None,
         end: datetime | int | None = None,
     ) -> tuple[PerpsOrder, ...]:
-        """Fetch historical orders for the session account."""
+        """Fetch Perps orders for the session account."""
         return await _account.fetch_orders(
             self._api,
             order_id=order_id,
@@ -505,7 +560,7 @@ class PerpsSession:
         start: datetime | int | None = None,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsFill]:
-        """List fills for the session account.
+        """List Perps fills for the session account.
 
         Defaults to the past 24 hours when ``start`` is omitted.
         """
@@ -518,7 +573,7 @@ class PerpsSession:
         start: datetime | int | None = None,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsFundingPayment]:
-        """List funding payments for the session account.
+        """List Perps funding payments for the session account.
 
         Defaults to the past 24 hours when ``start`` is omitted.
         """
@@ -534,7 +589,7 @@ class PerpsSession:
         start: datetime | int | None = None,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsDeposit]:
-        """List deposits for the session account.
+        """List Perps deposits for the session account.
 
         Defaults to the past 90 days when ``start`` is omitted.
         """
@@ -550,7 +605,7 @@ class PerpsSession:
         start: datetime | int | None = None,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsWithdrawal]:
-        """List withdrawals for the session account.
+        """List Perps withdrawals for the session account.
 
         Defaults to the past 90 days when ``start`` is omitted.
         """
@@ -569,7 +624,7 @@ class PerpsSession:
         start: datetime | int,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsEquityPoint]:
-        """List account equity history at the requested interval."""
+        """List Perps equity history at the requested interval."""
         return _account.list_equity_history(self._api, interval=interval, start=start, end=end)
 
     def list_pnl_history(
@@ -579,7 +634,7 @@ class PerpsSession:
         start: datetime | int,
         end: datetime | int | None = None,
     ) -> AsyncPaginator[PerpsPnlPoint]:
-        """List account profit-and-loss history at the requested interval."""
+        """List Perps profit-and-loss history at the requested interval."""
         return _account.list_pnl_history(self._api, interval=interval, start=start, end=end)
 
     async def _resolve_auth_headers(

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1304,7 +1304,7 @@ class AsyncPublicClient:
         instrument_id: int | None = None,
         category: PerpsInstrumentCategory | None = None,
     ) -> tuple[PerpsInstrument, ...]:
-        """Fetch Perps instruments, optionally filtered by id or category."""
+        """Fetch Perps instruments, optionally filtered by instrument or category."""
         return await _perps_actions.fetch_instruments(
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
@@ -1322,7 +1322,10 @@ class AsyncPublicClient:
     async def fetch_perps_book(
         self, *, instrument_id: int, depth: PerpsBookDepth = 100
     ) -> PerpsBook:
-        """Fetch a Perps order book snapshot."""
+        """Fetch a Perps order book snapshot.
+
+        ``depth`` controls the number of price levels returned on each side.
+        """
         return await _perps_actions.fetch_book(
             self._ctx.perps, instrument_id=instrument_id, depth=depth
         )
@@ -1339,7 +1342,7 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsCandle]:
-        """List Perps candles for an instrument.
+        """List Perps candles for an instrument with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -1362,9 +1365,10 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsFundingRate]:
-        """List Perps funding-rate history for an instrument.
+        """List Perps funding-rate history with SDK-owned pagination.
 
-        Defaults to the past 24 hours when ``start`` is omitted.
+        Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
+        ``end`` accept a ``datetime`` or an epoch-milliseconds int.
 
         Returns:
             An async paginator over funding-rate observations.
@@ -1380,9 +1384,10 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsTrade]:
-        """List recent public Perps trades for an instrument.
+        """List recent public Perps trades with SDK-owned pagination.
 
-        Defaults to the past 24 hours when ``start`` is omitted.
+        Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
+        ``end`` accept a ``datetime`` or an epoch-milliseconds int.
 
         Returns:
             An async paginator over matching trades.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -675,6 +675,11 @@ class AsyncSecureClient:
         ``credentials`` to validate and resume them without a new wallet
         signature.
 
+        Args:
+            credentials: Existing delegated credentials to validate and resume.
+            expires_in: Delegated credential lifetime for newly created credentials.
+            label: Optional label for newly created credentials.
+
         Returns:
             A connected session. Use it to place and cancel orders, read
             account state, and iterate over realtime account events. Close it
@@ -743,6 +748,7 @@ class AsyncSecureClient:
 
         Args:
             amount: Base-units collateral amount to deposit.
+            metadata: Optional wallet-visible metadata for gasless deposit workflows.
 
         Returns:
             A transaction handle. Await ``wait()`` to wait for a terminal outcome.
@@ -2749,7 +2755,7 @@ class AsyncSecureClient:
         instrument_id: int | None = None,
         category: PerpsInstrumentCategory | None = None,
     ) -> tuple[PerpsInstrument, ...]:
-        """Fetch Perps instruments, optionally filtered by id or category."""
+        """Fetch Perps instruments, optionally filtered by instrument or category."""
         return await _perps_actions.fetch_instruments(
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
@@ -2767,7 +2773,10 @@ class AsyncSecureClient:
     async def fetch_perps_book(
         self, *, instrument_id: int, depth: PerpsBookDepth = 100
     ) -> PerpsBook:
-        """Fetch a Perps order book snapshot."""
+        """Fetch a Perps order book snapshot.
+
+        ``depth`` controls the number of price levels returned on each side.
+        """
         return await _perps_actions.fetch_book(
             self._ctx.perps, instrument_id=instrument_id, depth=depth
         )
@@ -2784,7 +2793,7 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsCandle]:
-        """List Perps candles for an instrument.
+        """List Perps candles for an instrument with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -2807,9 +2816,10 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsFundingRate]:
-        """List Perps funding-rate history for an instrument.
+        """List Perps funding-rate history with SDK-owned pagination.
 
-        Defaults to the past 24 hours when ``start`` is omitted.
+        Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
+        ``end`` accept a ``datetime`` or an epoch-milliseconds int.
 
         Returns:
             An async paginator over funding-rate observations.
@@ -2825,9 +2835,10 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsTrade]:
-        """List recent public Perps trades for an instrument.
+        """List recent public Perps trades with SDK-owned pagination.
 
-        Defaults to the past 24 hours when ``start`` is omitted.
+        Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
+        ``end`` accept a ``datetime`` or an epoch-milliseconds int.
 
         Returns:
             An async paginator over matching trades.

--- a/src/polymarket/models/perps/requests.py
+++ b/src/polymarket/models/perps/requests.py
@@ -3,6 +3,7 @@
 import re
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
+from typing import Literal, overload
 
 from polymarket.errors import UserInputError
 from polymarket.models.perps.types import PerpsTimeInForce
@@ -34,7 +35,7 @@ def validate_client_order_id(value: str) -> str:
     return value
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
+@dataclass(frozen=True, slots=True, kw_only=True, init=False)
 class PerpsOrderRequest:
     """One Perps order to submit.
 
@@ -57,6 +58,51 @@ class PerpsOrderRequest:
     """Whether the order must rest instead of taking liquidity."""
     client_order_id: str | None = None
     """Optional caller-supplied idempotency identifier."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        instrument_id: int,
+        side: OrderSide,
+        quantity: DecimalInput,
+        time_in_force: Literal["gtc"],
+        price: DecimalInput,
+        post_only: bool = False,
+        client_order_id: str | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        instrument_id: int,
+        side: OrderSide,
+        quantity: DecimalInput,
+        time_in_force: Literal["ioc", "fok"],
+        price: DecimalInput | None = None,
+        client_order_id: str | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        instrument_id: int,
+        side: OrderSide,
+        quantity: DecimalInput,
+        time_in_force: PerpsTimeInForce,
+        price: DecimalInput | None = None,
+        post_only: bool = False,
+        client_order_id: str | None = None,
+    ) -> None:
+        object.__setattr__(self, "instrument_id", instrument_id)
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "time_in_force", time_in_force)
+        object.__setattr__(self, "price", price)
+        object.__setattr__(self, "post_only", post_only)
+        object.__setattr__(self, "client_order_id", client_order_id)
+        self.__post_init__()
 
     def __post_init__(self) -> None:
         if isinstance(self.instrument_id, bool) or not isinstance(self.instrument_id, int):  # pyright: ignore[reportUnnecessaryIsInstance]

--- a/tests/unit/test_perps_trading_commands.py
+++ b/tests/unit/test_perps_trading_commands.py
@@ -1,5 +1,7 @@
 """Perps trading command construction tests."""
 
+from typing import Any, cast
+
 import pytest
 
 from polymarket._internal.actions.perps.signing import build_perps_op_typed_data
@@ -126,7 +128,12 @@ def test_cancel_and_leverage_ops() -> None:
 
 def test_gtc_order_requires_price() -> None:
     with pytest.raises(UserInputError, match="price is required for gtc"):
-        PerpsOrderRequest(instrument_id=1, side="BUY", quantity="1", time_in_force="gtc")
+        PerpsOrderRequest(
+            instrument_id=1,
+            side="BUY",
+            quantity="1",
+            time_in_force=cast(Any, "gtc"),
+        )
 
 
 def test_post_only_rejected_for_ioc_and_fok() -> None:

--- a/tests/unit/test_perps_typing.py
+++ b/tests/unit/test_perps_typing.py
@@ -1,0 +1,77 @@
+"""Static Perps typing examples checked by pyright."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import CoroutineType
+from typing import TYPE_CHECKING, Any, assert_type
+
+from polymarket.models.perps import (
+    PerpsCancelOrderResult,
+    PerpsOrderRequest,
+    PerpsPostOrderAck,
+)
+from polymarket.perps import PerpsOrderPlacement, PerpsSession
+
+if TYPE_CHECKING:
+    assert_type(
+        PerpsOrderRequest(
+            instrument_id=1,
+            price="100",
+            quantity="1",
+            side="BUY",
+            time_in_force="gtc",
+        ),
+        PerpsOrderRequest,
+    )
+    assert_type(
+        PerpsOrderRequest(
+            instrument_id=1,
+            quantity="1",
+            side="BUY",
+            time_in_force="ioc",
+        ),
+        PerpsOrderRequest,
+    )
+
+    async def _check_session_typing(session: PerpsSession) -> None:
+        assert_type(
+            await session.place_order(
+                instrument_id=1,
+                price="100",
+                quantity="1",
+                side="BUY",
+                time_in_force="gtc",
+            ),
+            PerpsOrderPlacement,
+        )
+        assert_type(
+            await session.cancel_order(order_id=1),
+            PerpsCancelOrderResult,
+        )
+        assert_type(
+            await session.cancel_order(client_order_id="aabbccddeeff00112233445566778899"),
+            PerpsCancelOrderResult,
+        )
+        assert_type(
+            await session.cancel_orders(order_ids=[1, 2]),
+            tuple[PerpsCancelOrderResult, ...],
+        )
+        assert_type(
+            await session.post_orders(
+                [
+                    PerpsOrderRequest(
+                        instrument_id=1,
+                        price="100",
+                        quantity="1",
+                        side="BUY",
+                        time_in_force="gtc",
+                    )
+                ]
+            ),
+            tuple[PerpsPostOrderAck, ...],
+        )
+
+    _session_typing_check: Callable[[PerpsSession], CoroutineType[Any, Any, None]] = (
+        _check_session_typing
+    )


### PR DESCRIPTION
## Summary
- add overloads for `PerpsOrderRequest` so GTC price and IOC/FOK post-only constraints are visible to pyright
- add overloads for Perps session cancel methods so order id and client order id inputs are mutually exclusive at type-check time
- align Perps async client and session docstrings with the TypeScript SDK public-surface wording
- add pyright typing examples for Perps request/session usage

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration"`

Stacked on #133.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly type hints and documentation; the only behavioral tweak is rejecting post_only on non-gtc place_order paths, which matches documented constraints.
> 
> **Overview**
> Tightens **static typing** and **docs** for the Perps async surface without changing wire behavior for valid callers.
> 
> **`PerpsOrderRequest`** now uses constructor **overloads** so pyright requires **`price`** for **`gtc`** and disallows **`post_only`** on **`ioc`/`fok`**. **`PerpsSession.cancel_order`** and **`cancel_orders`** get the same pattern so **`order_id`** vs **`client_order_id`** (and list variants) are mutually exclusive at type-check time.
> 
> **`place_order`** builds the request in a **`gtc`** vs non-**`gtc`** branch and raises **`UserInputError`** if **`post_only`** is used outside **`gtc`** (runtime guard aligned with types).
> 
> **Docstrings** on **`PerpsSession`**, **`AsyncPublicClient`**, and **`AsyncSecureClient`** Perps helpers are expanded (pagination, **`depth`**, session **`Args`**, deposit **`metadata`**, etc.) to match the TypeScript SDK wording.
> 
> Adds **`tests/unit/test_perps_typing.py`** (pyright **`assert_type`** examples) and adjusts **`test_perps_trading_commands`** for the new **`PerpsOrderRequest`** constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63abf0197061989ef4d53b95326cd1b4697ef3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->