### PR TITLE
test: cover sync SecureClient market order placement

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,19 +55,28 @@ def builder_code(require_env: Callable[[str], str]) -> str:
 
 
 @pytest.fixture
+def deposit_wallet_private_key(require_env: Callable[[str], str]) -> str:
+    return require_env("POLYMARKET_PRIVATE_KEY")
+
+
+@pytest.fixture
+def deposit_wallet_address(require_env: Callable[[str], str]) -> str:
+    return require_env("POLYMARKET_DEPOSIT_WALLET")
+
+
+@pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
 
 @pytest.fixture
 async def deposit_wallet_client(
-    require_env: Callable[[str], str],
+    deposit_wallet_private_key: str,
+    deposit_wallet_address: str,
 ) -> AsyncGenerator[AsyncSecureClient, None]:
-    private_key = require_env("POLYMARKET_PRIVATE_KEY")
-    wallet = require_env("POLYMARKET_DEPOSIT_WALLET")
     client = await AsyncSecureClient.create(
-        private_key=private_key,
-        wallet=wallet,
+        private_key=deposit_wallet_private_key,
+        wallet=deposit_wallet_address,
     )
     try:
         yield client

--- a/tests/integration/test_clob_orders.py
+++ b/tests/integration/test_clob_orders.py
@@ -10,6 +10,7 @@ from polymarket import (
     AsyncSecureClient,
     Market,
     Position,
+    SecureClient,
 )
 from polymarket.errors import InsufficientLiquidityError, UserInputError
 
@@ -300,6 +301,53 @@ async def test_place_market_order_closes_inventory_or_buys_minimum_size(
         amount=amount,
         order_type="FAK",
     )
+    assert isinstance(response, AcceptedOrder)
+    assert response.status in ("live", "matched", "delayed")
+
+
+@pytest.mark.integration
+@pytest.mark.metered
+def test_sync_secure_client_create_places_market_order(
+    deposit_wallet_private_key: str,
+    deposit_wallet_address: str,
+    tradable_market: Market,
+) -> None:
+    # Live side effect: places a FAK market order, selling existing Yes inventory
+    # when present or buying the minimum size otherwise.
+    token_id = _yes_token_id(tradable_market)
+    market = _market_condition_id(tradable_market)
+    amount = _minimum_order_size(tradable_market)
+
+    with SecureClient.create(
+        private_key=deposit_wallet_private_key,
+        wallet=deposit_wallet_address,
+    ) as client:
+        positions = client.list_positions(market=[market], size_threshold=0.0).first_page()
+        position = next(
+            (
+                p
+                for p in positions.items
+                if p.token_id == token_id and p.size is not None and p.size > 0
+            ),
+            None,
+        )
+        if position is not None:
+            shares = position.size
+            assert shares is not None
+            response = client.place_market_order(
+                token_id=token_id,
+                side="SELL",
+                shares=shares,
+                order_type="FAK",
+            )
+        else:
+            response = client.place_market_order(
+                token_id=token_id,
+                side="BUY",
+                amount=amount,
+                order_type="FAK",
+            )
+
     assert isinstance(response, AcceptedOrder)
     assert response.status in ("live", "matched", "delayed")
 


### PR DESCRIPTION
## Summary
- add shared deposit wallet key/address fixtures for integration tests
- add metered sync SecureClient.create(...).place_market_order(...) coverage
- keep the test using derived credentials so it exercises the default sync client path

Refs #136

## Verification
- uv run pytest tests/integration/test_clob_orders.py::test_sync_secure_client_create_places_market_order (skipped unless metered tests are enabled)
- uv run ruff check tests/integration/conftest.py tests/integration/test_clob_orders.py
- uv run ruff format --check tests/integration/conftest.py tests/integration/test_clob_orders.py
- uv run pyright tests/integration/conftest.py tests/integration/test_clob_orders.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; the new metered test can place real orders when enabled but does not modify production SDK behavior.
> 
> **Overview**
> Adds shared **`deposit_wallet_private_key`** and **`deposit_wallet_address`** fixtures in integration `conftest`, and wires **`deposit_wallet_client`** through them instead of reading env vars inline.
> 
> Adds a **metered** sync test **`test_sync_secure_client_create_places_market_order`** that uses **`SecureClient.create(...)`** as a context manager, lists positions, and places a live **FAK** market order (sell existing Yes inventory or buy minimum size), asserting an **`AcceptedOrder`** with an expected status—parallel to the existing async market-order coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66dd6f749f20ec0eda047401313d98de24f7f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->