### PR TITLE
fix: wait for confirmed gasless transactions

### DIFF
--- a/src/polymarket/_internal/actions/relayer/poll.py
+++ b/src/polymarket/_internal/actions/relayer/poll.py
@@ -13,7 +13,7 @@ from polymarket.models.clob.relayer import (
 )
 from polymarket.types import TransactionHash
 
-_TERMINAL_SUCCESS = (RelayerTransactionState.MINED, RelayerTransactionState.CONFIRMED)
+_TERMINAL_SUCCESS = (RelayerTransactionState.CONFIRMED,)
 _TERMINAL_FAILURE = (RelayerTransactionState.FAILED, RelayerTransactionState.INVALID)
 
 

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -248,7 +248,7 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transactionHash": "0x" + "ab" * 32,
                     "transactionID": "tx-approve",
                 },
@@ -258,7 +258,7 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "ab" * 32,
                     "transaction_id": "tx-approve",
                 },
@@ -341,7 +341,7 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transactionHash": "0x" + "cd" * 32,
                     "transactionID": "tx-erc1155",
                 },
@@ -351,7 +351,7 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "cd" * 32,
                     "transaction_id": "tx-erc1155",
                 },
@@ -437,7 +437,7 @@ def test_place_limit_order_retry_failure_surfaces_directly() -> None:
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transactionHash": "0x" + "ab" * 32,
                     "transactionID": "tx-a",
                 },
@@ -447,7 +447,7 @@ def test_place_limit_order_retry_failure_surfaces_directly() -> None:
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "ab" * 32,
                     "transaction_id": "tx-a",
                 },

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -354,7 +354,7 @@ def test_approve_erc20_retries_with_fresh_nonce_on_nonce_mismatch() -> None:
     assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]
 
 
-def test_wait_polls_until_mined() -> None:
+def test_wait_polls_until_confirmed() -> None:
     captured: list[httpx.Request] = []
     polls = 0
 
@@ -383,7 +383,7 @@ def test_wait_polls_until_mined() -> None:
                 )
             if path.startswith("/v1/account/transactions/"):
                 polls += 1
-                state = "STATE_MINED" if polls >= 2 else "STATE_NEW"
+                state = "STATE_CONFIRMED" if polls >= 2 else "STATE_NEW"
                 return httpx.Response(
                     200,
                     json={

--- a/tests/unit/test_relayer_setup_trading_approvals.py
+++ b/tests/unit/test_relayer_setup_trading_approvals.py
@@ -39,7 +39,7 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
                     "transactionID": "tx-setup",
                 },
                 "/v1/account/transactions/tx-setup": {
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "ab" * 32,
                     "transaction_id": "tx-setup",
                 },
@@ -149,7 +149,7 @@ def test_setup_trading_approvals_uses_safe_multisend_for_safe() -> None:
                     "transactionID": "tx-setup-safe",
                 },
                 "/v1/account/transactions/tx-setup-safe": {
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "cd" * 32,
                     "transaction_id": "tx-setup-safe",
                 },

--- a/tests/unit/test_relayer_submit_poll.py
+++ b/tests/unit/test_relayer_submit_poll.py
@@ -160,13 +160,18 @@ def test_gasless_transaction_preserves_present_transaction_hash() -> None:
     assert tx.transaction_hash == expected
 
 
-def test_poll_until_terminal_returns_outcome_on_mined() -> None:
+def test_poll_until_terminal_waits_for_confirmed_after_mined() -> None:
+    polls = 0
+
     async def run() -> Any:
         def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal polls
+            polls += 1
+
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_MINED" if polls == 1 else "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "ab" * 32,
                     "transaction_id": "tx-7",
                 },
@@ -188,6 +193,7 @@ def test_poll_until_terminal_returns_outcome_on_mined() -> None:
     outcome = asyncio.run(run())
     assert outcome.transaction_id == "tx-7"
     assert outcome.transaction_hash == "0x" + "ab" * 32
+    assert polls == 2
 
 
 def test_poll_until_terminal_raises_on_failed_state() -> None:

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -175,7 +175,7 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "ab" * 32,
                     "transaction_id": "tx-setup",
                 },
@@ -264,7 +264,7 @@ def _safe_relayer_handler(captured: list[httpx.Request]):  # type: ignore[no-unt
             return httpx.Response(
                 200,
                 json={
-                    "state": "STATE_MINED",
+                    "state": "STATE_CONFIRMED",
                     "transaction_hash": "0x" + "cd" * 32,
                     "transaction_id": "tx-safe",
                 },
@@ -693,7 +693,7 @@ def test_gasless_wait_returns_outcome_on_terminal_success() -> None:
             client._ctx,
             environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
         )
-        install_sync_relayer_handler(client, _wait_relayer_handler("STATE_MINED"))
+        install_sync_relayer_handler(client, _wait_relayer_handler("STATE_CONFIRMED"))
         handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
         outcome = handle.wait()
 


### PR DESCRIPTION
## Summary
- wait for gasless relayer transactions to reach `STATE_CONFIRMED` before resolving transaction handles
- update async and sync relayer workflow tests to model confirmed transaction outcomes
- cover the mined-to-confirmed polling transition directly

## Why
The relayer can mine a Deposit Wallet transaction before the wallet registry is ready. Returning from `wait()` at `STATE_MINED` lets follow-up Deposit Wallet calls race the registry and fail with `wallet is not registered`.

## Verification
- `uv run pytest tests/unit/test_relayer_submit_poll.py tests/unit/test_relayer_approve_erc20.py tests/unit/test_sync_relayer_workflows.py tests/unit/test_relayer_setup_trading_approvals.py tests/unit/test_place_order_recovery.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when gasless transaction handles resolve, which affects deposit-wallet relayer workflows; behavior is narrower (longer waits) but reduces race failures on follow-up calls.
> 
> **Overview**
> Gasless relayer **`wait()`** / **`poll_until_terminal`** now treat only **`STATE_CONFIRMED`** as success, not **`STATE_MINED`**, so callers keep polling through the mined step until the deposit wallet registry is ready.
> 
> **`_TERMINAL_SUCCESS`** in `poll.py` drops **`MINED`**; async/sync handles and flows that depend on terminal polling (approvals, setup, place-order recovery) inherit the stricter gate. Unit tests mock **`STATE_CONFIRMED`** outcomes and add coverage that a first poll returning **`STATE_MINED`** requires a second poll before returning an outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fab25f869de0a97cc55e48bc1f7b63c6f3b6405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->