### PR TITLE
feat(client): add Perps cancel-all orders

### DIFF
--- a/src/polymarket/_internal/actions/perps/trading.py
+++ b/src/polymarket/_internal/actions/perps/trading.py
@@ -90,6 +90,16 @@ def cancel_orders_by_client_id_op(client_order_ids: Sequence[str]) -> list[Any]:
     return ["cancelOrdersCOID", ids]
 
 
+def cancel_all_orders_op(*, instrument_id: int | None = None) -> list[Any]:
+    if instrument_id is None:
+        return ["cancelAll", []]
+    if isinstance(instrument_id, bool) or not isinstance(instrument_id, int):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise UserInputError("instrument_id must be an int")
+    if instrument_id < 0:
+        raise UserInputError("instrument_id must be non-negative")
+    return ["cancelAll", [instrument_id]]
+
+
 def update_leverage_op(*, instrument_id: int, leverage: int, cross_margin: bool) -> list[Any]:
     if isinstance(instrument_id, bool) or not isinstance(instrument_id, int):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise UserInputError("instrument_id must be an int")
@@ -113,6 +123,13 @@ def to_command_body_op(op: Sequence[Any]) -> dict[str, Any]:
         return body
     if op_type in ("cancelOrders", "cancelOrdersCOID"):
         return {"type": op_type, "args": op[1]}
+    if op_type == "cancelAll":
+        args = op[1]
+        instrument_id = args[0] if args else None
+        return {
+            "type": op_type,
+            "args": {} if instrument_id is None else {"iid": instrument_id},
+        }
     if op_type == "updateLeverage":
         instrument_id, leverage, cross_margin = op[1]
         return {
@@ -146,6 +163,7 @@ def _to_trigger_body(trigger: list[Any]) -> dict[str, Any]:
 
 __all__ = [
     "RawPerpsOrder",
+    "cancel_all_orders_op",
     "cancel_orders_by_client_id_op",
     "cancel_orders_op",
     "create_orders_op",

--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -91,7 +91,7 @@ from polymarket.pagination import AsyncPaginator
 _AUTH_TIMEOUT_S = 30.0
 _ACK_TIMEOUT_S = 30.0
 # Purposefully generous: backend order updates are expected in the ~100ms range.
-_ORDER_PLACEMENT_UPDATE_TIMEOUT_S = 1.0
+_ORDER_PLACEMENT_UPDATE_TIMEOUT_S = 2.0
 _QUEUE_SIZE = 1024
 
 _SESSION_CHANNELS = (

--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -20,6 +20,7 @@ from polymarket._internal.actions.perps.signing import (
 )
 from polymarket._internal.actions.perps.trading import (
     RawPerpsOrder,
+    cancel_all_orders_op,
     cancel_orders_by_client_id_op,
     cancel_orders_op,
     create_orders_op,
@@ -58,6 +59,7 @@ from polymarket.models.perps.events import (
 )
 from polymarket.models.perps.funds import PerpsDeposit, PerpsWithdrawal
 from polymarket.models.perps.orders import (
+    PerpsCancelAllOrdersResponse,
     PerpsCancelOrderResult,
     PerpsFill,
     PerpsOrder,
@@ -498,6 +500,28 @@ class PerpsSession:
         )
         return tuple(results)
 
+    async def cancel_all_orders(
+        self,
+        *,
+        instrument_id: int | None = None,
+        expires_at: datetime | int | None = None,
+    ) -> None:
+        """Cancel all open Perps orders for the session account.
+
+        Omit ``instrument_id`` to cancel open orders across all instruments.
+        The request returns once accepted; individual orders can still race with
+        fills or other cancels.
+        """
+        op = cancel_all_orders_op(instrument_id=instrument_id)
+        response = await self._api.delete_json(
+            "/v1/trade/orders/all",
+            json={
+                **self._create_signed_command(op, expires_at=expires_at),
+                "op": to_command_body_op(op),
+            },
+        )
+        PerpsCancelAllOrdersResponse.parse_response(response)
+
     async def update_leverage(
         self, *, instrument_id: int, leverage: int, cross_margin: bool
     ) -> PerpsUpdateLeverageResult:
@@ -715,6 +739,20 @@ class PerpsSession:
         timeout_message: str,
         expires_at: datetime | int | None = None,
     ) -> Any:
+        command = self._create_signed_command(op, expires_at=expires_at)
+        frame: dict[str, Any] = {
+            "id": self._take_request_id(),
+            "req": "post",
+            "op": to_command_body_op(op),
+            **command,
+        }
+        return await self._send_request(
+            frame, parse=parse, timeout_s=_ACK_TIMEOUT_S, timeout_message=timeout_message
+        )
+
+    def _create_signed_command(
+        self, op: list[Any], *, expires_at: datetime | int | None = None
+    ) -> dict[str, Any]:
         salt = random_perps_salt()
         timestamp = now_ms()
         signature = sign_perps_op_with_key(
@@ -724,20 +762,11 @@ class PerpsSession:
             salt=salt,
             timestamp_ms=timestamp,
         )
-        frame: dict[str, Any] = {
-            "id": self._take_request_id(),
-            "req": "post",
-            "op": to_command_body_op(op),
-            "salt": salt,
-            "sig": signature,
-            "ts": timestamp,
-        }
+        command: dict[str, Any] = {"salt": salt, "sig": signature, "ts": timestamp}
         expiry_ms = to_epoch_ms("expires_at", expires_at)
         if expiry_ms is not None:
-            frame["exp"] = expiry_ms
-        return await self._send_request(
-            frame, parse=parse, timeout_s=_ACK_TIMEOUT_S, timeout_message=timeout_message
-        )
+            command["exp"] = expiry_ms
+        return command
 
     async def _send_request(
         self,

--- a/src/polymarket/models/perps/orders.py
+++ b/src/polymarket/models/perps/orders.py
@@ -147,6 +147,12 @@ class PerpsCancelOrderResult(BaseModel):
         return _default_ack_error(data)
 
 
+class PerpsCancelAllOrdersResponse(BaseModel):
+    """Accepted response for a Perps cancel-all request."""
+
+    status: Literal["ok"]
+
+
 class PerpsUpdateLeverageResult(BaseModel):
     """Result of a Perps leverage update."""
 
@@ -157,6 +163,7 @@ class PerpsUpdateLeverageResult(BaseModel):
 
 
 __all__ = [
+    "PerpsCancelAllOrdersResponse",
     "PerpsCancelOrderResult",
     "PerpsFill",
     "PerpsOrder",

--- a/tests/integration/test_perps.py
+++ b/tests/integration/test_perps.py
@@ -12,6 +12,7 @@ Metered side effects:
 """
 
 import asyncio
+import contextlib
 import math
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime, timedelta
@@ -195,6 +196,49 @@ async def test_places_and_cancels_one_perps_order(
         result = await session.cancel_order(order_id=placement.order.id)
         assert result.status == "ok"
     finally:
+        await session.close()
+
+
+@pytest.mark.integration
+@pytest.mark.metered
+async def test_places_and_cancels_all_perps_orders_for_one_instrument(
+    deposit_wallet_client: AsyncSecureClient,
+) -> None:
+    instrument = await _first_instrument(deposit_wallet_client)
+    ticker = await deposit_wallet_client.fetch_perps_ticker(instrument_id=instrument.id)
+    # Places two resting orders and cancels all open orders for this instrument.
+    price = _format_perps_price(ticker.mark_price / 2, instrument.price_decimals)
+    quantity = _minimal_order_quantity(instrument, Decimal(price))
+    order_ids: list[int] = []
+    session = await deposit_wallet_client.open_perps_session()
+    try:
+        for _ in range(2):
+            placement = await session.place_order(
+                instrument_id=instrument.id,
+                side="BUY",
+                price=price,
+                quantity=quantity,
+                time_in_force="gtc",
+            )
+            order_ids.append(placement.order.id)
+
+        await session.cancel_all_orders(instrument_id=instrument.id)
+
+        async def poll() -> None:
+            while True:
+                open_order_ids = {
+                    order.id
+                    for order in await session.fetch_open_orders(instrument_id=instrument.id)
+                }
+                if all(order_id not in open_order_ids for order_id in order_ids):
+                    return
+                await asyncio.sleep(1.0)
+
+        await asyncio.wait_for(poll(), timeout=30.0)
+    finally:
+        if order_ids:
+            with contextlib.suppress(Exception):
+                await session.cancel_orders(order_ids=order_ids)
         await session.close()
 
 

--- a/tests/unit/test_perps_session.py
+++ b/tests/unit/test_perps_session.py
@@ -9,10 +9,12 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket._internal.perps_session import PerpsSession
+from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import RequestRejectedError, TransportError
 from polymarket.models.perps.credentials import PerpsCredentials
 from polymarket.models.perps.events import PerpsOrderEvent, PerpsResyncEvent
@@ -326,6 +328,54 @@ def test_cancel_order_returns_result_without_raising_on_err_status() -> None:
             assert result.error == "order not found"
 
     asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
+def test_cancel_all_orders_uses_signed_rest_endpoint() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"status": "ok"}, request=request)
+
+    async def run() -> None:
+        session = PerpsSession(
+            chain_id=137,
+            credentials=_CREDENTIALS,
+            rest_url="https://perps.test",
+            ws_url="ws://127.0.0.1:9",
+        )
+        session._api = AsyncTransport(
+            base_url="https://perps.test",
+            client=httpx.AsyncClient(
+                base_url="https://perps.test",
+                transport=httpx.MockTransport(handler),
+            ),
+            header_resolver=session._resolve_auth_headers,
+        )
+        try:
+            await session.cancel_all_orders(instrument_id=1, expires_at=1_700_000_005_000)
+            await session.cancel_all_orders()
+        finally:
+            await session.close()
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+    assert len(captured) == 2
+    assert captured[0].method == "DELETE"
+    assert captured[0].url.path == "/v1/trade/orders/all"
+    assert captured[0].headers["polymarket-proxy"] == _PROXY_ADDRESS
+    assert captured[0].headers["polymarket-secret"] == "session-secret"
+
+    scoped_body = json.loads(captured[0].content)
+    assert scoped_body["op"] == {"type": "cancelAll", "args": {"iid": 1}}
+    assert scoped_body["exp"] == 1_700_000_005_000
+    assert isinstance(scoped_body["salt"], int)
+    assert isinstance(scoped_body["ts"], int)
+    assert scoped_body["sig"].startswith("0x") and len(scoped_body["sig"]) == 132
+
+    unscoped_body = json.loads(captured[1].content)
+    assert unscoped_body["op"] == {"type": "cancelAll", "args": {}}
+    assert "exp" not in unscoped_body
 
 
 def test_sequence_gap_emits_resync_event_before_update() -> None:

--- a/tests/unit/test_perps_trading_commands.py
+++ b/tests/unit/test_perps_trading_commands.py
@@ -6,6 +6,7 @@ import pytest
 
 from polymarket._internal.actions.perps.signing import build_perps_op_typed_data
 from polymarket._internal.actions.perps.trading import (
+    cancel_all_orders_op,
     cancel_orders_by_client_id_op,
     cancel_orders_op,
     create_orders_op,
@@ -121,6 +122,13 @@ def test_cancel_and_leverage_ops() -> None:
     assert to_command_body_op(
         cancel_orders_by_client_id_op(["aabbccddeeff00112233445566778899"])
     ) == {"type": "cancelOrdersCOID", "args": ["aabbccddeeff00112233445566778899"]}
+    assert cancel_all_orders_op() == ["cancelAll", []]
+    assert to_command_body_op(cancel_all_orders_op()) == {"type": "cancelAll", "args": {}}
+    assert cancel_all_orders_op(instrument_id=3) == ["cancelAll", [3]]
+    assert to_command_body_op(cancel_all_orders_op(instrument_id=3)) == {
+        "type": "cancelAll",
+        "args": {"iid": 3},
+    }
     assert to_command_body_op(
         update_leverage_op(instrument_id=3, leverage=20, cross_margin=True)
     ) == {"type": "updateLeverage", "args": {"cross": True, "iid": 3, "lev": 20}}
@@ -180,3 +188,10 @@ def test_empty_cancel_batches_rejected() -> None:
         cancel_orders_op([])
     with pytest.raises(UserInputError):
         cancel_orders_by_client_id_op([])
+
+
+def test_invalid_cancel_all_instrument_id_rejected() -> None:
+    with pytest.raises(UserInputError, match="instrument_id"):
+        cancel_all_orders_op(instrument_id=True)  # type: ignore[arg-type]
+    with pytest.raises(UserInputError, match="non-negative"):
+        cancel_all_orders_op(instrument_id=-1)


### PR DESCRIPTION
## Summary
- Add `PerpsSession.cancel_all_orders(...)` for proxy-signed cancel-all REST calls
- Serialize `cancelAll` as scoped or unscoped signed ops and validate the accepted response
- Add focused unit coverage and opt-in metered live coverage

## Verification
- `uv run pytest tests/unit/test_perps_trading_commands.py tests/unit/test_perps_session.py`
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest tests/integration/test_perps.py::test_places_and_cancels_all_perps_orders_for_one_instrument` skipped by default
- `uv run pytest tests/unit`
- `uv run ruff format --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a broad trading action (account-wide cancel when unscoped) over signed REST; behavior is covered by tests but mistakes could cancel more orders than intended.
> 
> **Overview**
> Adds **`PerpsSession.cancel_all_orders`** so callers can clear open Perps orders with an optional **`instrument_id`** scope, or across all instruments when omitted. The call is a proxy-signed **`DELETE /v1/trade/orders/all`** (not the WebSocket cancel path) and accepts an optional **`expires_at`** like other signed commands.
> 
> Command plumbing adds **`cancel_all_orders_op`** and **`cancelAll`** serialization (empty **`args`** vs **`{"iid": …}`**), plus **`PerpsCancelAllOrdersResponse`** for the accepted **`status: ok`** payload. Signed-command building is refactored into **`_create_signed_command`** so REST cancel-all and WebSocket commands share salt/signature/expiry logic.
> 
> **`_ORDER_PLACEMENT_UPDATE_TIMEOUT_S`** is raised from 1s to 2s. Unit tests cover op/body validation and REST request shape; an opt-in metered integration test places two resting orders and verifies instrument-scoped cancel-all clears them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c52720bf52445c38cdfe883fbe7af0291be42a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->