### PR TITLE
fix(ws): bound websocket close latency

### DIFF
--- a/src/polymarket/_internal/ws/connection.py
+++ b/src/polymarket/_internal/ws/connection.py
@@ -21,6 +21,7 @@ OnError = Callable[[BaseException], None]
 
 DEFAULT_WATCHDOG_INTERVAL_S = 5.0
 DEFAULT_OPEN_TIMEOUT_S = 10.0
+DEFAULT_CLOSE_TIMEOUT_S = 0.5
 
 
 @dataclass(frozen=True)
@@ -40,13 +41,17 @@ class AsyncWebSocketConnection:
         logger: logging.Logger | None = None,
         watchdog_interval_s: float = DEFAULT_WATCHDOG_INTERVAL_S,
         open_timeout_s: float = DEFAULT_OPEN_TIMEOUT_S,
+        close_timeout_s: float = DEFAULT_CLOSE_TIMEOUT_S,
     ) -> None:
         if watchdog_interval_s <= 0:
             raise ValueError("watchdog_interval_s must be positive")
+        if close_timeout_s <= 0:
+            raise ValueError("close_timeout_s must be positive")
         self._heartbeat: Heartbeat = heartbeat or NoopHeartbeat()
         self._logger = logger or logging.getLogger("polymarket.ws")
         self._watchdog_interval_s = watchdog_interval_s
         self._open_timeout_s = open_timeout_s
+        self._close_timeout_s = close_timeout_s
         self._socket: ClientConnection | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._watchdog_task: asyncio.Task[None] | None = None
@@ -108,6 +113,7 @@ class AsyncWebSocketConnection:
                 url,
                 additional_headers=additional_headers,
                 open_timeout=self._open_timeout_s,
+                close_timeout=self._close_timeout_s,
             )
         except (OSError, TimeoutError, WebSocketException) as error:
             raise TransportError(str(error) or f"WebSocket connection failed: {url}") from error
@@ -184,6 +190,10 @@ class AsyncWebSocketConnection:
                 await self._heartbeat.stop()
                 if watchdog is not None:
                     watchdog.cancel()
+                try:
+                    await socket.close()
+                except Exception:
+                    self._logger.debug("error closing socket after reader stopped", exc_info=True)
                 if on_close is not None:
                     try:
                         on_close()

--- a/tests/integration/test_ws_connection_shutdown.py
+++ b/tests/integration/test_ws_connection_shutdown.py
@@ -1,0 +1,25 @@
+import asyncio
+import time
+
+import pytest
+
+from polymarket import AsyncPublicClient
+from polymarket.environments import PRODUCTION
+from polymarket.streams import CryptoPricesSpec
+
+
+@pytest.mark.integration
+def test_live_rtds_single_subscription_close_returns_within_one_second() -> None:
+    async def run() -> float:
+        client = AsyncPublicClient(environment=PRODUCTION)
+        try:
+            stream = await client.subscribe(CryptoPricesSpec(topic="prices.crypto.binance"))
+            await asyncio.sleep(0.5)
+            started = time.monotonic()
+            await asyncio.wait_for(stream.close(), timeout=1.0)
+            return time.monotonic() - started
+        finally:
+            await client.close()
+
+    elapsed_s = asyncio.run(asyncio.wait_for(run(), timeout=15.0))
+    assert elapsed_s < 1.0


### PR DESCRIPTION
## Summary
- Bound websocket close handshakes so single-subscription shutdown returns quickly when the peer does not acknowledge close frames.
- Close sockets claimed by the reader cleanup path so later cleanup does not become a no-op.
- Add live RTDS single-subscription integration coverage asserting close returns within one second.

Linear: DEV-314
Fixes #114

## Verification
- uv run pytest tests/unit/test_ws_connection.py tests/integration/test_ws_connection_shutdown.py
- uv run ruff format --check src/polymarket/_internal/ws/connection.py tests/unit/test_ws_connection.py tests/integration/test_ws_connection_shutdown.py
- uv run ruff check src/polymarket/_internal/ws/connection.py tests/unit/test_ws_connection.py tests/integration/test_ws_connection_shutdown.py
- uv run pyright src/polymarket/_internal/ws/connection.py tests/unit/test_ws_connection.py tests/integration/test_ws_connection_shutdown.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to WebSocket transport teardown timing and cleanup; no auth or data-handling logic is touched.
> 
> **Overview**
> WebSocket shutdown is tightened so clients don’t hang when the server never completes the close handshake.
> 
> `AsyncWebSocketConnection` now takes a **`close_timeout_s`** (default **0.5s**) and passes it into **`ws_connect`**, capping how long the library waits on the close handshake. When the reader loop exits and claims the socket, it **explicitly `await socket.close()`** in cleanup so the connection is actually torn down instead of leaving later shutdown as a no-op.
> 
> A live RTDS integration test asserts a single crypto price subscription **`stream.close()`** finishes in under one second.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea08081fa28c77f2365e6765042682db9b4c429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->