### PR TITLE
fix(models): parse Combo activity type

### DIFF
--- a/src/polymarket/models/data/activity.py
+++ b/src/polymarket/models/data/activity.py
@@ -375,14 +375,14 @@ _KNOWN_ACTIVITY_TYPES: dict[str, type[_KnownActivityBase]] = {
     "YIELD": YieldActivity,
 }
 
-_COMBO_ACTIVITY_TYPES: dict[str, tuple[ComboActivityType, type[_ComboActivityBase]]] = {
-    "Split": ("SPLIT", ComboSplitActivity),
-    "Merge": ("MERGE", ComboMergeActivity),
-    "Convert": ("CONVERT", ComboConvertActivity),
-    "Compress": ("COMPRESS", ComboCompressActivity),
-    "Wrap": ("WRAP", ComboWrapActivity),
-    "Unwrap": ("UNWRAP", ComboUnwrapActivity),
-    "Redeem": ("REDEEM", ComboRedeemActivity),
+_COMBO_ACTIVITY_TYPES: dict[ComboActivityType, type[_ComboActivityBase]] = {
+    "SPLIT": ComboSplitActivity,
+    "MERGE": ComboMergeActivity,
+    "CONVERT": ComboConvertActivity,
+    "COMPRESS": ComboCompressActivity,
+    "WRAP": ComboWrapActivity,
+    "UNWRAP": ComboUnwrapActivity,
+    "REDEEM": ComboRedeemActivity,
 }
 
 
@@ -410,11 +410,10 @@ def parse_combo_activity(payload: object) -> ComboActivity:
     if not isinstance(payload, dict):
         raise UnexpectedResponseError("Combo activity payload must be an object.")
     data = dict(cast(dict[str, Any], payload))
-    raw_type = data.get("side")
+    raw_type = data.get("type")
     if not isinstance(raw_type, str) or raw_type not in _COMBO_ACTIVITY_TYPES:
         raise UnexpectedResponseError("Combo activity response did not match expected shape")
-    activity_type, cls = _COMBO_ACTIVITY_TYPES[raw_type]
-    data["type"] = activity_type
+    cls = _COMBO_ACTIVITY_TYPES[raw_type]
     return cast(ComboActivity, cls.parse_response(data))
 
 

--- a/tests/unit/test_data_models.py
+++ b/tests/unit/test_data_models.py
@@ -254,11 +254,10 @@ def test_combo_position_rejects_invalid_condition_id() -> None:
         ComboPosition.parse_response(_combo_position_payload(condition_id=_CTF_CONDITION_ID))
 
 
-def test_combo_activity_normalizes_upstream_type_and_redeem_fields() -> None:
+def test_combo_activity_parses_api_type_and_redeem_fields() -> None:
     payload = {
         "id": "tx:1",
-        "side": "Redeem",
-        "module_kind": "combo",
+        "type": "REDEEM",
         "user_address": "0x0000000000000000000000000000000000000001",
         "combo_condition_id": _COMBO_CONDITION_ID,
         "combo_position_id": "123",


### PR DESCRIPTION
## Summary
- Parse Combo lifecycle activity from the canonical API type field.
- Stop deriving Combo activity types from the legacy side verb.
- Keep the ComboActivityType enum unchanged because it already matches the API values.

## Verification
- uv run ruff format --check
- uv run ruff check
- uv run pyright
- uv run pytest tests/unit/test_data_models.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to response parsing in the data models layer with no auth or persistence impact; callers must send the canonical `type` values.
> 
> **Overview**
> **Combo lifecycle activities** are now parsed from the canonical API **`type`** field (e.g. `REDEEM`) instead of the legacy **`side`** verb (e.g. `Redeem`).
> 
> `_COMBO_ACTIVITY_TYPES` is simplified to map each `ComboActivityType` directly to its Pydantic class, and `parse_combo_activity` no longer rewrites `type` on the payload before `parse_response`. The unit test fixture was updated to match the API shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ef685fc130108d27c6f9e6947875d3bb5e79a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->