### PR TITLE
fix: attach builder auth headers to CLOB requests

### DIFF
--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -81,7 +81,10 @@ from polymarket._internal.actions.perps import public as _perps_actions
 from polymarket._internal.actions.relayer.approvals import (
     resolve_missing_trading_approval_calls,
 )
-from polymarket._internal.actions.relayer.auth import make_relayer_header_resolver
+from polymarket._internal.actions.relayer.auth import (
+    build_builder_key_headers,
+    make_relayer_header_resolver,
+)
 from polymarket._internal.actions.relayer.calls import (
     MAX_UINT256,
     TransactionCall,
@@ -458,7 +461,11 @@ class AsyncSecureClient:
         secure_clob = AsyncTransport(
             base_url=environment.clob_url,
             logger=logger,
-            header_resolver=_make_l2_header_resolver(signer, credentials),
+            header_resolver=_make_l2_header_resolver(
+                signer,
+                credentials,
+                api_key if isinstance(api_key, BuilderApiKey) else None,
+            ),
         )
         rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
         rpc = JsonRpcClient(rpc_transport)
@@ -3198,7 +3205,11 @@ async def _credentials_are_active(
     return credentials.key in keys
 
 
-def _make_l2_header_resolver(signer: LocalAccount, credentials: ApiKeyCreds) -> _L2HeaderResolver:
+def _make_l2_header_resolver(
+    signer: LocalAccount,
+    credentials: ApiKeyCreds,
+    builder_key: BuilderApiKey | None = None,
+) -> _L2HeaderResolver:
     async def resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
         timestamp = int(time.time())
         signature = build_hmac_signature(
@@ -3208,12 +3219,17 @@ def _make_l2_header_resolver(signer: LocalAccount, credentials: ApiKeyCreds) -> 
             path=path,
             body=body,
         )
-        return {
+        headers = {
             "POLY_ADDRESS": signer.address,
             "POLY_API_KEY": credentials.key,
             "POLY_PASSPHRASE": credentials.passphrase,
             "POLY_SIGNATURE": signature,
             "POLY_TIMESTAMP": str(timestamp),
         }
+        if builder_key is not None:
+            headers.update(
+                build_builder_key_headers(creds=builder_key, method=method, path=path, body=body)
+            )
+        return headers
 
     return resolver

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -68,7 +68,10 @@ from polymarket._internal.actions.orders.types import OrderDraft
 from polymarket._internal.actions.relayer.approvals import (
     resolve_missing_trading_approval_calls_sync,
 )
-from polymarket._internal.actions.relayer.auth import make_relayer_header_resolver_sync
+from polymarket._internal.actions.relayer.auth import (
+    build_builder_key_headers,
+    make_relayer_header_resolver_sync,
+)
 from polymarket._internal.actions.relayer.calls import (
     MAX_UINT256,
     TransactionCall,
@@ -380,7 +383,11 @@ class SecureClient:
             secure_clob = SyncTransport(
                 base_url=environment.clob_url,
                 logger=logger,
-                header_resolver=_make_l2_header_resolver_sync(signer, credentials),
+                header_resolver=_make_l2_header_resolver_sync(
+                    signer,
+                    credentials,
+                    api_key if isinstance(api_key, BuilderApiKey) else None,
+                ),
             )
             rpc_transport = SyncTransport(base_url=environment.rpc_url, logger=logger)
             rpc = SyncJsonRpcClient(rpc_transport)
@@ -2662,7 +2669,9 @@ def _credentials_are_active_sync(
 
 
 def _make_l2_header_resolver_sync(
-    signer: LocalAccount, credentials: ApiKeyCreds
+    signer: LocalAccount,
+    credentials: ApiKeyCreds,
+    builder_key: BuilderApiKey | None = None,
 ) -> SyncHeaderResolver:
     def resolver(method: str, path: str, body: str | None) -> Mapping[str, str]:
         timestamp = int(time.time())
@@ -2673,12 +2682,17 @@ def _make_l2_header_resolver_sync(
             path=path,
             body=body,
         )
-        return {
+        headers = {
             "POLY_ADDRESS": signer.address,
             "POLY_API_KEY": credentials.key,
             "POLY_PASSPHRASE": credentials.passphrase,
             "POLY_SIGNATURE": signature,
             "POLY_TIMESTAMP": str(timestamp),
         }
+        if builder_key is not None:
+            headers.update(
+                build_builder_key_headers(creds=builder_key, method=method, path=path, body=body)
+            )
+        return headers
 
     return resolver

--- a/tests/unit/test_secure_orders_sync.py
+++ b/tests/unit/test_secure_orders_sync.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 import httpx
 import pytest
 
-from polymarket import ApiKeyCreds, SecureClient
+from polymarket import ApiKeyCreds, BuilderApiKey, SecureClient
 from polymarket.clients._transport import SyncTransport
 from polymarket.errors import UserInputError
 from polymarket.models.clob.order_response import AcceptedOrder
@@ -15,6 +15,7 @@ from polymarket.models.clob.order_response import AcceptedOrder
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 SIGNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 FAKE_CREDS = ApiKeyCreds(key="test-key", passphrase="test-passphrase", secret="dGVzdA==")
+BUILDER_KEY = BuilderApiKey(key="builder-key", passphrase="builder-passphrase", secret="dGVzdA==")
 
 
 def _public_routes() -> dict[str, Any]:
@@ -97,11 +98,12 @@ def _install_secure_clob(client: SecureClient, handler: httpx.MockTransport) -> 
     client._ctx = dataclasses.replace(client._ctx, secure_clob=transport)
 
 
-def _make_client() -> SecureClient:
+def _make_client(*, builder_auth: bool = False) -> SecureClient:
     return SecureClient._create(
         private_key=PRIVATE_KEY,
         wallet=SIGNER_ADDRESS,
         credentials=FAKE_CREDS,
+        api_key=BUILDER_KEY if builder_auth else None,
         validate_credentials=False,
     )
 
@@ -152,6 +154,23 @@ def test_place_limit_order_posts_after_signing() -> None:
         r for r in secure_captured if r.method == "POST" and urlparse(str(r.url)).path == "/order"
     )
     assert post_request.headers.get("POLY_SIGNATURE")
+
+
+def test_place_limit_order_sends_builder_headers() -> None:
+    secure_captured: list[httpx.Request] = []
+
+    with _make_client(builder_auth=True) as client:
+        _install_clob(client, _routed_handler([], _public_routes()))
+        _install_secure_clob(client, _routed_handler(secure_captured, _secure_routes()))
+        client.place_limit_order(token_id="8501497", price="0.5", size="10", side="BUY")
+
+    post_request = next(
+        r for r in secure_captured if r.method == "POST" and urlparse(str(r.url)).path == "/order"
+    )
+    assert post_request.headers.get("POLY_SIGNATURE")
+    assert post_request.headers.get("POLY_BUILDER_API_KEY") == BUILDER_KEY.key
+    assert post_request.headers.get("POLY_BUILDER_PASSPHRASE") == BUILDER_KEY.passphrase
+    assert post_request.headers.get("POLY_BUILDER_SIGNATURE")
 
 
 def test_place_market_order_buy_signs_and_posts() -> None:


### PR DESCRIPTION
## Summary

- attach `POLY_BUILDER_*` headers to authenticated CLOB requests when a secure client is configured with `BuilderApiKey`
- preserve the existing `POLY_*` L2 headers on the same request
- cover order posting with a regression test
- keep relayer-key behavior unchanged

## Problem

`SecureClient.create(api_key=BuilderApiKey(...))` accepted builder credentials, but only installed their HMAC header resolver on the relayer transport. The authenticated CLOB transport always installed only the account's L2 resolver.

As a result, Python order submissions such as `POST /order` and `POST /orders` omitted `POLY_BUILDER_*` even though the equivalent TypeScript client merges builder and L2 authorization for authenticated CLOB requests.

## Why this matters

Builder-authenticated order submission requires both independent layers:

- `POLY_*` authenticates the trading account
- `POLY_BUILDER_*` authenticates the builder integration

Without the builder headers, Python integrations cannot submit orders with the same builder-authenticated request contract as TypeScript integrations. This is particularly important for external Combos builders and omnibus integrations that keep builder credentials server-side and use local HMAC signing.

The signed order's `builder` field remains separate: it provides builder attribution in the order payload, while these headers authorize the HTTP request.

## Implementation

The change is intentionally narrow and internal. The existing builder-header construction is reused by the sync and async CLOB header resolvers only when `api_key` is a `BuilderApiKey`. No public API, model, or transport abstraction is added.

## Validation

- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run pyright`
- `uv run pytest -q tests/unit` — 1,827 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order-submission auth headers on the trading path; scope is narrow and gated on BuilderApiKey, with a regression test for POST /order.
> 
> **Overview**
> When a secure client is created with `api_key=BuilderApiKey(...)`, **authenticated CLOB traffic** (e.g. `POST /order`) now includes **`POLY_BUILDER_*` headers** alongside the existing **`POLY_*` L2 headers**, matching the dual-auth contract used elsewhere in the SDK.
> 
> Sync and async `_make_l2_header_resolver*` helpers take an optional `builder_key` and merge headers from `build_builder_key_headers` when present; client construction passes the builder key only when `api_key` is a `BuilderApiKey`. Relayer transport behavior is unchanged.
> 
> A sync unit test asserts builder headers on limit-order posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 602d898eb37920d70996ba9307b42309e088a9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->