### PR TITLE
fix(models): treat empty strings as absent for optional stream decimals

### DIFF
--- a/src/polymarket/models/clob/_validators.py
+++ b/src/polymarket/models/clob/_validators.py
@@ -30,6 +30,18 @@ def _coerce_decimalish(value: object) -> object:
     raise ValueError(msg)
 
 
+def _coerce_optional_decimalish(value: object) -> object:
+    """Coerce a decimal-ish value, treating an empty string as absent.
+
+    Streaming messages use ``""`` for optional decimal fields that have no
+    value (for example ``fee_rate_bps`` on a trade with no fee), so an empty
+    string maps to ``None`` instead of failing decimal parsing.
+    """
+    if value == "":
+        return None
+    return _coerce_decimalish(value)
+
+
 def _parse_epoch_ms_timestamp(value: object) -> object:
     if value is None or value == "":
         return None
@@ -192,9 +204,16 @@ def _parse_expiration_timestamp(value: object) -> object:
 if TYPE_CHECKING:
     _DecimalFromString = Decimal
     _DecimalFromNumberOrString = Decimal
+    _OptionalDecimalFromNumberOrString = Decimal | None
 else:
     _DecimalFromString = Annotated[Decimal, BeforeValidator(_require_decimal_string)]
     _DecimalFromNumberOrString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
+    # The validator must wrap the whole optional annotation: on a
+    # ``Decimal | None`` union, a BeforeValidator attached only to the Decimal
+    # member cannot map "" to None (the None branch still sees the original "").
+    _OptionalDecimalFromNumberOrString = Annotated[
+        Decimal | None, BeforeValidator(_coerce_optional_decimalish)
+    ]
 
 EpochMsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms_timestamp)]
 EpochMsOrIsoTimestamp = Annotated[

--- a/src/polymarket/models/clob/market_events.py
+++ b/src/polymarket/models/clob/market_events.py
@@ -6,6 +6,7 @@ from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
     EpochMsTimestamp,
     _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _OptionalDecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import CtfConditionId, TokenId, validate_optional_ctf_condition_id
@@ -32,8 +33,8 @@ class PriceChange(BaseModel):
     size: _DecimalFromNumberOrString
     side: _OrderSide
     hash: str | None = None
-    best_bid: _DecimalFromNumberOrString | None = None
-    best_ask: _DecimalFromNumberOrString | None = None
+    best_bid: _OptionalDecimalFromNumberOrString = None
+    best_ask: _OptionalDecimalFromNumberOrString = None
 
 
 # --- Payloads (the variant-specific data; lifted out of the wire's top level) ---
@@ -46,10 +47,10 @@ class MarketBookPayload(BaseModel):
     asks: tuple[OrderBookLevel, ...]
     hash: str | None = None
     timestamp: EpochMsTimestamp = None
-    min_order_size: _DecimalFromNumberOrString | None = None
-    tick_size: _DecimalFromNumberOrString | None = None
+    min_order_size: _OptionalDecimalFromNumberOrString = None
+    tick_size: _OptionalDecimalFromNumberOrString = None
     neg_risk: bool | None = None
-    last_trade_price: _DecimalFromNumberOrString | None = None
+    last_trade_price: _OptionalDecimalFromNumberOrString = None
 
 
 class MarketPriceChangePayload(BaseModel):
@@ -62,9 +63,9 @@ class MarketLastTradePricePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
     price: _DecimalFromNumberOrString
-    size: _DecimalFromNumberOrString | None = None
+    size: _OptionalDecimalFromNumberOrString = None
     side: _OrderSide
-    fee_rate_bps: _DecimalFromNumberOrString | None = None
+    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
     transaction_hash: str | None = None
     timestamp: EpochMsTimestamp = None
 
@@ -72,7 +73,7 @@ class MarketLastTradePricePayload(BaseModel):
 class MarketTickSizeChangePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    old_tick_size: _DecimalFromNumberOrString | None = None
+    old_tick_size: _OptionalDecimalFromNumberOrString = None
     new_tick_size: _DecimalFromNumberOrString
     timestamp: EpochMsTimestamp = None
 
@@ -80,9 +81,9 @@ class MarketTickSizeChangePayload(BaseModel):
 class MarketBestBidAskPayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    best_bid: _DecimalFromNumberOrString | None = None
-    best_ask: _DecimalFromNumberOrString | None = None
-    spread: _DecimalFromNumberOrString | None = None
+    best_bid: _OptionalDecimalFromNumberOrString = None
+    best_ask: _OptionalDecimalFromNumberOrString = None
+    spread: _OptionalDecimalFromNumberOrString = None
     timestamp: EpochMsTimestamp = None
 
 
@@ -101,11 +102,11 @@ class NewMarketPayload(BaseModel):
     active: bool | None = None
     clob_token_ids: tuple[str, ...] | None = None
     sports_market_type: str | None = None
-    line: _DecimalFromNumberOrString | None = None
+    line: _OptionalDecimalFromNumberOrString = None
     game_start_time: EpochMsTimestamp = None
-    order_price_min_tick_size: _DecimalFromNumberOrString | None = None
+    order_price_min_tick_size: _OptionalDecimalFromNumberOrString = None
     group_item_title: str | None = None
-    taker_base_fee: _DecimalFromNumberOrString | None = None
+    taker_base_fee: _OptionalDecimalFromNumberOrString = None
     fees_enabled: bool | None = None
     fee_schedule: object | None = None
 

--- a/src/polymarket/models/clob/user_events.py
+++ b/src/polymarket/models/clob/user_events.py
@@ -8,6 +8,7 @@ from polymarket.models.clob._validators import (
     EpochSecondsTimestamp,
     ExpirationTimestamp,
     _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _OptionalDecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import TokenId
 
@@ -77,7 +78,7 @@ class UserTradeMakerOrder(BaseModel):
     maker_address: str | None = None
     matched_amount: _DecimalFromNumberOrString
     price: _DecimalFromNumberOrString
-    fee_rate_bps: _DecimalFromNumberOrString | None = None
+    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
     token_id: TokenId = Field(validation_alias="asset_id")
     side: _OrderSide
     outcome: str | None = None
@@ -95,7 +96,7 @@ class UserTradePayload(BaseModel):
     status: _TradeStatusValidator
     owner: str
     timestamp: EpochSecondsOrMsTimestamp = None
-    fee_rate_bps: _DecimalFromNumberOrString | None = None
+    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
     matched_at: EpochSecondsTimestamp = Field(
         default=None, validation_alias=AliasChoices("match_time", "matchtime")
     )

--- a/tests/unit/test_streams_market_events.py
+++ b/tests/unit/test_streams_market_events.py
@@ -263,3 +263,36 @@ def test_new_market_game_start_time_parsed_to_datetime() -> None:
     event = parse_market_event(payload)
     assert isinstance(event, NewMarketEvent)
     assert event.payload.game_start_time == datetime.fromtimestamp(1710000000, tz=UTC)
+
+
+def test_last_trade_empty_string_fee_rate_bps_parsed_as_none() -> None:
+    payload = dict(_LAST_TRADE) | {"fee_rate_bps": ""}
+    event = parse_market_event(payload)
+    assert isinstance(event, MarketLastTradePriceEvent)
+    assert event.payload.fee_rate_bps is None
+
+
+def test_price_change_empty_string_best_bid_ask_parsed_as_none() -> None:
+    # The wire sends "" for best_bid/best_ask when they are absent.
+    price_change = dict(_PRICE_CHANGE["price_changes"][0]) | {"best_bid": "", "best_ask": ""}
+    payload = dict(_PRICE_CHANGE) | {"price_changes": [price_change]}
+    event = parse_market_event(payload)
+    assert isinstance(event, MarketPriceChangeEvent)
+    assert event.payload.price_changes[0].best_bid is None
+    assert event.payload.price_changes[0].best_ask is None
+
+
+def test_best_bid_ask_empty_strings_parsed_as_none() -> None:
+    payload = dict(_BBA) | {"best_bid": "", "best_ask": "", "spread": ""}
+    event = parse_market_event(payload)
+    assert isinstance(event, MarketBestBidAskEvent)
+    assert event.payload.best_bid is None
+    assert event.payload.best_ask is None
+    assert event.payload.spread is None
+
+
+def test_empty_string_required_decimal_rejected() -> None:
+    # "" only means absent for optional decimals; required ones stay strict.
+    payload = dict(_LAST_TRADE) | {"price": ""}
+    with pytest.raises(ValidationError):
+        parse_market_event(payload)

--- a/tests/unit/test_streams_user_events.py
+++ b/tests/unit/test_streams_user_events.py
@@ -222,3 +222,32 @@ def test_parse_user_events_drops_malformed() -> None:
     events, dropped = parse_user_events([_ORDER_PLACEMENT, {"bogus": True}, _TRADE])
     assert dropped == 1
     assert len(events) == 2
+
+
+def test_trade_empty_string_fee_rate_bps_parsed_as_none() -> None:
+    # The user channel sends "" when a trade carries no fee.
+    event = parse_user_event({**_TRADE, "fee_rate_bps": ""})
+    assert isinstance(event, UserTradeEvent)
+    assert event.payload.fee_rate_bps is None
+
+
+def test_trade_maker_order_empty_string_fee_rate_bps_parsed_as_none() -> None:
+    maker_order = {**_TRADE["maker_orders"][0], "fee_rate_bps": ""}
+    event = parse_user_event({**_TRADE, "maker_orders": [maker_order]})
+    assert isinstance(event, UserTradeEvent)
+    assert event.payload.maker_orders is not None
+    assert event.payload.maker_orders[0].fee_rate_bps is None
+
+
+def test_trade_fee_rate_bps_still_parsed_when_present() -> None:
+    from decimal import Decimal
+
+    event = parse_user_event(_TRADE)
+    assert isinstance(event, UserTradeEvent)
+    assert event.payload.fee_rate_bps == Decimal("25")
+
+
+def test_trade_empty_string_required_decimal_rejected() -> None:
+    # "" only means absent for optional decimals; required ones stay strict.
+    with pytest.raises(ValidationError):
+        parse_user_event({**_TRADE, "price": ""})


### PR DESCRIPTION
Fixes #155

## Problem

The user channel sends `""` for `fee_rate_bps` when a trade carries no fee. Optional decimal fields on the stream models are typed `_DecimalFromNumberOrString | None`, and `_coerce_decimalish` passes strings through, so `""` fails decimal parsing. On the user channel this surfaces as a `ValidationError`; on the market channel the event would be silently dropped.

Note the fix has to put the optionality inside the annotation: on a `Decimal | None` union, a `BeforeValidator` attached only to the `Decimal` member cannot map `""` to `None`, because the `None` branch still sees the original `""` and both members fail.

## Change

- Add `_OptionalDecimalFromNumberOrString` (`Annotated[Decimal | None, BeforeValidator(...)]`) that maps `""` to `None` before delegating to `_coerce_decimalish`.
- Point all optional decimal fields in the stream models at it: `fee_rate_bps` on user trades and maker orders, plus the optional decimals in the market event models (`best_bid`/`best_ask`, `spread`, tick sizes, `min_order_size`, `last_trade_price`, `size`, `line`, `order_price_min_tick_size`, `taker_base_fee`). The wire serializer emits `""` for any absent optional value (the upstream test fixtures show `"best_bid":"","best_ask":""` on `price_change`), so the exposure is not limited to `fee_rate_bps`.
- Required decimal fields are unchanged and still reject `""`.

This matches the existing `""` -> `None` convention already used for `MakerOrder.fee_rate_bps` and `OrderBook.last_trade_price` on the REST models.

## Verification

- `make check` passes (ruff, format check, pyright, 1834 unit tests)
- Reproduced the issue #155 trade payload before the fix (fails with `decimal_parsing`) and after (parses with `fee_rate_bps=None`)
- New tests cover `""` on user trade / maker order / market last-trade / price-change / best-bid-ask fields, a present-value regression check, and that required decimals still reject `""`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Pydantic validation for stream models; required decimals stay strict and behavior aligns with existing REST `""` → `None` handling.
> 
> **Overview**
> Streaming wire payloads use `""` for optional decimals with no value (e.g. `fee_rate_bps` on fee-less trades). Optional fields typed as `_DecimalFromNumberOrString | None` still ran `""` through decimal parsing and failed validation—user events raised `ValidationError`; market events could be dropped.
> 
> This adds `_coerce_optional_decimalish` and `_OptionalDecimalFromNumberOrString`, with the `BeforeValidator` on the full `Decimal | None` union so `""` becomes `None` before coercion. **Market** and **user** stream models now use that type for optional decimals (`fee_rate_bps`, `best_bid`/`best_ask`, `spread`, sizes, tick fields, etc.); required decimals are unchanged and still reject `""`.
> 
> Unit tests cover empty-string optional fields, a present-value regression, and strict required decimals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377d13ed6609a870be5801db7b375c9921a9b967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->