### PR TITLE
ci: enable Dependabot version updates (ISVBE-262)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Dependabot configuration for py-sdk (polymarket-client).
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Python dependencies managed by uv (pyproject.toml + uv.lock).
+  # Dependabot's uv ecosystem (GA since 2025-03) keeps uv.lock and pinned
+  # pyproject.toml constraints in sync.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    # Wait before adopting freshly-published releases (supply-chain buffer).
+    # Applies to version updates only; security fixes are never delayed.
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # One PR for all backward-compatible version bumps, to cut noise.
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # One PR for security fixes once an advisory has a fix available.
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    # Major-version bumps are left ungrouped so each gets its own PR and review.
+
+  # GitHub Actions used by the CI workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      # Routine action bumps in one PR, to cut noise.
+      github-actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Major action bumps in their own PR for migration-note review
+      # (kept grouped so they stay within the open-PR limit, but separate
+      # from routine bumps since majors can change runner/input contracts).
+      github-actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Enable Dependabot version updates (ISVBE-262)

py-sdk had no dependency-update automation, so deps only surfaced as security alerts or incidents (eng-practice assessment gap #10). This adds `.github/dependabot.yml`.

**What it does**
- `uv` ecosystem (pyproject.toml + uv.lock): Dependabot's native uv support (GA 2025-03) keeps the lockfile and pinned constraints in sync
- `github-actions` ecosystem for the CI workflows
- Python minor/patch grouped into one PR; Python majors left ungrouped for individual review; Python security advisories grouped once a fix is available
- GitHub Actions split into two groups: routine minor/patch in one PR, and majors in their own PR for migration-note review (kept grouped so they stay within the open-PR limit, but separate from routine bumps since action majors can change runner or input contracts)
- 7-day cooldown on version updates (security fixes never delayed); weekly Monday 09:00 America/New_York
- open-PR limits kept tight: uv 3, github-actions 2

**How to verify**
`ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"` parses clean. After merge, GitHub validates it under Insights → Dependency graph → Dependabot; first grouped PRs open on the next scheduled run (or via "Check for updates").

**Risk & rollback**
low: config-only; update PRs run full CI before merge. Rollback = revert the file (updates stop immediately).

Extends the us-backend `.github/dependabot.yml` (#138) with a separate majors group for GitHub Actions; us-backend to follow with the same split.
## Consolidation

Supersedes #164 (a duplicate config for the same ticket). The tighter `open-pull-requests-limit` values from that PR are folded in here (uv 3, github-actions 2); #164 is closed as redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change; generated update PRs still go through CI before merge, and reverting the file stops automation immediately.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so py-sdk gets automated dependency update PRs instead of relying only on security alerts.
> 
> **`uv`** (repo root): weekly Monday 09:00 ET, up to 3 open PRs, 7-day cooldown on version bumps (not security), `chore(deps)` commits. Minor/patch Python deps are **grouped** into one PR; **major** bumps stay separate; security fixes are **grouped** when a fix exists.
> 
> **`github-actions`**: same schedule, limit 2 open PRs, 7-day cooldown, `chore(ci)` prefix, all action bumps **grouped** into one PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607f3be0cf140e1021b26c7322e99bd997e338d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



