### PR TITLE
fix(clob): return TokenId-keyed maps from batch price reads

### DIFF
--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -19,7 +19,7 @@ from polymarket.models.clob import (
 from polymarket.models.clob._validators import (
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
-from polymarket.models.types import OrderSide
+from polymarket.models.types import OrderSide, TokenId
 
 
 class _MidpointResponse(BaseModel):
@@ -37,9 +37,9 @@ class _SpreadResponse(BaseModel):
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[str, _DecimalFromString])
-_SpreadsAdapter = TypeAdapter(dict[str, _DecimalFromString])
-_PricesAdapter = TypeAdapter(dict[str, dict[OrderSide, _DecimalFromString]])
+_MidpointsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
+_SpreadsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
+_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, _DecimalFromString]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])
@@ -110,7 +110,7 @@ def build_midpoints_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict
     return "/midpoints", [{"token_id": tid} for tid in validated]
 
 
-def parse_midpoints(data: object) -> dict[str, Decimal]:
+def parse_midpoints(data: object) -> dict[TokenId, Decimal]:
     try:
         return _MidpointsAdapter.validate_python(data)
     except ValidationError as error:
@@ -132,7 +132,7 @@ def build_prices_request(*, requests: Sequence[PriceRequest]) -> tuple[str, list
     return "/prices", [{"token_id": r.token_id, "side": r.side} for r in validated]
 
 
-def parse_prices(data: object) -> dict[str, dict[OrderSide, Decimal]]:
+def parse_prices(data: object) -> dict[TokenId, dict[OrderSide, Decimal]]:
     try:
         return _PricesAdapter.validate_python(data)
     except ValidationError as error:
@@ -174,7 +174,7 @@ def build_spreads_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict[s
     return "/spreads", [{"token_id": tid} for tid in validated]
 
 
-def parse_spreads(data: object) -> dict[str, Decimal]:
+def parse_spreads(data: object) -> dict[TokenId, Decimal]:
     try:
         return _SpreadsAdapter.validate_python(data)
     except ValidationError as error:

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -116,7 +116,7 @@ from polymarket.models.rtds_events import (
     RtdsEvent,
 )
 from polymarket.models.sports_events import SportsEvent
-from polymarket.models.types import CtfConditionId
+from polymarket.models.types import CtfConditionId, TokenId
 from polymarket.pagination import AsyncPaginator, Page
 from polymarket.streams._specs import (
     CommentsSpec,
@@ -1220,7 +1220,7 @@ class AsyncPublicClient:
         path, params = _clob_actions.build_midpoint_request(token_id=token_id)
         return _clob_actions.parse_midpoint(await self._ctx.clob.get_json(path, params=params))
 
-    async def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    async def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get midpoint prices for multiple tokens."""
         path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
         return _clob_actions.parse_midpoints(await self._ctx.clob.post_json(path, json=body))
@@ -1232,7 +1232,7 @@ class AsyncPublicClient:
 
     async def get_prices(
         self, *, requests: Sequence[PriceRequest]
-    ) -> dict[str, dict[OrderSide, Decimal]]:
+    ) -> dict[TokenId, dict[OrderSide, Decimal]]:
         """Get executable prices for multiple token-side requests."""
         path, body = _clob_actions.build_prices_request(requests=requests)
         return _clob_actions.parse_prices(await self._ctx.clob.post_json(path, json=body))
@@ -1252,7 +1252,7 @@ class AsyncPublicClient:
         path, params = _clob_actions.build_spread_request(token_id=token_id)
         return _clob_actions.parse_spread(await self._ctx.clob.get_json(path, params=params))
 
-    async def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    async def get_spreads(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get bid-ask spreads for multiple tokens."""
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -234,7 +234,7 @@ from polymarket.models.rtds_events import (
     RtdsEvent,
 )
 from polymarket.models.sports_events import SportsEvent
-from polymarket.models.types import CtfConditionId
+from polymarket.models.types import CtfConditionId, TokenId
 from polymarket.pagination import AsyncPaginator, Page
 from polymarket.streams._specs import (
     CommentsSpec,
@@ -1787,7 +1787,7 @@ class AsyncSecureClient:
         path, params = _clob_actions.build_midpoint_request(token_id=token_id)
         return _clob_actions.parse_midpoint(await self._ctx.clob.get_json(path, params=params))
 
-    async def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    async def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get midpoint prices for multiple tokens."""
         path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
         return _clob_actions.parse_midpoints(await self._ctx.clob.post_json(path, json=body))
@@ -1799,7 +1799,7 @@ class AsyncSecureClient:
 
     async def get_prices(
         self, *, requests: Sequence[PriceRequest]
-    ) -> dict[str, dict[OrderSide, Decimal]]:
+    ) -> dict[TokenId, dict[OrderSide, Decimal]]:
         """Get executable prices for multiple token-side requests."""
         path, body = _clob_actions.build_prices_request(requests=requests)
         return _clob_actions.parse_prices(await self._ctx.clob.post_json(path, json=body))
@@ -1819,7 +1819,7 @@ class AsyncSecureClient:
         path, params = _clob_actions.build_spread_request(token_id=token_id)
         return _clob_actions.parse_spread(await self._ctx.clob.get_json(path, params=params))
 
-    async def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    async def get_spreads(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get bid-ask spreads for multiple tokens."""
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -92,7 +92,7 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.models.types import CtfConditionId
+from polymarket.models.types import CtfConditionId, TokenId
 from polymarket.pagination import Page, Paginator
 
 
@@ -1032,7 +1032,7 @@ class PublicClient:
         path, params = _clob_actions.build_midpoint_request(token_id=token_id)
         return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
 
-    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get midpoint prices for multiple tokens."""
         path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
         return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
@@ -1044,7 +1044,7 @@ class PublicClient:
 
     def get_prices(
         self, *, requests: Sequence[PriceRequest]
-    ) -> dict[str, dict[OrderSide, Decimal]]:
+    ) -> dict[TokenId, dict[OrderSide, Decimal]]:
         """Get executable prices for multiple token-side requests."""
         path, body = _clob_actions.build_prices_request(requests=requests)
         return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
@@ -1064,7 +1064,7 @@ class PublicClient:
         path, params = _clob_actions.build_spread_request(token_id=token_id)
         return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
 
-    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get bid-ask spreads for multiple tokens."""
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -192,7 +192,7 @@ from polymarket.models.data import (
     TradedMarketCount,
     TraderLeaderboardEntry,
 )
-from polymarket.models.types import CtfConditionId
+from polymarket.models.types import CtfConditionId, TokenId
 from polymarket.pagination import Page, Paginator
 from polymarket.transactions import (
     MergePositionRequest,
@@ -1339,7 +1339,7 @@ class SecureClient:
         path, params = _clob_actions.build_midpoint_request(token_id=token_id)
         return _clob_actions.parse_midpoint(self._ctx.clob.get_json(path, params=params))
 
-    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    def get_midpoints(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get midpoint prices for multiple tokens."""
         path, body = _clob_actions.build_midpoints_request(token_ids=token_ids)
         return _clob_actions.parse_midpoints(self._ctx.clob.post_json(path, json=body))
@@ -1351,7 +1351,7 @@ class SecureClient:
 
     def get_prices(
         self, *, requests: Sequence[PriceRequest]
-    ) -> dict[str, dict[OrderSide, Decimal]]:
+    ) -> dict[TokenId, dict[OrderSide, Decimal]]:
         """Get executable prices for multiple token-side requests."""
         path, body = _clob_actions.build_prices_request(requests=requests)
         return _clob_actions.parse_prices(self._ctx.clob.post_json(path, json=body))
@@ -1371,7 +1371,7 @@ class SecureClient:
         path, params = _clob_actions.build_spread_request(token_id=token_id)
         return _clob_actions.parse_spread(self._ctx.clob.get_json(path, params=params))
 
-    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[str, Decimal]:
+    def get_spreads(self, *, token_ids: Sequence[str]) -> dict[TokenId, Decimal]:
         """Get bid-ask spreads for multiple tokens."""
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))

--- a/tests/integration/test_clob_reads.py
+++ b/tests/integration/test_clob_reads.py
@@ -60,7 +60,7 @@ def test_async_secure_get_midpoint_returns_decimal_in_unit_range(
 
 @pytest.mark.integration
 def test_async_get_midpoints_returns_decimal_per_token(active_clob_token: TokenId) -> None:
-    async def run() -> dict[str, Decimal]:
+    async def run() -> dict[TokenId, Decimal]:
         async with AsyncPublicClient() as client:
             return await client.get_midpoints(token_ids=[active_clob_token])
 
@@ -84,7 +84,7 @@ def test_async_get_price_returns_decimal_for_buy_side(active_clob_token: TokenId
 
 @pytest.mark.integration
 def test_async_get_prices_returns_decimal_per_token_and_side(active_clob_token: TokenId) -> None:
-    async def run() -> dict[str, dict[OrderSide, Decimal]]:
+    async def run() -> dict[TokenId, dict[OrderSide, Decimal]]:
         async with AsyncPublicClient() as client:
             return await client.get_prices(
                 requests=[
@@ -140,7 +140,7 @@ def test_async_get_spread_returns_non_negative_decimal(active_clob_token: TokenI
 
 @pytest.mark.integration
 def test_async_get_spreads_returns_decimal_per_token(active_clob_token: TokenId) -> None:
-    async def run() -> dict[str, Decimal]:
+    async def run() -> dict[TokenId, Decimal]:
         async with AsyncPublicClient() as client:
             return await client.get_spreads(token_ids=[active_clob_token])
 

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import assert_type
 
 import pytest
 
@@ -27,7 +28,7 @@ from polymarket._internal.actions.clob import (
     parse_spreads,
 )
 from polymarket.errors import UnexpectedResponseError, UserInputError
-from polymarket.models import PriceRequest
+from polymarket.models import OrderSide, PriceRequest, TokenId
 
 
 def test_build_midpoint_request_targets_midpoint_path_with_token_id() -> None:
@@ -114,9 +115,12 @@ def test_build_last_trade_prices_request_rejects_bare_string() -> None:
 
 
 def test_parse_midpoints_returns_decimal_keyed_by_token_id() -> None:
-    assert parse_midpoints({"1": "0.5", "2": "0.4"}) == {
-        "1": Decimal("0.5"),
-        "2": Decimal("0.4"),
+    result = parse_midpoints({"1": "0.5", "2": "0.4"})
+
+    assert_type(result, dict[TokenId, Decimal])
+    assert result == {
+        TokenId("1"): Decimal("0.5"),
+        TokenId("2"): Decimal("0.4"),
     }
 
 
@@ -225,7 +229,8 @@ def test_build_prices_request_rejects_dict_entry() -> None:
 def test_parse_prices_returns_nested_decimal_dict() -> None:
     result = parse_prices({"1": {"BUY": "0.52", "SELL": "0.53"}})
 
-    assert result == {"1": {"BUY": Decimal("0.52"), "SELL": Decimal("0.53")}}
+    assert_type(result, dict[TokenId, dict[OrderSide, Decimal]])
+    assert result == {TokenId("1"): {"BUY": Decimal("0.52"), "SELL": Decimal("0.53")}}
 
 
 def test_parse_prices_rejects_invalid_side_key() -> None:
@@ -401,7 +406,10 @@ def test_build_spreads_request_emits_post_body() -> None:
 
 
 def test_parse_spreads_returns_decimal_keyed_by_token_id() -> None:
-    assert parse_spreads({"1": "0.02"}) == {"1": Decimal("0.02")}
+    result = parse_spreads({"1": "0.02"})
+
+    assert_type(result, dict[TokenId, Decimal])
+    assert result == {TokenId("1"): Decimal("0.02")}
 
 
 def test_build_last_trade_price_request_targets_last_trade_price_path() -> None:

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -19,6 +19,7 @@ from polymarket import (
     OrderSide,
     PriceHistoryPoint,
     PriceRequest,
+    TokenId,
 )
 from polymarket._internal.context import AsyncSecureClientContext
 from polymarket.clients._transport import AsyncTransport
@@ -103,7 +104,7 @@ def test_async_get_midpoint_propagates_malformed_response_error() -> None:
 def test_async_get_midpoints_posts_token_ids_to_clob() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> dict[str, Decimal]:
+    async def run() -> dict[TokenId, Decimal]:
         async with AsyncPublicClient() as client:
             _install_async_clob(client, _clob_handler(captured, {"1": "0.5", "2": "0.4"}))
             return await client.get_midpoints(token_ids=["1", "2"])
@@ -135,7 +136,7 @@ def test_async_get_price_includes_token_id_and_side() -> None:
 def test_async_get_prices_posts_token_id_and_side() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> dict[str, dict[OrderSide, Decimal]]:
+    async def run() -> dict[TokenId, dict[OrderSide, Decimal]]:
         async with AsyncPublicClient() as client:
             _install_async_clob(
                 client,
@@ -216,7 +217,7 @@ def test_async_get_spread_returns_decimal() -> None:
 def test_async_get_spreads_posts_token_ids() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> dict[str, Decimal]:
+    async def run() -> dict[TokenId, Decimal]:
         async with AsyncPublicClient() as client:
             _install_async_clob(client, _clob_handler(captured, {"1": "0.02"}))
             return await client.get_spreads(token_ids=["1"])

--- a/tests/unit/test_clob_transport_sync.py
+++ b/tests/unit/test_clob_transport_sync.py
@@ -17,6 +17,7 @@ from polymarket import (
     PriceRequest,
     PublicClient,
     SecureClient,
+    TokenId,
 )
 from polymarket._internal.context import SyncSecureClientContext
 from polymarket.clients._transport import SyncTransport
@@ -142,7 +143,7 @@ class TestGetPrices:
                 ]
             )
 
-        assert result["tok-1"]["BUY"] == Decimal("0.50")
+        assert result[TokenId("tok-1")]["BUY"] == Decimal("0.50")
         assert urlparse(str(captured[0].url)).path == "/prices"
         assert captured[0].method == "POST"
 

--- a/tests/unit/test_clob_typing.py
+++ b/tests/unit/test_clob_typing.py
@@ -1,0 +1,61 @@
+"""Static CLOB typing examples checked by pyright."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from types import CoroutineType
+from typing import Any, assert_type
+
+from polymarket import AsyncPublicClient, AsyncSecureClient, PublicClient, SecureClient
+from polymarket.models import OrderSide, PriceRequest, TokenId
+
+
+def _check_public_client_batch_price_typing(client: PublicClient) -> None:
+    assert_type(client.get_midpoints(token_ids=["1"]), dict[TokenId, Decimal])
+    assert_type(
+        client.get_prices(requests=[PriceRequest("1", "BUY")]),
+        dict[TokenId, dict[OrderSide, Decimal]],
+    )
+    assert_type(client.get_spreads(token_ids=["1"]), dict[TokenId, Decimal])
+
+
+def _check_secure_client_batch_price_typing(client: SecureClient) -> None:
+    assert_type(client.get_midpoints(token_ids=["1"]), dict[TokenId, Decimal])
+    assert_type(
+        client.get_prices(requests=[PriceRequest("1", "BUY")]),
+        dict[TokenId, dict[OrderSide, Decimal]],
+    )
+    assert_type(client.get_spreads(token_ids=["1"]), dict[TokenId, Decimal])
+
+
+async def _check_async_public_client_batch_price_typing(client: AsyncPublicClient) -> None:
+    assert_type(await client.get_midpoints(token_ids=["1"]), dict[TokenId, Decimal])
+    assert_type(
+        await client.get_prices(requests=[PriceRequest("1", "BUY")]),
+        dict[TokenId, dict[OrderSide, Decimal]],
+    )
+    assert_type(await client.get_spreads(token_ids=["1"]), dict[TokenId, Decimal])
+
+
+async def _check_async_secure_client_batch_price_typing(client: AsyncSecureClient) -> None:
+    assert_type(await client.get_midpoints(token_ids=["1"]), dict[TokenId, Decimal])
+    assert_type(
+        await client.get_prices(requests=[PriceRequest("1", "BUY")]),
+        dict[TokenId, dict[OrderSide, Decimal]],
+    )
+    assert_type(await client.get_spreads(token_ids=["1"]), dict[TokenId, Decimal])
+
+
+_public_client_typing_check: Callable[[PublicClient], None] = (
+    _check_public_client_batch_price_typing
+)
+_secure_client_typing_check: Callable[[SecureClient], None] = (
+    _check_secure_client_batch_price_typing
+)
+_async_public_client_typing_check: Callable[[AsyncPublicClient], CoroutineType[Any, Any, None]] = (
+    _check_async_public_client_batch_price_typing
+)
+_async_secure_client_typing_check: Callable[[AsyncSecureClient], CoroutineType[Any, Any, None]] = (
+    _check_async_secure_client_batch_price_typing
+)


### PR DESCRIPTION
Fixes DEV-419.

CLOB batch price reads now return `TokenId`-keyed maps instead of plain `str` keys, matching the token-keyed return typing added to the TypeScript SDK in #203 (DEV-417):

- `get_midpoints(...) -> dict[TokenId, Decimal]`
- `get_prices(...) -> dict[TokenId, dict[OrderSide, Decimal]]`
- `get_spreads(...) -> dict[TokenId, Decimal]`

Changes:
- Internal batch response adapters and `parse_midpoints` / `parse_prices` / `parse_spreads` now validate and type keys as `TokenId`.
- Return annotations updated across sync/async public and secure clients.
- Request inputs stay developer-friendly (`str` / `Sequence[str]`); runtime response shapes and `Decimal` value parsing are unchanged.
- `get_prices` keeps `dict[OrderSide, Decimal]` for the nested map since missing sides are represented by absent keys.
- Added `assert_type` coverage for the parsers and a static typing test for all four client surfaces; updated affected unit/integration test annotations.

Verification:
- `uv run ruff format --check .`
- `uv run ruff check`
- `uv run pyright` (strict, 0 errors)
- `uv run pytest tests/unit` (1834 passed)

https://linear.app/polymarket/issue/DEV-419/strengthen-python-clob-batch-price-return-keys-with-tokenid

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing and validation-layer changes on read-only CLOB batch endpoints; no auth, trading, or request-shape changes. Callers using plain `str` keys may need minor annotation or key-wrapper updates.
> 
> **Overview**
> Batch CLOB read helpers and all four client surfaces now type batch price results with **`TokenId`** map keys instead of plain **`str`**, aligned with the TypeScript SDK (DEV-417 / DEV-419).
> 
> **`get_midpoints`**, **`get_spreads`**, and **`get_prices`** return types are now `dict[TokenId, Decimal]` and `dict[TokenId, dict[OrderSide, Decimal]]` on public/secure sync and async clients. Internal **`parse_midpoints` / `parse_prices` / `parse_spreads`** and their Pydantic **`TypeAdapter`** dict key types were updated to match; request inputs remain **`str`** / **`Sequence[str]`**. **`Decimal`** parsing and HTTP behavior are unchanged.
> 
> Tests add **`assert_type`** on parsers, a pyright **`test_clob_typing`** module for client return types, and updated expectations where keys are expressed as **`TokenId`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e3bafab96029cbc5a7d0de9935a6b1412f84a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->