### PR TITLE
fix(streams): support batched Perps trade frames

### DIFF
--- a/src/polymarket/_internal/streams/perps/market_protocol.py
+++ b/src/polymarket/_internal/streams/perps/market_protocol.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from polymarket.models.perps.events import (
     PerpsMarketEvent,
+    PerpsTradeEvent,
     parse_perps_market_events,
 )
 from polymarket.streams._specs import (
@@ -76,6 +77,13 @@ def diff_channels(before: PerpsServerState, after: PerpsServerState) -> tuple[li
 
 
 def match_for(spec: PerpsSpec) -> Callable[[PerpsMarketEvent], bool]:
+    if isinstance(spec, PerpsTradesSpec):
+        channel = channel_for(spec)
+
+        def matches_trades(event: PerpsMarketEvent) -> bool:
+            return event.topic == "perps.trades" and event.channel == channel
+
+        return matches_trades
     if isinstance(spec, PerpsCandlesSpec):
         instrument_id = spec.instrument_id
         interval = spec.interval
@@ -93,8 +101,10 @@ def match_for(spec: PerpsSpec) -> Callable[[PerpsMarketEvent], bool]:
         optional_id = spec.instrument_id
 
         def matches_optional(event: PerpsMarketEvent) -> bool:
-            return event.topic == topic and (
-                optional_id is None or event.payload.instrument_id == optional_id
+            return (
+                not isinstance(event, PerpsTradeEvent)
+                and event.topic == topic
+                and (optional_id is None or event.payload.instrument_id == optional_id)
             )
 
         return matches_optional
@@ -102,7 +112,11 @@ def match_for(spec: PerpsSpec) -> Callable[[PerpsMarketEvent], bool]:
     instrument_id = spec.instrument_id
 
     def matches(event: PerpsMarketEvent) -> bool:
-        return event.topic == topic and event.payload.instrument_id == instrument_id
+        return (
+            not isinstance(event, PerpsTradeEvent)
+            and event.topic == topic
+            and event.payload.instrument_id == instrument_id
+        )
 
     return matches
 

--- a/src/polymarket/models/perps/events.py
+++ b/src/polymarket/models/perps/events.py
@@ -40,14 +40,14 @@ _SESSION_CHANNEL_TYPES: dict[str, str] = {
 
 
 class PerpsTradeEvent(BaseModel):
-    """A public trade printed on a subscribed instrument."""
+    """Public trades printed in one update for a subscribed instrument."""
 
     topic: Literal["perps.trades"] = "perps.trades"
     type: Literal["trade"]
     channel: str
     timestamp: PerpsTimestamp
     sequence: int
-    payload: PerpsTrade
+    payload: list[PerpsTrade]
 
 
 class PerpsBboEvent(BaseModel):

--- a/tests/unit/test_perps_market_stream.py
+++ b/tests/unit/test_perps_market_stream.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
+import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
@@ -50,20 +51,59 @@ def _book_frame(instrument_id: int) -> dict[str, Any]:
     }
 
 
-def _trade_frame(instrument_id: int) -> dict[str, Any]:
+def _trade_frame(instrument_id: int, *, sequence: int = 2) -> dict[str, Any]:
     return {
         "ch": f"trades::{instrument_id}",
         "ts": 1751500000000,
-        "sq": 2,
-        "data": {
-            "tid": 9,
-            "iid": instrument_id,
-            "side": "long",
-            "p": "0.5",
-            "qty": "1",
-            "ts": 1751500000000,
-        },
+        "sq": sequence,
+        "data": [
+            {
+                "tid": 9,
+                "iid": instrument_id,
+                "side": "long",
+                "p": "0.5",
+                "qty": "1",
+                "ts": 1751500000000,
+            },
+            {
+                "tid": 10,
+                "iid": instrument_id,
+                "side": "short",
+                "p": "0.6",
+                "qty": "2",
+                "ts": 1751500000001,
+            },
+        ],
     }
+
+
+def test_batched_trade_frame_yields_one_event_and_routes_by_channel() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        async for raw in ws:
+            if _is_ping(raw):
+                continue
+            frame = json.loads(raw)
+            if frame["req"] == "sub":
+                await ws.send(json.dumps(_trade_frame(8)))
+                await ws.send(json.dumps(_trade_frame(7)))
+
+    async def run() -> None:
+        async with ws_server(handler) as url:
+            manager = PerpsMarketStreamManager(url=url)
+            try:
+                handle = await manager.subscribe(PerpsTradesSpec(instrument_id=7))
+                async with handle:
+                    event = await asyncio.wait_for(handle.__anext__(), timeout=5.0)
+                    assert isinstance(event, PerpsTradeEvent)
+                    assert event.channel == "trades::7"
+                    assert event.sequence == 2
+                    assert [trade.trade_id for trade in event.payload] == [9, 10]
+                    with pytest.raises(TimeoutError):
+                        await asyncio.wait_for(handle.__anext__(), timeout=0.1)
+            finally:
+                await manager.close()
+
+    asyncio.run(asyncio.wait_for(run(), timeout=15.0))
 
 
 def test_derive_state_collapses_all_subscriptions() -> None:


### PR DESCRIPTION
## Summary

- model `trades::<instrumentId>` frame data as a list of Perps trades
- preserve one SDK event per server frame
- route trade subscriptions by channel

## Verification

- `uv run pytest tests/unit/test_perps_market_stream.py` (6 passed)
- combined stack: `make check` (Ruff, format, Pyright, 1,836 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public shape of `PerpsTradeEvent.payload` (breaking for code that assumed one trade per event) and alters stream routing for trade vs other market subscriptions.
> 
> **Overview**
> Aligns Perps public trade WebSocket frames with the server sending **multiple trades per frame** while still emitting **one SDK event per frame**.
> 
> `PerpsTradeEvent.payload` is now a **`list[PerpsTrade]`** instead of a single trade. Stream routing adds an explicit **`PerpsTradesSpec`** matcher on `perps.trades` plus the subscribed `trades::<instrumentId>` channel, and other market matchers ignore `PerpsTradeEvent` so batched trades are not mis-routed via `payload.instrument_id`. Tests cover batched `data` arrays and channel filtering when multiple instruments publish trades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f088ffb1812a974fb641f50bc7ed08b3eb0c30ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->