### PR TITLE
feat(clob): add condition_id alias to CLOB models, deprecate market

### DIFF
--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -10,7 +10,7 @@ from polymarket.models.clob._validators import (
     RequiredEpochOrIsoTimestamp,
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
-from polymarket.models.types import OrderSide, TokenId
+from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
 AssetType: TypeAlias = Literal["COLLATERAL", "CONDITIONAL"]
 
@@ -20,6 +20,8 @@ class OpenOrder(BaseModel):
 
     id: str
     market: str
+    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
+    condition_id: CtfConditionId = Field(validation_alias="market")
     token_id: TokenId = Field(validation_alias="asset_id")
     owner: str
     maker_address: str = Field(validation_alias="maker_address")
@@ -76,6 +78,8 @@ class ClobTrade(BaseModel):
 
     id: str
     market: str
+    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
+    condition_id: CtfConditionId = Field(validation_alias="market")
     token_id: TokenId = Field(validation_alias="asset_id")
     owner: str
     maker_address: str = Field(validation_alias="maker_address")

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -19,9 +19,13 @@ class OpenOrder(BaseModel):
     """Open order owned by an account."""
 
     id: str
-    market: str
-    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
-    condition_id: CtfConditionId = Field(validation_alias="market")
+    market: CtfConditionId = Field(
+        description="Deprecated: use condition_id. Retained for backward compatibility."
+    )
+    condition_id: CtfConditionId = Field(
+        validation_alias="market",
+        description="CTF condition id for the market associated with this order.",
+    )
     token_id: TokenId = Field(validation_alias="asset_id")
     owner: str
     maker_address: str = Field(validation_alias="maker_address")
@@ -77,9 +81,13 @@ class ClobTrade(BaseModel):
     """Executed trade for an account or market."""
 
     id: str
-    market: str
-    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
-    condition_id: CtfConditionId = Field(validation_alias="market")
+    market: CtfConditionId = Field(
+        description="Deprecated: use condition_id. Retained for backward compatibility."
+    )
+    condition_id: CtfConditionId = Field(
+        validation_alias="market",
+        description="CTF condition id for the market associated with this trade.",
+    )
     token_id: TokenId = Field(validation_alias="asset_id")
     owner: str
     maker_address: str = Field(validation_alias="maker_address")

--- a/src/polymarket/models/clob/builder.py
+++ b/src/polymarket/models/clob/builder.py
@@ -11,7 +11,7 @@ from polymarket.models.clob._validators import (
     RequiredEpochOrIsoTimestamp,
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
-from polymarket.models.types import OrderSide, TokenId
+from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
 _BUILDER_FEES_BPS = Decimal(10_000)
 
@@ -45,6 +45,8 @@ class BuilderTrade(BaseModel):
     taker_order_hash: str = Field(validation_alias="takerOrderHash")
     builder: str
     market: str
+    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
+    condition_id: CtfConditionId = Field(validation_alias="market")
     token_id: TokenId = Field(validation_alias="assetId")
     side: OrderSide
     size: _DecimalFromString

--- a/src/polymarket/models/clob/builder.py
+++ b/src/polymarket/models/clob/builder.py
@@ -44,9 +44,13 @@ class BuilderTrade(BaseModel):
     trade_type: str = Field(validation_alias="tradeType")
     taker_order_hash: str = Field(validation_alias="takerOrderHash")
     builder: str
-    market: str
-    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
-    condition_id: CtfConditionId = Field(validation_alias="market")
+    market: CtfConditionId = Field(
+        description="Deprecated: use condition_id. Retained for backward compatibility."
+    )
+    condition_id: CtfConditionId = Field(
+        validation_alias="market",
+        description="CTF condition id for the market associated with this trade.",
+    )
     token_id: TokenId = Field(validation_alias="assetId")
     side: OrderSide
     size: _DecimalFromString

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -11,7 +11,7 @@ from polymarket.models.clob._validators import (
     EpochMsTimestamp,
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
-from polymarket.models.types import TokenId
+from polymarket.models.types import CtfConditionId, TokenId
 
 _DecimalMode = Literal["decimal", "float"]
 
@@ -23,6 +23,8 @@ class OrderBookLevel(BaseModel):
 
 class OrderBook(BaseModel):
     market: str
+    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
+    condition_id: CtfConditionId = Field(validation_alias="market")
     token_id: TokenId = Field(validation_alias="asset_id")
     timestamp: EpochMsTimestamp = None
     bids: tuple[OrderBookLevel, ...]

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -22,9 +22,13 @@ class OrderBookLevel(BaseModel):
 
 
 class OrderBook(BaseModel):
-    market: str
-    """Deprecated: use ``condition_id``. Retained for back-compat; holds the CTF condition id."""
-    condition_id: CtfConditionId = Field(validation_alias="market")
+    market: CtfConditionId = Field(
+        description="Deprecated: use condition_id. Retained for backward compatibility."
+    )
+    condition_id: CtfConditionId = Field(
+        validation_alias="market",
+        description="CTF condition id for the market represented by this order book.",
+    )
     token_id: TokenId = Field(validation_alias="asset_id")
     timestamp: EpochMsTimestamp = None
     bids: tuple[OrderBookLevel, ...]


### PR DESCRIPTION
The CLOB order book, open order, trade, and builder trade models expose a `market` field that holds a CTF condition id. This adds a same-valued `condition_id` (a blind `Field(validation_alias="market")`, no validator) on each and flags `market` deprecated in its docstring, aligning the field name with the rest of the SDK.

Additive and non-breaking: both fields are emitted with the same value. Verified: `ruff`, `pyright` (strict), full unit suite, and round-trips confirming `market == condition_id` on all four models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Pydantic field aliases and type tightening on response models only; no API or runtime behavior changes beyond clearer field names.
> 
> **Overview**
> CLOB models that used a plain `market` string for the CTF condition id now expose a **`condition_id`** field and type **`market`** as `CtfConditionId`, matching naming elsewhere in the SDK.
> 
> **`OpenOrder`**, **`ClobTrade`**, **`BuilderTrade`**, and **`OrderBook`** each add `condition_id` populated from the API’s `market` key via `validation_alias="market"`, while **`market`** stays on the model with a deprecation note. Parsing and serialization stay backward compatible: both attributes carry the same value after validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cef6795dbb5960b61406c0529fe361a78f6de47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->