### PR TITLE
fix(relayer): stop approving retired neg-risk adapter in trading setup

### DIFF
--- a/src/polymarket/_internal/actions/relayer/approvals.py
+++ b/src/polymarket/_internal/actions/relayer/approvals.py
@@ -152,11 +152,6 @@ def _required_trading_approvals(
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.neg_risk_adapter),
-                amount=MAX_UINT256,
-            ),
-            _Erc20TradingApproval(
-                token_address=collateral,
                 spender=cast(EvmAddress, environment.collateral_adapter),
                 amount=MAX_UINT256,
             ),
@@ -189,10 +184,6 @@ def _required_trading_approvals(
             _Erc1155TradingApproval(
                 token_address=conditional,
                 operator=cast(EvmAddress, environment.neg_risk_exchange),
-            ),
-            _Erc1155TradingApproval(
-                token_address=conditional,
-                operator=cast(EvmAddress, environment.neg_risk_adapter),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,

--- a/tests/unit/test_eoa_broadcast.py
+++ b/tests/unit/test_eoa_broadcast.py
@@ -138,7 +138,7 @@ def test_eoa_transfer_erc20_dispatches_to_rpc() -> None:
 def test_eoa_setup_trading_approvals_submits_and_waits_for_required_calls_sequentially() -> None:
     send_hashes = ["0x" + f"{i:02x}" * 32 for i in range(1, 18)]
     send_iter = iter(send_hashes)
-    receipts: list[dict[str, object] | None] = [{"status": "0x1"} for _ in range(17)]
+    receipts: list[dict[str, object] | None] = [{"status": "0x1"} for _ in range(15)]
     receipt_iter = iter(receipts)
     calls: list[object] = []
 
@@ -205,8 +205,8 @@ def test_eoa_setup_trading_approvals_submits_and_waits_for_required_calls_sequen
     handle = asyncio.run(run())
     assert isinstance(handle, DeprecatedTransactionHandle)
     assert handle.transaction_hash is None
-    assert _rpc_method_count(calls, "eth_sendRawTransaction") == 17
-    assert _rpc_method_count(calls, "eth_getTransactionReceipt") >= 17
+    assert _rpc_method_count(calls, "eth_sendRawTransaction") == 15
+    assert _rpc_method_count(calls, "eth_getTransactionReceipt") >= 15
 
 
 def _rpc_method_count(calls: list[object], method: str) -> int:

--- a/tests/unit/test_relayer_setup_trading_approvals.py
+++ b/tests/unit/test_relayer_setup_trading_approvals.py
@@ -57,18 +57,16 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
     body = request_json(submit_calls[0])
     assert body["type"] == "WALLET"
     inner = body["depositWalletParams"]["calls"]
-    assert len(inner) == 17
+    assert len(inner) == 15
 
     erc20_sel = _selector("approve(address,uint256)")
     erc1155_sel = _selector("setApprovalForAll(address,bool)")
-    # ERC20 approvals: standard_exchange, neg_risk_exchange, neg_risk_adapter,
-    # collateral_adapter, neg_risk_collateral_adapter, protocol_v2_router, exchange_v3,
-    # perps_deposit_contract
+    # ERC20 approvals: standard_exchange, neg_risk_exchange, collateral_adapter,
+    # neg_risk_collateral_adapter, protocol_v2_router, exchange_v3, perps_deposit_contract
     for index, spender in enumerate(
         [
             PRODUCTION.standard_exchange,
             PRODUCTION.neg_risk_exchange,
-            PRODUCTION.neg_risk_adapter,
             PRODUCTION.collateral_adapter,
             PRODUCTION.neg_risk_collateral_adapter,
             PRODUCTION.protocol_v2_router,
@@ -80,18 +78,17 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
         assert inner[index]["data"].startswith(erc20_sel)
         assert spender[2:].lower() in inner[index]["data"].lower()
     # ERC1155 conditional-token approvals: standard_exchange, neg_risk_exchange,
-    # neg_risk_adapter, collateral_adapter, neg_risk_collateral_adapter, auto_redeem_operator
+    # collateral_adapter, neg_risk_collateral_adapter, auto_redeem_operator
     for offset, operator in enumerate(
         [
             PRODUCTION.standard_exchange,
             PRODUCTION.neg_risk_exchange,
-            PRODUCTION.neg_risk_adapter,
             PRODUCTION.collateral_adapter,
             PRODUCTION.neg_risk_collateral_adapter,
             PRODUCTION.auto_redeem_operator,
         ]
     ):
-        index = 8 + offset
+        index = 7 + offset
         assert inner[index]["target"].lower() == PRODUCTION.conditional_tokens.lower()
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()
@@ -104,7 +101,7 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
             PRODUCTION.auto_redeem_operator,
         ]
     ):
-        index = 14 + offset
+        index = 12 + offset
         assert inner[index]["target"].lower() == PRODUCTION.position_manager.lower()
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -191,7 +191,7 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner_calls = body["depositWalletParams"]["calls"]
-    assert len(inner_calls) == 17
+    assert len(inner_calls) == 15
 
 
 def test_setup_trading_approvals_skips_submit_when_already_approved() -> None:


### PR DESCRIPTION
Fixes #178

`setup_trading_approvals` (sync and async) still granted a MAX collateral allowance and ERC-1155 approval-for-all to the CLOB v1 Neg Risk Adapter (`0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`), which was fully retired on July 17, 2026 at 00:00 UTC (see https://docs.polymarket.com/resources/contracts).

Changes:
- Remove the two approvals to `environment.neg_risk_adapter` from the required trading approvals (15 calls instead of 17).
- The environment field itself is retained; position lifecycle reads that reference the legacy adapter are unchanged.
- Update approval-count and ordering assertions in the relayer, sync relayer, and EOA broadcast unit tests.

Verification:
- `uv run pytest tests/unit` (1836 passed)
- `uv run pyright` (0 errors)
- `uv run ruff check .` and `uv run ruff format --check .` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows token approvals to active contracts only; no auth or data-model changes, with test coverage for the new 15-call bundle.
> 
> **Overview**
> **`setup_trading_approvals`** no longer grants collateral `approve` or conditional-token `setApprovalForAll` to **`environment.neg_risk_adapter`** (retired CLOB v1 Neg Risk Adapter). Required approval bundles drop from **17 to 15** on-chain calls for relayer deposit wallets, sync relayer, and EOA sequential broadcast paths.
> 
> The **`neg_risk_adapter`** field stays on **`Environment`**; position lifecycle code that still references it for neg-risk ERC-1155 addressing is unchanged. Unit tests were updated for the new call count and approval ordering/indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5577721f339b2e5f9e6777a5e23b976e183e1407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->