### PR TITLE
feat(models): add isolated_only to perps instrument

### DIFF
--- a/src/polymarket/models/perps/market.py
+++ b/src/polymarket/models/perps/market.py
@@ -45,6 +45,7 @@ class PerpsInstrument(BaseModel):
     max_market_notional: _Decimal
     max_limit_notional: _Decimal
     max_leverage: int
+    isolated_only: bool
     risk_tiers: tuple[PerpsRiskTier, ...]
 
 


### PR DESCRIPTION
Adds the new required `isolated_only` boolean from the perps `Instrument` schema to the `PerpsInstrument` model.

Part of [DEV-431](https://linear.app/polymarket/issue/DEV-431/add-isolated-only-field-to-perps-instrument-in-sdks-and-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field model update with no auth or trading-path changes; consumers must supply `isolated_only` when constructing instruments manually or tests may need fixture updates.
> 
> **Overview**
> Adds a required **`isolated_only`** boolean on **`PerpsInstrument`** so instrument payloads from the perps API deserialize correctly and callers can tell whether an instrument only supports isolated margin.
> 
> This is a schema-alignment change in `PerpsInstrument` only; no client or trading logic is updated in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c21e17733dff483729367c44fa194af00e8799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->