### PR TITLE
fix(errors): expose retry_after on RequestRejectedError

### DIFF
--- a/src/polymarket/clients/_transport.py
+++ b/src/polymarket/clients/_transport.py
@@ -318,7 +318,29 @@ def _raise_for_response_status(response: httpx.Response) -> None:
     raise RequestRejectedError(
         _extract_response_error_message(response),
         status=response.status_code,
+        retry_after=_extract_retry_after(response),
     )
+
+
+def _extract_retry_after(response: httpx.Response) -> float | None:
+    header = response.headers.get("retry-after")
+    if header is not None:
+        try:
+            seconds = float(header.strip())
+        except ValueError:
+            seconds = None
+        if seconds is not None and seconds >= 0:
+            return seconds
+
+    if "application/json" in response.headers.get("content-type", "").lower():
+        try:
+            value = response.json().get("retry_after_seconds")
+        except (AttributeError, ValueError):
+            value = None
+        if isinstance(value, int | float) and not isinstance(value, bool) and value >= 0:
+            return float(value)
+
+    return None
 
 
 def _clean_params(

--- a/src/polymarket/clients/_transport.py
+++ b/src/polymarket/clients/_transport.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
@@ -329,7 +330,7 @@ def _extract_retry_after(response: httpx.Response) -> float | None:
             seconds = float(header.strip())
         except ValueError:
             seconds = None
-        if seconds is not None and seconds >= 0:
+        if seconds is not None and math.isfinite(seconds) and seconds >= 0:
             return seconds
 
     if "application/json" in response.headers.get("content-type", "").lower():
@@ -337,8 +338,13 @@ def _extract_retry_after(response: httpx.Response) -> float | None:
             value = response.json().get("retry_after_seconds")
         except (AttributeError, ValueError):
             value = None
-        if isinstance(value, int | float) and not isinstance(value, bool) and value >= 0:
-            return float(value)
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            try:
+                seconds = float(value)
+            except OverflowError:
+                seconds = None
+            if seconds is not None and math.isfinite(seconds) and seconds >= 0:
+                return seconds
 
     return None
 

--- a/src/polymarket/errors.py
+++ b/src/polymarket/errors.py
@@ -32,11 +32,17 @@ class ConnectionLostError(PolymarketError):
 
 
 class RequestRejectedError(PolymarketError):
-    """Error raised when a request receives a non-success status."""
+    """Error raised when a request receives a non-success status.
 
-    def __init__(self, message: str, *, status: int) -> None:
+    ``retry_after`` is the server-suggested delay in seconds before retrying,
+    taken from the ``Retry-After`` response header or a ``retry_after_seconds``
+    field in the response body; ``None`` when the response provides neither.
+    """
+
+    def __init__(self, message: str, *, status: int, retry_after: float | None = None) -> None:
         super().__init__(message)
         self.status = status
+        self.retry_after = retry_after
 
 
 class RateLimitError(PolymarketError):

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -60,6 +60,73 @@ def test_sync_transport_maps_rejected_json_error_response() -> None:
         transport.get_json("/markets/1")
 
     assert exc_info.value.status == 400
+    assert exc_info.value.retry_after is None
+
+
+def test_sync_transport_exposes_retry_after_header_on_rejection() -> None:
+    transport = SyncTransport(
+        base_url="https://example.test",
+        client=httpx.Client(
+            base_url="https://example.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    503,
+                    json={"error": "matching engine restarting"},
+                    headers={"Retry-After": "30"},
+                    request=request,
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(RequestRejectedError, match="matching engine restarting") as exc_info:
+        transport.post_json("/order", json={})
+
+    assert exc_info.value.status == 503
+    assert exc_info.value.retry_after == 30.0
+
+
+def test_sync_transport_exposes_retry_after_seconds_from_body() -> None:
+    transport = SyncTransport(
+        base_url="https://example.test",
+        client=httpx.Client(
+            base_url="https://example.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    503,
+                    json={"error": "unavailable", "retry_after_seconds": 2.5},
+                    request=request,
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(RequestRejectedError) as exc_info:
+        transport.get_json("/markets/1")
+
+    assert exc_info.value.retry_after == 2.5
+
+
+def test_sync_transport_ignores_unparseable_retry_after_header() -> None:
+    transport = SyncTransport(
+        base_url="https://example.test",
+        client=httpx.Client(
+            base_url="https://example.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    503,
+                    json={"error": "unavailable"},
+                    headers={"Retry-After": "Sun, 20 Jul 2026 12:00:00 GMT"},
+                    request=request,
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(RequestRejectedError) as exc_info:
+        transport.get_json("/markets/1")
+
+    assert exc_info.value.retry_after is None
 
 
 def test_sync_transport_maps_non_json_success_response() -> None:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -129,6 +129,59 @@ def test_sync_transport_ignores_unparseable_retry_after_header() -> None:
     assert exc_info.value.retry_after is None
 
 
+@pytest.mark.parametrize("header_value", ["1e400", "inf", "nan"])
+def test_sync_transport_ignores_non_finite_retry_after_header(header_value: str) -> None:
+    transport = SyncTransport(
+        base_url="https://example.test",
+        client=httpx.Client(
+            base_url="https://example.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    503,
+                    json={"error": "unavailable"},
+                    headers={"Retry-After": header_value},
+                    request=request,
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(RequestRejectedError) as exc_info:
+        transport.get_json("/markets/1")
+
+    assert exc_info.value.retry_after is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b'{"error": "unavailable", "retry_after_seconds": Infinity}',
+        b'{"error": "unavailable", "retry_after_seconds": 1e400}',
+        b'{"error": "unavailable", "retry_after_seconds": ' + b"9" * 400 + b"}",
+    ],
+)
+def test_sync_transport_ignores_out_of_range_retry_after_seconds_in_body(body: bytes) -> None:
+    transport = SyncTransport(
+        base_url="https://example.test",
+        client=httpx.Client(
+            base_url="https://example.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    503,
+                    content=body,
+                    headers={"Content-Type": "application/json"},
+                    request=request,
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(RequestRejectedError) as exc_info:
+        transport.get_json("/markets/1")
+
+    assert exc_info.value.retry_after is None
+
+
 def test_sync_transport_maps_non_json_success_response() -> None:
     transport = SyncTransport(
         base_url="https://example.test",


### PR DESCRIPTION
Fixes #182 (DEV-439).

`RequestRejectedError` now carries a `retry_after: float | None` attribute, populated from the `Retry-After` response header (delta-seconds) or, when the header is absent, a `retry_after_seconds` field in a JSON error body. This lets callers honor the server-suggested delay on 503s during matching-engine restarts instead of using a blind backoff.

Unparseable or negative values are ignored and `retry_after` stays `None`, so existing behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on error handling with safe defaults; no change to 429 mapping or successful request paths.
> 
> **Overview**
> **`RequestRejectedError` now includes an optional `retry_after` (seconds)** so callers can wait before retrying on transient failures such as matching-engine 503s.
> 
> The HTTP transport populates it via new **`_extract_retry_after`**: it prefers a numeric **`Retry-After`** header, otherwise **`retry_after_seconds`** in a JSON error body. HTTP-date headers, non-finite values, negatives, and malformed body numbers are ignored and **`retry_after` stays `None`**, preserving prior behavior when the server gives no usable hint. **`RateLimitError` (429) is unchanged.**
> 
> Unit tests cover header/body success paths and several rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891a413881d738bde586320ada2493649270432f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->