### PR TITLE
feat(models): type cancellation result order IDs with OrderId

### DIFF
--- a/src/polymarket/models/clob/cancel.py
+++ b/src/polymarket/models/clob/cancel.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from pydantic import Field
 
 from polymarket.models.base import BaseModel
+from polymarket.models.types import OrderId
 
 
 class CancelOrdersResponse(BaseModel):
-    canceled: tuple[str, ...]
-    not_canceled: dict[str, str] = Field(default_factory=dict, validation_alias="not_canceled")
+    canceled: tuple[OrderId, ...]
+    not_canceled: dict[OrderId, str] = Field(
+        default_factory=dict[OrderId, str], validation_alias="not_canceled"
+    )
 
 
 __all__ = ["CancelOrdersResponse"]

--- a/tests/unit/test_order_cancel.py
+++ b/tests/unit/test_order_cancel.py
@@ -72,6 +72,12 @@ def test_parse_cancel_orders_response_returns_model() -> None:
     assert parsed.not_canceled == {"c": "in flight"}
 
 
+def test_parse_cancel_orders_response_accepts_empty_collections() -> None:
+    parsed = parse_cancel_orders_response({"canceled": [], "not_canceled": {}})
+    assert parsed.canceled == ()
+    assert parsed.not_canceled == {}
+
+
 def test_parse_cancel_orders_response_rejects_non_dict() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_cancel_orders_response([])


### PR DESCRIPTION
## Summary

Types CLOB cancellation result order IDs with the existing public `OrderId` (DEV-444).

- `CancelOrdersResponse.canceled` is now `tuple[OrderId, ...]` and `not_canceled` is `dict[OrderId, str]`, applied to `cancel_order`, `cancel_orders`, `cancel_market_orders`, and `cancel_all` on both sync and async clients.
- Reason values in `not_canceled` remain plain strings.
- `OrderId` is a `typing.NewType` over `str`, so runtime values and the wire shape are unchanged.

## Testing

- Added an empty-collections parse test alongside the existing canceled/not-canceled coverage in `tests/unit/test_order_cancel.py`.
- `make check` (ruff check, ruff format --check, pyright strict, pytest: 1848 passed).

Linear: [DEV-444](https://linear.app/polymarket/issue/DEV-444/type-clob-cancellation-result-order-ids-across-typescript-and-python)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only model change with no runtime or API behavior change; low blast radius.
> 
> **Overview**
> **`CancelOrdersResponse`** now types **`canceled`** as `tuple[OrderId, ...]` and **`not_canceled`** keys as **`OrderId`** (values stay `str`). This is a static typing change only—`OrderId` is a `NewType` over `str`, so wire format and runtime behavior are unchanged.
> 
> A unit test was added to confirm parsing succeeds when both **`canceled`** and **`not_canceled`** are empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8cd8317b76a3419a4d1f4dcdb32e8c16c62fc17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->