### PR TITLE
feat: prepare Python SDK for stable 0.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,8 @@
 # Contributing
 
-The Python SDK is currently in beta.
-
-During beta, we are using GitHub Issues as the primary public feedback channel. Please open an issue for bug reports, feature requests, or general feedback.
+We use GitHub Issues as the primary public feedback channel. Please open an issue for bug reports, feature requests, or general feedback.
 
 We are not broadly accepting external pull requests yet. Large changes should not be started without prior discussion and agreement with the Polymarket team.
-
-Once the SDK is stable and out of beta, we will expand these guidelines and start opening the project to external contributions.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,19 @@
 # Polymarket Python SDK
 
-![Beta](https://img.shields.io/badge/status-beta-yellow)
-
 Official Python SDK for Polymarket.
 
 The SDK gives Python developers one coherent, workflow-oriented interface for building on Polymarket across public data, authenticated account, trading, builder attribution, and wallet workflows.
 
-## Beta Status
-
-The Python SDK is currently in beta. We are working toward a stable public API and will use feedback during the beta period to refine the developer experience.
-
-We welcome bug reports, feature requests, and general feedback through GitHub Issues. Please use the provided issue templates so we can triage reports consistently.
-
 ## Installation
 
 ```bash
-uv add --prerelease allow polymarket-client
+uv add polymarket-client
 ```
 
 or:
 
 ```bash
-pip install --pre polymarket-client
+pip install polymarket-client
 ```
 
 ## Usage
@@ -99,6 +91,15 @@ handle = client.merge_multiple_positions(
 
 outcome = handle.wait()
 ```
+
+## API Compatibility
+
+The SDK follows semantic versioning. Although minor releases on the 0.x line
+may include breaking changes, we aim to avoid them and, whenever possible,
+provide a deprecation path before removing or changing an API. Patch releases
+remain backward compatible except for APIs marked experimental, which may
+change in any release. All Perps APIs are currently experimental, including
+client methods, sessions, stream subscriptions, and models.
 
 ## API Design
 
@@ -190,3 +191,8 @@ def test_order_lifecycle(require_env):
 ```bash
 POLYMARKET_RUN_METERED_TESTS=1 make test-integration
 ```
+
+## Contributing
+
+We welcome bug reports, feature requests, and feedback through GitHub Issues.
+See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing code changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ We will review reports and coordinate fixes before public disclosure.
 
 ## Supported Versions
 
-The Python SDK is currently in beta. Security fixes are focused on the latest published beta version and the current development branch.
+Security fixes are focused on the latest published version and the current development branch.
 
 ## Public Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 keywords = ["polymarket", "prediction-markets", "client", "trading", "web3"]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "package-name": "polymarket-client",
       "changelog-path": "CHANGELOG.md",
       "versioning": "prerelease",
-      "prerelease": true,
+      "prerelease": false,
       "prerelease-type": "b"
     }
   }

--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -126,7 +126,10 @@ class _EventWaiter:
 
 
 class PerpsSession:
-    """An authenticated Perps account session.
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    An authenticated Perps account session.
 
     The session multiplexes trading commands, private account updates, and
     account reads over one connection. Iterate over the session to receive

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1377,25 +1377,40 @@ class AsyncPublicClient:
         instrument_id: int | None = None,
         category: PerpsInstrumentCategory | None = None,
     ) -> tuple[PerpsInstrument, ...]:
-        """Fetch Perps instruments, optionally filtered by instrument or category."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch Perps instruments, optionally filtered by instrument or category.
+        """
         return await _perps_actions.fetch_instruments(
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
     async def fetch_perps_ticker(self, *, instrument_id: int) -> PerpsTicker:
-        """Fetch the current Perps ticker for an instrument."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch the current Perps ticker for an instrument.
+        """
         return await _perps_actions.fetch_ticker(self._ctx.perps, instrument_id=instrument_id)
 
     async def fetch_perps_tickers(
         self, *, instrument_id: int | None = None
     ) -> tuple[PerpsTicker, ...]:
-        """Fetch current Perps tickers."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch current Perps tickers.
+        """
         return await _perps_actions.fetch_tickers(self._ctx.perps, instrument_id=instrument_id)
 
     async def fetch_perps_book(
         self, *, instrument_id: int, depth: PerpsBookDepth = 100
     ) -> PerpsBook:
-        """Fetch a Perps order book snapshot.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch a Perps order book snapshot.
 
         ``depth`` controls the number of price levels returned on each side.
         """
@@ -1404,7 +1419,11 @@ class AsyncPublicClient:
         )
 
     async def fetch_perps_fees(self) -> tuple[PerpsFeeScheduleEntry, ...]:
-        """Fetch the Perps fee schedule."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch the Perps fee schedule.
+        """
         return await _perps_actions.fetch_fees(self._ctx.perps)
 
     def list_perps_candles(
@@ -1415,7 +1434,10 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsCandle]:
-        """List Perps candles for an instrument with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List Perps candles for an instrument with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -1438,7 +1460,10 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsFundingRate]:
-        """List Perps funding-rate history with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List Perps funding-rate history with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -1457,7 +1482,10 @@ class AsyncPublicClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsTrade]:
-        """List recent public Perps trades with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List recent public Perps trades with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -673,7 +673,10 @@ class AsyncSecureClient:
         expires_in: "timedelta | None" = None,
         label: str | None = None,
     ) -> "PerpsSession":
-        """Open an authenticated Perps account session.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Open an authenticated Perps account session.
 
         With no arguments, new delegated session credentials are created with
         a wallet signature and expire after one week. Pass ``expires_in`` for
@@ -730,7 +733,10 @@ class AsyncSecureClient:
         return session
 
     async def revoke_perps_credentials(self, *, proxy: str) -> None:
-        """Revoke delegated Perps session credentials by proxy address.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Revoke delegated Perps session credentials by proxy address.
 
         The revocation is signed by the owner account and also works for
         credentials that are not currently in use.
@@ -745,7 +751,10 @@ class AsyncSecureClient:
     async def deposit_to_perps(
         self, *, amount: int, metadata: str | None = None
     ) -> TransactionHandle:
-        """Deposit collateral into the Perps account.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Deposit collateral into the Perps account.
 
         The deposit sends approved collateral into the Perps deposit contract
         and credits the authenticated signer account. It does not approve
@@ -770,7 +779,10 @@ class AsyncSecureClient:
         return await self._dispatch_single_call(call, metadata=resolved_metadata)
 
     async def withdraw_from_perps(self, *, amount: int) -> PerpsWithdrawalId:
-        """Request a Perps withdrawal to the authenticated wallet.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Request a Perps withdrawal to the authenticated wallet.
 
         The withdrawal is signed by the owner account and sends funds to the
         wallet address associated with this client.
@@ -2995,25 +3007,40 @@ class AsyncSecureClient:
         instrument_id: int | None = None,
         category: PerpsInstrumentCategory | None = None,
     ) -> tuple[PerpsInstrument, ...]:
-        """Fetch Perps instruments, optionally filtered by instrument or category."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch Perps instruments, optionally filtered by instrument or category.
+        """
         return await _perps_actions.fetch_instruments(
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
     async def fetch_perps_ticker(self, *, instrument_id: int) -> PerpsTicker:
-        """Fetch the current Perps ticker for an instrument."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch the current Perps ticker for an instrument.
+        """
         return await _perps_actions.fetch_ticker(self._ctx.perps, instrument_id=instrument_id)
 
     async def fetch_perps_tickers(
         self, *, instrument_id: int | None = None
     ) -> tuple[PerpsTicker, ...]:
-        """Fetch current Perps tickers."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch current Perps tickers.
+        """
         return await _perps_actions.fetch_tickers(self._ctx.perps, instrument_id=instrument_id)
 
     async def fetch_perps_book(
         self, *, instrument_id: int, depth: PerpsBookDepth = 100
     ) -> PerpsBook:
-        """Fetch a Perps order book snapshot.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch a Perps order book snapshot.
 
         ``depth`` controls the number of price levels returned on each side.
         """
@@ -3022,7 +3049,11 @@ class AsyncSecureClient:
         )
 
     async def fetch_perps_fees(self) -> tuple[PerpsFeeScheduleEntry, ...]:
-        """Fetch the Perps fee schedule."""
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Fetch the Perps fee schedule.
+        """
         return await _perps_actions.fetch_fees(self._ctx.perps)
 
     def list_perps_candles(
@@ -3033,7 +3064,10 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsCandle]:
-        """List Perps candles for an instrument with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List Perps candles for an instrument with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -3056,7 +3090,10 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsFundingRate]:
-        """List Perps funding-rate history with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List Perps funding-rate history with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.
@@ -3075,7 +3112,10 @@ class AsyncSecureClient:
         start: "datetime | int | None" = None,
         end: "datetime | int | None" = None,
     ) -> AsyncPaginator[PerpsTrade]:
-        """List recent public Perps trades with SDK-owned pagination.
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        List recent public Perps trades with SDK-owned pagination.
 
         Defaults to the past 24 hours when ``start`` is omitted. ``start`` and
         ``end`` accept a ``datetime`` or an epoch-milliseconds int.

--- a/src/polymarket/models/perps/__init__.py
+++ b/src/polymarket/models/perps/__init__.py
@@ -1,4 +1,8 @@
-"""Perps SDK models."""
+"""Experimental Perps SDK models.
+
+Experimental: This API may change in a breaking way in any release, including
+patch releases.
+"""
 
 from polymarket.models.perps.account import (
     PerpsAccountConfig,

--- a/src/polymarket/perps.py
+++ b/src/polymarket/perps.py
@@ -1,4 +1,7 @@
-"""Perps trading session types.
+"""Experimental Perps trading session types.
+
+Experimental: This API may change in a breaking way in any release, including
+patch releases.
 
 Open a session with :meth:`polymarket.AsyncSecureClient.open_perps_session`.
 """

--- a/src/polymarket/streams/_specs.py
+++ b/src/polymarket/streams/_specs.py
@@ -196,7 +196,11 @@ class UserSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsTradesSpec:
-    """Subscribe to public trades for one Perps instrument."""
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to public trades for one Perps instrument.
+    """
 
     instrument_id: int
     topic: Literal["perps.trades"] = field(default="perps.trades", init=False)
@@ -207,7 +211,11 @@ class PerpsTradesSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsBboSpec:
-    """Subscribe to best bid/ask updates for one Perps instrument."""
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to best bid/ask updates for one Perps instrument.
+    """
 
     instrument_id: int
     topic: Literal["perps.bbo"] = field(default="perps.bbo", init=False)
@@ -218,7 +226,11 @@ class PerpsBboSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsBookSpec:
-    """Subscribe to order book deltas for one Perps instrument."""
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to order book deltas for one Perps instrument.
+    """
 
     instrument_id: int
     topic: Literal["perps.book"] = field(default="perps.book", init=False)
@@ -229,7 +241,11 @@ class PerpsBookSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsCandlesSpec:
-    """Subscribe to streaming candles for one Perps instrument and interval."""
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to streaming candles for one Perps instrument and interval.
+    """
 
     instrument_id: int
     interval: Literal["1m", "5m", "15m", "1h", "4h", "1d", "1w"]
@@ -245,7 +261,10 @@ class PerpsCandlesSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsTickersSpec:
-    """Subscribe to ticker updates for one Perps instrument or all instruments.
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to ticker updates for one Perps instrument or all instruments.
 
     When ``instrument_id`` is omitted, the subscription receives ticker
     updates for every instrument.
@@ -260,7 +279,10 @@ class PerpsTickersSpec:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PerpsStatisticsSpec:
-    """Subscribe to statistics updates for one Perps instrument or all instruments.
+    """Experimental: This API may change in a breaking way in any release,
+    including patch releases.
+
+    Subscribe to statistics updates for one Perps instrument or all instruments.
 
     When ``instrument_id`` is omitted, the subscription receives statistics
     updates for every instrument.


### PR DESCRIPTION
## Summary

- mark the public Perps client, session, stream, and model surfaces as experimental
- document the stable 0.x compatibility policy without displacing installation and usage in the README
- remove stale beta installation, contribution, security, and package-classifier messaging
- disable release-please prerelease output so the next release PR targets plain `0.1.0`

## Why

The SDK is ready to move from beta prereleases to a stable 0.x line. Perps remains explicitly experimental so it can evolve independently of the compatibility expectations for the rest of the SDK.

No API names or runtime behavior change in this PR.

Linear: [DEV-435](https://linear.app/polymarket/issue/DEV-435/python-sdk-transition-polymarket-client-out-of-beta-to-stable-0x-flag)

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration"` — 1,861 passed, 178 deselected
- release-please version strategy verified to transition `0.1.0-b21` to `0.1.0`
- repository-wide stale beta reference sweep passed outside changelog/history and internal agent guidance
- experimental markers verified through rendered Python docstrings

## Release flow

After this PR merges, release-please should create or update its release PR for stable `0.1.0`. Publishing remains gated on merging that separate release PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, package metadata, and release tooling only; Perps warnings are docstring-only with no runtime or public API signature changes.
> 
> **Overview**
> Prepares **polymarket-client** for a stable **0.x** line while keeping Perps explicitly outside normal compatibility guarantees.
> 
> **Stable positioning:** README drops the beta badge and section; install examples no longer use `--pre` / `--prerelease`. CONTRIBUTING and SECURITY stop describing a beta-only support window. `pyproject.toml` sets **Development Status :: 5 - Production/Stable**. `release-please-config.json` sets **`prerelease`: false** so the next release PR targets plain **0.1.0** (e.g. from `0.1.0-b21`).
> 
> **Compatibility policy:** README adds an **API Compatibility** section (semver on 0.x, patch stability, experimental APIs exempt). A short **Contributing** pointer links to CONTRIBUTING.md.
> 
> **Perps experimental:** Module and class docstrings on Perps clients (`fetch_perps_*`, `list_perps_*`, `open_perps_session`, deposits/withdrawals), `PerpsSession`, Perps stream specs, and `models/perps` / `perps.py` now state they **may break in any release, including patches**. No renames or logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3f25687a181f5d9ba9110b13c6c8167b6adfff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->