### PR TITLE
fix: parse zero GTC expiration as None in OpenOrder

### DIFF
--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -6,7 +6,7 @@ from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochOrIsoTimestamp,
+    ExpirationTimestamp,
     RequiredEpochOrIsoTimestamp,
     _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
 )
@@ -38,7 +38,7 @@ class OpenOrder(BaseModel):
     status: str
     associate_trades: tuple[str, ...] = Field(default=(), validation_alias="associate_trades")
     created_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="created_at")
-    expires_at: EpochOrIsoTimestamp = Field(default=None, validation_alias="expiration")
+    expires_at: ExpirationTimestamp = Field(default=None, validation_alias="expiration")
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid

--- a/tests/unit/test_account_actions.py
+++ b/tests/unit/test_account_actions.py
@@ -24,7 +24,7 @@ _OPEN_ORDER_PAYLOAD: dict[str, Any] = {
     "asset_id": "8501497",
     "associate_trades": ["trade-1"],
     "created_at": 1700000000000,
-    "expiration": 1800000000000,
+    "expiration": 1800000000,
     "id": "order-1",
     "maker_address": "0xMAKER",
     "market": "0xMARKET",

--- a/tests/unit/test_account_models.py
+++ b/tests/unit/test_account_models.py
@@ -18,7 +18,7 @@ def _open_order_payload(**overrides: object) -> dict[str, object]:
         "asset_id": "8501497",
         "associate_trades": ["trade-1"],
         "created_at": 1700000000000,
-        "expiration": 1800000000000,
+        "expiration": 1800000000,
         "id": "order-1",
         "maker_address": "0xMAKER",
         "market": "0xMARKET",
@@ -94,6 +94,12 @@ def test_open_order_accepts_iso_string_with_z_suffix() -> None:
 
 def test_open_order_treats_empty_expiration_as_none() -> None:
     order = OpenOrder.parse_response(_open_order_payload(expiration=""))
+    assert order.expires_at is None
+
+
+@pytest.mark.parametrize("expiration", [0, "0"])
+def test_open_order_treats_zero_expiration_as_none(expiration: object) -> None:
+    order = OpenOrder.parse_response(_open_order_payload(expiration=expiration))
     assert order.expires_at is None
 
 

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -20,7 +20,7 @@ _OPEN_ORDER_PAYLOAD: dict[str, Any] = {
     "asset_id": "8501497",
     "associate_trades": ["trade-1"],
     "created_at": 1700000000000,
-    "expiration": 1800000000000,
+    "expiration": 1800000000,
     "id": "order-1",
     "maker_address": "0xMAKER",
     "market": "0xMARKET",

--- a/tests/unit/test_jupyter_repr.py
+++ b/tests/unit/test_jupyter_repr.py
@@ -88,7 +88,7 @@ _OPEN_ORDER_PAYLOAD: dict[str, Any] = {
     "asset_id": "8501497",
     "associate_trades": ["trade-1"],
     "created_at": 1700000000000,
-    "expiration": 1800000000000,
+    "expiration": 1800000000,
     "id": "order-abcdef0123456789",
     "maker_address": "0xMAKER",
     "market": "0xMARKET01234567890",

--- a/tests/unit/test_secure_account_sync.py
+++ b/tests/unit/test_secure_account_sync.py
@@ -19,7 +19,7 @@ _OPEN_ORDER_PAYLOAD: dict[str, Any] = {
     "asset_id": "8501497",
     "associate_trades": ["trade-1"],
     "created_at": 1700000000000,
-    "expiration": 1800000000000,
+    "expiration": 1800000000,
     "id": "order-1",
     "maker_address": "0xMAKER",
     "market": "0xMARKET",


### PR DESCRIPTION
Fixes #191.

`OpenOrder.expires_at` parsed a GTC order's wire expiration `"0"` through the generic epoch parser, yielding `1970-01-01T00:00:00Z` instead of `None`. Switch the field to the existing `ExpirationTimestamp` type, matching the user-event order model.

Verified against the live CLOB API: `expiration` is returned in epoch seconds (`"0"` for GTC, the signed seconds value for GTD), so the test fixtures now use seconds instead of milliseconds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing fix for one model field with tests; behavior change only affects how GTC/zero expirations and second-based expirations are represented.
> 
> **Overview**
> **`OpenOrder.expires_at`** now uses **`ExpirationTimestamp`** instead of the generic epoch/ISO parser, so wire values **`0`** / **`"0"`** (GTC “no expiry”) become **`None`** instead of **`1970-01-01`**.
> 
> Non-zero **`expiration`** values are interpreted as **epoch seconds**, matching the live CLOB API and the user-event order model. Test fixtures and model tests were updated accordingly, including coverage for zero expiration as int or string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f713e76d7493af1a20aba5860d5388b91b83070a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->