### PR TITLE
fix(pagination): do not truncate results when page_size equals the endpoint maximum

### DIFF
--- a/src/polymarket/_internal/actions/data.py
+++ b/src/polymarket/_internal/actions/data.py
@@ -213,6 +213,7 @@ def list_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/positions",
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "user": user,
@@ -251,6 +252,7 @@ def list_closed_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/closed-positions",
+        max_page_size=50,
         base_params=build_data_params(
             {
                 "user": user,
@@ -337,6 +339,7 @@ def list_market_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/market-positions",
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "market": market,
@@ -374,6 +377,7 @@ def list_trades_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/trades",
+        max_page_size=10000,
         base_params=build_data_params(
             {
                 "takerOnly": taker_only,
@@ -422,6 +426,7 @@ def list_activity_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/activity",
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "user": user,
@@ -447,6 +452,7 @@ def list_builder_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/builders/leaderboard",
+        max_page_size=50,
         base_params=build_data_params({"timePeriod": time_period}),
         parse_items=_parser_for(LeaderboardEntry),
     )
@@ -466,6 +472,7 @@ def list_trader_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/leaderboard",
+        max_page_size=50,
         base_params=build_data_params(
             {
                 "category": category,

--- a/src/polymarket/_internal/dispatch.py
+++ b/src/polymarket/_internal/dispatch.py
@@ -10,6 +10,7 @@ from polymarket._internal.pagination import (
     decode_keyset_cursor,
     decode_offset_cursor,
     decode_page_cursor,
+    offset_request_limit,
 )
 from polymarket._internal.request import (
     KeysetPaginatedSpec,
@@ -79,6 +80,8 @@ def sync_paginate_offset(
 ) -> Paginator[T]:
     if page_size < 1:
         raise UserInputError("page_size must be a positive integer.")
+    if spec.max_page_size is not None and page_size > spec.max_page_size:
+        raise UserInputError(f"page_size must be at most {spec.max_page_size}.")
     transport = _sync_transport_for(ctx, spec.service)
 
     def fetch(cursor: str | None) -> Page[T]:
@@ -94,7 +97,9 @@ def sync_paginate_offset(
         )
         params: dict[str, QueryParamValue] = {
             **(spec.base_params or {}),
-            "limit": effective_size + 1,
+            "limit": offset_request_limit(
+                page_size=effective_size, max_page_size=spec.max_page_size
+            ),
             "offset": offset,
         }
         payload = transport.get_json(spec.path, params=params)
@@ -106,6 +111,7 @@ def sync_paginate_offset(
             offset=offset,
             page_size=effective_size,
             items=items,
+            max_page_size=spec.max_page_size,
         )
 
     return Paginator(fetch=fetch, initial_cursor=initial_cursor)
@@ -120,6 +126,8 @@ def async_paginate_offset(
 ) -> AsyncPaginator[T]:
     if page_size < 1:
         raise UserInputError("page_size must be a positive integer.")
+    if spec.max_page_size is not None and page_size > spec.max_page_size:
+        raise UserInputError(f"page_size must be at most {spec.max_page_size}.")
     transport = _async_transport_for(ctx, spec.service)
 
     async def fetch(cursor: str | None) -> Page[T]:
@@ -135,7 +143,9 @@ def async_paginate_offset(
         )
         params: dict[str, QueryParamValue] = {
             **(spec.base_params or {}),
-            "limit": effective_size + 1,
+            "limit": offset_request_limit(
+                page_size=effective_size, max_page_size=spec.max_page_size
+            ),
             "offset": offset,
         }
         payload = await transport.get_json(spec.path, params=params)
@@ -147,6 +157,7 @@ def async_paginate_offset(
             offset=offset,
             page_size=effective_size,
             items=items,
+            max_page_size=spec.max_page_size,
         )
 
     return AsyncPaginator(fetch=fetch, initial_cursor=initial_cursor)

--- a/src/polymarket/_internal/pagination.py
+++ b/src/polymarket/_internal/pagination.py
@@ -101,6 +101,15 @@ def decode_offset_cursor(
     return raw_offset, raw_page_size
 
 
+def offset_request_limit(*, page_size: int, max_page_size: int | None) -> int:
+    """Limit to request for one page: page_size plus a lookahead row, unless the
+    endpoint would clamp the lookahead away because page_size is already at its
+    maximum."""
+    if max_page_size is not None and page_size >= max_page_size:
+        return page_size
+    return page_size + 1
+
+
 def compute_offset_page(
     *,
     service: Service,
@@ -109,8 +118,9 @@ def compute_offset_page(
     offset: int,
     page_size: int,
     items: tuple[T, ...],
+    max_page_size: int | None = None,
 ) -> Page[T]:
-    has_more = len(items) > page_size
+    has_more = len(items) >= offset_request_limit(page_size=page_size, max_page_size=max_page_size)
     trimmed = items[:page_size]
     next_cursor = (
         encode_offset_cursor(
@@ -327,4 +337,5 @@ __all__ = [
     "encode_offset_cursor",
     "encode_page_cursor",
     "fingerprint_query",
+    "offset_request_limit",
 ]

--- a/src/polymarket/_internal/request.py
+++ b/src/polymarket/_internal/request.py
@@ -26,6 +26,7 @@ class OffsetPaginatedSpec(Generic[T]):
     path: str
     parse_items: Callable[[object], tuple[T, ...]]
     base_params: Mapping[str, QueryParamValue] | None = None
+    max_page_size: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/test_data_paginated_specs.py
+++ b/tests/unit/test_data_paginated_specs.py
@@ -205,6 +205,16 @@ def test_list_activity_spec_serializes_filters() -> None:
     }
 
 
+def test_offset_specs_set_documented_max_page_size() -> None:
+    assert data_actions.list_positions_spec(user="0xWALLET").max_page_size == 500
+    assert data_actions.list_closed_positions_spec(user="0xWALLET").max_page_size == 50
+    assert data_actions.list_market_positions_spec(market="0xMARKET").max_page_size == 500
+    assert data_actions.list_trades_spec().max_page_size == 10000
+    assert data_actions.list_activity_spec(user="0xWALLET").max_page_size == 500
+    assert data_actions.list_builder_leaderboard_spec().max_page_size == 50
+    assert data_actions.list_trader_leaderboard_spec().max_page_size == 50
+
+
 def test_list_builder_leaderboard_spec() -> None:
     spec = data_actions.list_builder_leaderboard_spec(time_period="WEEK")
     assert spec.path == "/v1/builders/leaderboard"

--- a/tests/unit/test_paginate_transport.py
+++ b/tests/unit/test_paginate_transport.py
@@ -32,12 +32,17 @@ def _items_handler(captured: list[httpx.Request], rows: list[list[int]]) -> http
     return httpx.MockTransport(handler)
 
 
-def _spec(path: str = "/positions", base_params: dict[str, str] | None = None):
+def _spec(
+    path: str = "/positions",
+    base_params: dict[str, str] | None = None,
+    max_page_size: int | None = None,
+):
     return OffsetPaginatedSpec[int](
         service="data",
         path=path,
         parse_items=lambda payload: tuple(payload),  # type: ignore[arg-type]
         base_params=base_params,
+        max_page_size=max_page_size,
     )
 
 
@@ -173,6 +178,25 @@ def test_sync_paginate_offset_round_trip_next_cursor() -> None:
     assert qs1["limit"] == ["11"]
 
 
+def test_sync_paginate_offset_at_max_page_size_fetches_next_page() -> None:
+    captured: list[httpx.Request] = []
+    handler = _items_handler(captured, [list(range(5)), list(range(5, 8))])
+    with PublicClient() as client:
+        _install_sync_data_transport(client, handler)
+        paginator = sync_paginate_offset(client._ctx, _spec(max_page_size=5), page_size=5)
+        all_items = list(paginator.iter_items())
+
+    assert all_items == list(range(8))
+    assert len(captured) == 2
+    limits = [parse_qs(urlparse(str(request.url)).query)["limit"] for request in captured]
+    assert limits == [["5"], ["5"]]
+
+
+def test_sync_paginate_offset_rejects_page_size_above_max() -> None:
+    with PublicClient() as client, pytest.raises(UserInputError, match="at most 5"):
+        sync_paginate_offset(client._ctx, _spec(max_page_size=5), page_size=6)
+
+
 def test_sync_paginate_offset_cursor_rejects_different_endpoint() -> None:
     captured: list[httpx.Request] = []
     handler = _items_handler(captured, [list(range(11))])
@@ -262,6 +286,34 @@ def test_async_paginate_offset_round_trip_next_cursor() -> None:
         qs1 = parse_qs(urlparse(str(captured[1].url)).query)
         assert qs1["offset"] == ["10"]
         assert qs1["limit"] == ["11"]
+
+    asyncio.run(run())
+
+
+def test_async_paginate_offset_at_max_page_size_fetches_next_page() -> None:
+    async def run() -> None:
+        captured: list[httpx.Request] = []
+        handler = _items_handler(captured, [list(range(5)), list(range(5, 8))])
+        async with AsyncPublicClient() as client:
+            _install_async_data_transport(client, handler)
+            paginator = async_paginate_offset(client._ctx, _spec(max_page_size=5), page_size=5)
+            collected: list[int] = []
+            async for page in paginator:
+                collected.extend(page.items)
+
+        assert collected == list(range(8))
+        assert len(captured) == 2
+        limits = [parse_qs(urlparse(str(request.url)).query)["limit"] for request in captured]
+        assert limits == [["5"], ["5"]]
+
+    asyncio.run(run())
+
+
+def test_async_paginate_offset_rejects_page_size_above_max() -> None:
+    async def run() -> None:
+        async with AsyncPublicClient() as client:
+            with pytest.raises(UserInputError, match="at most 5"):
+                async_paginate_offset(client._ctx, _spec(max_page_size=5), page_size=6)
 
     asyncio.run(run())
 

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -243,6 +243,21 @@ def test_compute_offset_page_no_more_when_full() -> None:
     assert page.next_cursor is None
 
 
+def test_compute_offset_page_full_page_at_max_page_size_has_more() -> None:
+    page = compute_offset_page(
+        service="data",
+        path="/positions",
+        base_params=None,
+        offset=0,
+        page_size=10,
+        items=tuple(range(10)),
+        max_page_size=10,
+    )
+    assert page.items == tuple(range(10))
+    assert page.has_more is True
+    assert page.next_cursor is not None
+
+
 def test_compute_offset_page_no_more_when_partial() -> None:
     page = compute_offset_page(
         service="data",


### PR DESCRIPTION
Offset pagination detected a next page by requesting `page_size + 1` rows, so when `page_size` equaled an endpoint's documented maximum `limit` the server clamped the lookahead row away and iteration stopped one page early. Each offset-paginated Data API spec now declares its documented maximum: at the maximum the lookahead is skipped and a full page fetches the next page, and larger page sizes are rejected up front.

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pagination behavior for all offset Data API list calls; fixes missing rows but alters when iteration continues at maximum page sizes.
> 
> **Overview**
> Fixes offset pagination stopping early when **`page_size` matches the Data API’s maximum `limit`**. The client used to request `page_size + 1` rows to detect a next page; servers that cap `limit` dropped the extra row, so a full “max size” page looked like the end of the list.
> 
> **`OffsetPaginatedSpec`** now carries optional **`max_page_size`**, set on Data offset endpoints (e.g. 50 for closed positions/leaderboards, 500 for positions/activity, 10000 for trades). **`offset_request_limit`** skips the +1 lookahead at the cap; **`compute_offset_page`** treats a full page at the cap as **`has_more`**. Sync/async offset paginators reject **`page_size` above the spec maximum** and pass the cap through when building requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67dcda5cb2b25dbf04da7f4cba5392909f236ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->