### PR TITLE
fix: stop exposing per-page count as Page.total_count

### DIFF
--- a/src/polymarket/_internal/actions/account.py
+++ b/src/polymarket/_internal/actions/account.py
@@ -6,7 +6,6 @@ from pydantic import TypeAdapter, ValidationError
 from polymarket._internal.actions._cursor import (
     END_CURSOR,
     next_cursor_or_none,
-    optional_int,
     validate_cursor,
 )
 from polymarket._internal.request import QueryParamValue
@@ -91,7 +90,6 @@ def parse_open_orders_page(data: object) -> Page[OpenOrder]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 
@@ -146,7 +144,6 @@ def parse_account_trades_page(data: object) -> Page[ClobTrade]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 

--- a/src/polymarket/_internal/actions/builders.py
+++ b/src/polymarket/_internal/actions/builders.py
@@ -4,7 +4,6 @@ from pydantic import TypeAdapter, ValidationError
 
 from polymarket._internal.actions._cursor import (
     next_cursor_or_none,
-    optional_int,
     validate_cursor,
 )
 from polymarket._internal.request import QueryParamValue
@@ -61,7 +60,6 @@ def parse_builder_trades_page(data: object) -> Page[BuilderTrade]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 

--- a/src/polymarket/_internal/actions/rewards.py
+++ b/src/polymarket/_internal/actions/rewards.py
@@ -75,7 +75,6 @@ def parse_current_rewards_page(data: object) -> Page[CurrentReward]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 
@@ -114,7 +113,6 @@ def parse_market_rewards_page(data: object) -> Page[MarketReward]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 
@@ -188,7 +186,6 @@ def parse_user_earnings_page(data: object) -> Page[UserEarning]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
     )
 
 
@@ -261,7 +258,7 @@ def parse_user_rewards_earnings_page(data: object) -> Page[UserRewardsEarning]:
         items=items,
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
-        total_count=optional_int(payload, "count"),
+        total_count=optional_int(payload, "total_count"),
     )
 
 

--- a/tests/unit/test_account_actions.py
+++ b/tests/unit/test_account_actions.py
@@ -117,7 +117,7 @@ def test_parse_open_orders_page_decodes_end_cursor_as_none() -> None:
         {"data": [_OPEN_ORDER_PAYLOAD], "next_cursor": END_CURSOR, "count": 1}
     )
     assert page.next_cursor is None
-    assert page.total_count == 1
+    assert page.total_count is None
     assert len(page.items) == 1
     assert page.items[0].id == "order-1"
 
@@ -136,11 +136,6 @@ def test_parse_open_orders_page_returns_none_total_count_when_missing() -> None:
     page = parse_open_orders_page({"data": [], "next_cursor": END_CURSOR})
     assert page.total_count is None
     assert page.next_cursor is None
-
-
-def test_parse_open_orders_page_raises_on_wrong_type_count() -> None:
-    with pytest.raises(UnexpectedResponseError, match="count"):
-        parse_open_orders_page({"data": [], "next_cursor": END_CURSOR, "count": "5"})
 
 
 def test_parse_open_orders_page_treats_missing_next_cursor_as_terminal() -> None:

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -204,7 +204,7 @@ class TestParseBuilderTradesPage:
         assert page.items[0].id == "trade-1"
         assert page.next_cursor == "cursor-2"
         assert page.has_more is True
-        assert page.total_count == 1
+        assert page.total_count is None
 
     def test_end_cursor_signals_no_more(self) -> None:
         page = parse_builder_trades_page(

--- a/tests/unit/test_rewards_actions.py
+++ b/tests/unit/test_rewards_actions.py
@@ -137,7 +137,7 @@ def test_parse_current_rewards_page_decodes_end_cursor_as_none() -> None:
     )
     assert page.next_cursor is None
     assert page.has_more is False
-    assert page.total_count == 1
+    assert page.total_count is None
     assert len(page.items) == 1
     assert page.items[0].condition_id == _CONDITION_ID
     assert page.items[0].sponsors_count == 2
@@ -154,11 +154,6 @@ def test_parse_current_rewards_page_keeps_non_terminal_cursor() -> None:
 def test_parse_current_rewards_page_returns_none_total_count_when_missing() -> None:
     page = parse_current_rewards_page({"data": [], "next_cursor": END_CURSOR})
     assert page.total_count is None
-
-
-def test_parse_current_rewards_page_raises_on_wrong_type_count() -> None:
-    with pytest.raises(UnexpectedResponseError, match="count"):
-        parse_current_rewards_page({"data": [], "next_cursor": END_CURSOR, "count": "0"})
 
 
 def test_parse_current_rewards_page_raises_on_empty_string_next_cursor() -> None:
@@ -343,9 +338,11 @@ def test_parse_user_rewards_earnings_page_decodes_full_payload() -> None:
             "data": [_USER_REWARDS_EARNING_PAYLOAD],
             "next_cursor": END_CURSOR,
             "count": 1,
+            "total_count": 42,
             "limit": 100,
         }
     )
+    assert page.total_count == 42
     assert len(page.items) == 1
     item = page.items[0]
     assert item.earning_percentage == 0.25


### PR DESCRIPTION
Fixes #193.

The CLOB paginated endpoints return `count` as the number of items in the current response, not a total across the result set. `Page.total_count` is now left unset for open orders, account trades, builder trades, and rewards pages. The user earnings and markets configuration endpoint does return a real `total_count` field, so that page now maps it (validated against the live API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes public pagination semantics for multiple list endpoints; callers that treated `Page.total_count` as a global total may need to adjust, though the new behavior matches the API.
> 
> **Overview**
> Corrects how CLOB paginated responses populate **`Page.total_count`**. Several endpoints expose **`count`** as the number of rows in the **current** page, not the size of the full result set; those parsers no longer set **`total_count`** from **`count`** (open orders, account trades, builder trades, and most rewards list pages now leave **`total_count`** unset).
> 
> The user earnings + markets configuration page is the exception: it exposes a real **`total_count`** field, so **`parse_user_rewards_earnings_page`** now reads **`total_count`** (via **`optional_int`**) instead of **`count`**. Unit tests were updated to expect **`None`** where **`count`** is ignored, and to assert **`total_count`** when that field is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d578a36a67e37d6a464f298859a2cfae2362b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->