### PR TITLE
chore: update uv.lock for 0.1.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -892,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-client"
-version = "0.1.0b21"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "eth-abi" },


### PR DESCRIPTION
`uv.lock` still records `polymarket-client 0.1.0b21` while `pyproject.toml` is at `0.1.0`, so `uv sync --locked` fails in CI. Regenerated with `uv lock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only version alignment with no application or dependency graph changes beyond the recorded package version.
> 
> **Overview**
> Aligns **`uv.lock`** with **`pyproject.toml`** by updating the editable **`polymarket-client`** entry from **`0.1.0b21`** to **`0.1.0`**, so **`uv sync --locked`** succeeds in CI instead of failing on a version mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06842be52adb3b0729f485e683077387d831ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->