### PR TITLE
fix: drop pagination look-ahead probe and cap page_size at upstream limits

### DIFF
--- a/src/polymarket/_internal/actions/data.py
+++ b/src/polymarket/_internal/actions/data.py
@@ -213,8 +213,8 @@ def list_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/positions",
-        # Upstream caps limit at 500 and the probe requests page_size + 1.
-        max_page_size=499,
+        # Matches the upstream per-request limit cap.
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "user": user,
@@ -253,8 +253,8 @@ def list_closed_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/closed-positions",
-        # Upstream caps limit at 50 and the probe requests page_size + 1.
-        max_page_size=49,
+        # Matches the upstream per-request limit cap.
+        max_page_size=50,
         base_params=build_data_params(
             {
                 "user": user,
@@ -341,8 +341,8 @@ def list_market_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/market-positions",
-        # Upstream caps limit at 500 and the probe requests page_size + 1.
-        max_page_size=499,
+        # Matches the upstream per-request limit cap.
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "market": market,
@@ -380,8 +380,8 @@ def list_trades_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/trades",
-        # Upstream caps limit at 10,000 and the probe requests page_size + 1.
-        max_page_size=9_999,
+        # Matches the upstream per-request limit cap.
+        max_page_size=10_000,
         base_params=build_data_params(
             {
                 "takerOnly": taker_only,
@@ -430,8 +430,8 @@ def list_activity_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/activity",
-        # Upstream caps limit at 500 and the probe requests page_size + 1.
-        max_page_size=499,
+        # Matches the upstream per-request limit cap.
+        max_page_size=500,
         base_params=build_data_params(
             {
                 "user": user,
@@ -457,8 +457,8 @@ def list_builder_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/builders/leaderboard",
-        # Upstream caps limit at 50 and the probe requests page_size + 1.
-        max_page_size=49,
+        # Matches the upstream per-request limit cap.
+        max_page_size=50,
         base_params=build_data_params({"timePeriod": time_period}),
         parse_items=_parser_for(LeaderboardEntry),
     )
@@ -478,8 +478,8 @@ def list_trader_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/leaderboard",
-        # Upstream caps limit at 50 and the probe requests page_size + 1.
-        max_page_size=49,
+        # Matches the upstream per-request limit cap.
+        max_page_size=50,
         base_params=build_data_params(
             {
                 "category": category,

--- a/src/polymarket/_internal/actions/data.py
+++ b/src/polymarket/_internal/actions/data.py
@@ -213,6 +213,8 @@ def list_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/positions",
+        # Upstream caps limit at 500 and the probe requests page_size + 1.
+        max_page_size=499,
         base_params=build_data_params(
             {
                 "user": user,
@@ -251,6 +253,8 @@ def list_closed_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/closed-positions",
+        # Upstream caps limit at 50 and the probe requests page_size + 1.
+        max_page_size=49,
         base_params=build_data_params(
             {
                 "user": user,
@@ -337,6 +341,8 @@ def list_market_positions_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/market-positions",
+        # Upstream caps limit at 500 and the probe requests page_size + 1.
+        max_page_size=499,
         base_params=build_data_params(
             {
                 "market": market,
@@ -374,6 +380,8 @@ def list_trades_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/trades",
+        # Upstream caps limit at 10,000 and the probe requests page_size + 1.
+        max_page_size=9_999,
         base_params=build_data_params(
             {
                 "takerOnly": taker_only,
@@ -422,6 +430,8 @@ def list_activity_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/activity",
+        # Upstream caps limit at 500 and the probe requests page_size + 1.
+        max_page_size=499,
         base_params=build_data_params(
             {
                 "user": user,
@@ -447,6 +457,8 @@ def list_builder_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/builders/leaderboard",
+        # Upstream caps limit at 50 and the probe requests page_size + 1.
+        max_page_size=49,
         base_params=build_data_params({"timePeriod": time_period}),
         parse_items=_parser_for(LeaderboardEntry),
     )
@@ -466,6 +478,8 @@ def list_trader_leaderboard_spec(
     return OffsetPaginatedSpec(
         service="data",
         path="/v1/leaderboard",
+        # Upstream caps limit at 50 and the probe requests page_size + 1.
+        max_page_size=49,
         base_params=build_data_params(
             {
                 "category": category,

--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -598,8 +598,8 @@ def list_series_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/series",
-        # Upstream caps limit at 50 and the probe requests page_size + 1.
-        max_page_size=49,
+        # Matches the upstream per-request limit cap.
+        max_page_size=50,
         parse_items=Series.parse_response_list,
         base_params=params or None,
     )
@@ -623,8 +623,8 @@ def list_tags_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/tags",
-        # Upstream caps limit at 100 and the probe requests page_size + 1.
-        max_page_size=99,
+        # Matches the upstream per-request limit cap.
+        max_page_size=100,
         parse_items=Tag.parse_response_list,
         base_params=params or None,
     )
@@ -650,8 +650,8 @@ def list_teams_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/teams",
-        # Upstream caps limit at 100 and the probe requests page_size + 1.
-        max_page_size=99,
+        # Matches the upstream per-request limit cap.
+        max_page_size=100,
         parse_items=Team.parse_response_list,
         base_params=params or None,
     )
@@ -681,8 +681,8 @@ def list_comments_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/comments",
-        # Upstream caps limit at 100 and the probe requests page_size + 1.
-        max_page_size=99,
+        # Matches the upstream per-request limit cap.
+        max_page_size=100,
         parse_items=Comment.parse_response_list,
         base_params=params,
     )
@@ -703,8 +703,8 @@ def list_comments_by_user_address_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path=path,
-        # Upstream caps limit at 100 and the probe requests page_size + 1.
-        max_page_size=99,
+        # Matches the upstream per-request limit cap.
+        max_page_size=100,
         parse_items=Comment.parse_response_list,
         base_params=params or None,
     )

--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -598,6 +598,8 @@ def list_series_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/series",
+        # Upstream caps limit at 50 and the probe requests page_size + 1.
+        max_page_size=49,
         parse_items=Series.parse_response_list,
         base_params=params or None,
     )
@@ -621,6 +623,8 @@ def list_tags_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/tags",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Tag.parse_response_list,
         base_params=params or None,
     )
@@ -646,6 +650,8 @@ def list_teams_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/teams",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Team.parse_response_list,
         base_params=params or None,
     )
@@ -675,6 +681,8 @@ def list_comments_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/comments",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Comment.parse_response_list,
         base_params=params,
     )
@@ -695,6 +703,8 @@ def list_comments_by_user_address_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path=path,
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Comment.parse_response_list,
         base_params=params or None,
     )

--- a/src/polymarket/_internal/dispatch.py
+++ b/src/polymarket/_internal/dispatch.py
@@ -79,6 +79,8 @@ def sync_paginate_offset(
 ) -> Paginator[T]:
     if page_size < 1:
         raise UserInputError("page_size must be a positive integer.")
+    if spec.max_page_size is not None and page_size > spec.max_page_size:
+        raise UserInputError(f"page_size must be at most {spec.max_page_size}.")
     transport = _sync_transport_for(ctx, spec.service)
 
     def fetch(cursor: str | None) -> Page[T]:
@@ -120,6 +122,8 @@ def async_paginate_offset(
 ) -> AsyncPaginator[T]:
     if page_size < 1:
         raise UserInputError("page_size must be a positive integer.")
+    if spec.max_page_size is not None and page_size > spec.max_page_size:
+        raise UserInputError(f"page_size must be at most {spec.max_page_size}.")
     transport = _async_transport_for(ctx, spec.service)
 
     async def fetch(cursor: str | None) -> Page[T]:

--- a/src/polymarket/_internal/dispatch.py
+++ b/src/polymarket/_internal/dispatch.py
@@ -96,7 +96,7 @@ def sync_paginate_offset(
         )
         params: dict[str, QueryParamValue] = {
             **(spec.base_params or {}),
-            "limit": effective_size + 1,
+            "limit": effective_size,
             "offset": offset,
         }
         payload = transport.get_json(spec.path, params=params)
@@ -139,7 +139,7 @@ def async_paginate_offset(
         )
         params: dict[str, QueryParamValue] = {
             **(spec.base_params or {}),
-            "limit": effective_size + 1,
+            "limit": effective_size,
             "offset": offset,
         }
         payload = await transport.get_json(spec.path, params=params)

--- a/src/polymarket/_internal/pagination.py
+++ b/src/polymarket/_internal/pagination.py
@@ -110,12 +110,11 @@ def compute_offset_page(
     page_size: int,
     items: tuple[T, ...],
 ) -> Page[T]:
-    # >= tolerates servers that clamp the page_size + 1 probe back to page_size:
-    # a full page continues pagination instead of silently dropping the tail. It
-    # costs one extra empty-page request when the total count is an exact
-    # multiple of page_size.
+    # Requests ask for exactly page_size rows, so a full page means another
+    # page may exist. This costs one extra empty-page request when the total
+    # count is an exact multiple of page_size, but cannot silently drop the
+    # tail when a server caps or clamps the limit.
     has_more = len(items) >= page_size
-    trimmed = items[:page_size]
     next_cursor = (
         encode_offset_cursor(
             service=service,
@@ -127,7 +126,7 @@ def compute_offset_page(
         if has_more
         else None
     )
-    return Page(items=trimmed, has_more=has_more, next_cursor=next_cursor)
+    return Page(items=items, has_more=has_more, next_cursor=next_cursor)
 
 
 def encode_keyset_cursor(

--- a/src/polymarket/_internal/pagination.py
+++ b/src/polymarket/_internal/pagination.py
@@ -110,7 +110,11 @@ def compute_offset_page(
     page_size: int,
     items: tuple[T, ...],
 ) -> Page[T]:
-    has_more = len(items) > page_size
+    # >= tolerates servers that clamp the page_size + 1 probe back to page_size:
+    # a full page continues pagination instead of silently dropping the tail. It
+    # costs one extra empty-page request when the total count is an exact
+    # multiple of page_size.
+    has_more = len(items) >= page_size
     trimmed = items[:page_size]
     next_cursor = (
         encode_offset_cursor(

--- a/src/polymarket/_internal/request.py
+++ b/src/polymarket/_internal/request.py
@@ -24,10 +24,9 @@ class RequestSpec(Generic[T]):
 class OffsetPaginatedSpec(Generic[T]):
     """A spec for endpoints that paginate via limit/offset.
 
-    The dispatcher requests `page_size + 1` items to probe for another page, so
-    `max_page_size` must be set to one below the endpoint's server-side limit
-    cap. Without it, a page size at or above the cap makes the server clamp or
-    reject the probe and pagination silently stops at the first page.
+    `max_page_size` must match the endpoint's server-side limit cap. Without
+    it, a page size above the cap makes the server clamp or reject the request
+    and pagination silently skips or drops rows.
     """
 
     service: Service

--- a/src/polymarket/_internal/request.py
+++ b/src/polymarket/_internal/request.py
@@ -22,10 +22,19 @@ class RequestSpec(Generic[T]):
 
 @dataclass(frozen=True, slots=True)
 class OffsetPaginatedSpec(Generic[T]):
+    """A spec for endpoints that paginate via limit/offset.
+
+    The dispatcher requests `page_size + 1` items to probe for another page, so
+    `max_page_size` must be set to one below the endpoint's server-side limit
+    cap. Without it, a page size at or above the cap makes the server clamp or
+    reject the probe and pagination silently stops at the first page.
+    """
+
     service: Service
     path: str
     parse_items: Callable[[object], tuple[T, ...]]
     base_params: Mapping[str, QueryParamValue] | None = None
+    max_page_size: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/polymarket/pagination.py
+++ b/src/polymarket/pagination.py
@@ -229,16 +229,15 @@ def _drain_paginator(paginator: Paginator[T], limit: int | None) -> tuple[list[T
     if limit == 0:
         # Skip the fetch entirely; with no observation we can't claim truncation.
         return [], False
-    # Drain page-by-page so that hitting `limit` exactly at a page boundary can
-    # read truncation from page.has_more instead of fetching the next page.
+    # A full page reports has_more=True as a heuristic, so when `limit` lands
+    # exactly on a page boundary the next page is fetched to decide truncation:
+    # a further item proves truncation, an empty page proves completeness.
     out: list[T] = []
     for page in paginator:
         for item in page.items:
             if len(out) >= limit:
                 return out, True
             out.append(item)
-        if len(out) >= limit:
-            return out, page.has_more
         if not page.has_more:
             return out, False
     return out, False
@@ -264,8 +263,6 @@ async def _drain_async_paginator(
             if len(out2) >= limit:
                 return out2, True
             out2.append(item)
-        if len(out2) >= limit:
-            return out2, page.has_more
         if not page.has_more:
             return out2, False
     return out2, False

--- a/tests/unit/test_data_paginated_specs.py
+++ b/tests/unit/test_data_paginated_specs.py
@@ -237,3 +237,32 @@ def test_list_trader_leaderboard_spec_serializes_all_filters() -> None:
 def test_list_trader_leaderboard_spec_validates_category() -> None:
     with pytest.raises(UserInputError, match="category"):
         data_actions.list_trader_leaderboard_spec(category="OTHER")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected_max"),
+    [
+        (data_actions.list_positions_spec(user="0xWALLET"), 499),
+        (data_actions.list_closed_positions_spec(user="0xWALLET"), 49),
+        (data_actions.list_market_positions_spec(market="0xabc"), 499),
+        (data_actions.list_trades_spec(), 9_999),
+        (data_actions.list_activity_spec(user="0xWALLET"), 499),
+        (data_actions.list_builder_leaderboard_spec(), 49),
+        (data_actions.list_trader_leaderboard_spec(), 49),
+    ],
+    ids=[
+        "positions",
+        "closed-positions",
+        "market-positions",
+        "trades",
+        "activity",
+        "builder-leaderboard",
+        "trader-leaderboard",
+    ],
+)
+def test_offset_specs_cap_page_size_below_server_limit(spec: object, expected_max: int) -> None:
+    # The dispatcher probes with page_size + 1, so each cap sits one below the
+    # server-side limit cap. Page sizes past the cap fail fast instead of the
+    # server clamping or rejecting the probe and pagination stopping early.
+    assert isinstance(spec, data_actions.OffsetPaginatedSpec)
+    assert spec.max_page_size == expected_max

--- a/tests/unit/test_data_paginated_specs.py
+++ b/tests/unit/test_data_paginated_specs.py
@@ -242,13 +242,13 @@ def test_list_trader_leaderboard_spec_validates_category() -> None:
 @pytest.mark.parametrize(
     ("spec", "expected_max"),
     [
-        (data_actions.list_positions_spec(user="0xWALLET"), 499),
-        (data_actions.list_closed_positions_spec(user="0xWALLET"), 49),
-        (data_actions.list_market_positions_spec(market="0xabc"), 499),
-        (data_actions.list_trades_spec(), 9_999),
-        (data_actions.list_activity_spec(user="0xWALLET"), 499),
-        (data_actions.list_builder_leaderboard_spec(), 49),
-        (data_actions.list_trader_leaderboard_spec(), 49),
+        (data_actions.list_positions_spec(user="0xWALLET"), 500),
+        (data_actions.list_closed_positions_spec(user="0xWALLET"), 50),
+        (data_actions.list_market_positions_spec(market="0xabc"), 500),
+        (data_actions.list_trades_spec(), 10_000),
+        (data_actions.list_activity_spec(user="0xWALLET"), 500),
+        (data_actions.list_builder_leaderboard_spec(), 50),
+        (data_actions.list_trader_leaderboard_spec(), 50),
     ],
     ids=[
         "positions",
@@ -260,9 +260,9 @@ def test_list_trader_leaderboard_spec_validates_category() -> None:
         "trader-leaderboard",
     ],
 )
-def test_offset_specs_cap_page_size_below_server_limit(spec: object, expected_max: int) -> None:
-    # The dispatcher probes with page_size + 1, so each cap sits one below the
-    # server-side limit cap. Page sizes past the cap fail fast instead of the
-    # server clamping or rejecting the probe and pagination stopping early.
+def test_offset_specs_cap_page_size_at_server_limit(spec: object, expected_max: int) -> None:
+    # Each cap matches the server-side limit cap. Page sizes past the cap fail
+    # fast instead of the server clamping or rejecting the request and
+    # pagination silently misbehaving.
     assert isinstance(spec, data_actions.OffsetPaginatedSpec)
     assert spec.max_page_size == expected_max

--- a/tests/unit/test_frames_paginator.py
+++ b/tests/unit/test_frames_paginator.py
@@ -126,22 +126,36 @@ def test_paginator_limit_int_larger_than_available() -> None:
     assert "polymarket_truncated" not in df.attrs
 
 
-def test_paginator_limit_at_page_boundary_does_not_fetch_extra_page() -> None:
-    """limit landing exactly on a full page that reports has_more=True
-    must read truncation from page metadata, not by fetching the next page."""
+def test_paginator_limit_at_page_boundary_confirms_truncation_via_next_page() -> None:
+    """A full page reports has_more=True as a heuristic, so limit landing
+    exactly on a page boundary fetches the next page: a further item proves
+    truncation."""
     paginator, fetched = _three_page_sync()
     df = paginator.to_pandas(limit=2)
     assert len(df) == 2
     assert df.attrs.get("polymarket_truncated") is True
-    assert fetched == [None, "p2"]
+    assert fetched == [None, "p2", "p3"]
 
 
-def test_paginator_limit_at_first_page_boundary_fetches_only_one_page() -> None:
-    paginator, fetched = _three_page_sync()
-    df = paginator.to_pandas(limit=1)
+def test_paginator_limit_at_exhausted_boundary_omits_truncation_marker() -> None:
+    """When the collection ends exactly at limit, the confirming fetch returns
+    an empty page and no truncation is reported."""
+    fetched: list[str | None] = []
+
+    def fetch(cursor: str | None) -> Page[_Item]:
+        fetched.append(cursor)
+        if cursor is None:
+            return Page(
+                items=(_Item(n=1, v=Decimal("0.1")),),
+                has_more=True,
+                next_cursor="p2",
+            )
+        return Page(items=(), has_more=False)
+
+    df = Paginator(fetch=fetch).to_pandas(limit=1)
     assert len(df) == 1
-    assert df.attrs.get("polymarket_truncated") is True
-    assert fetched == [None]
+    assert "polymarket_truncated" not in df.attrs
+    assert fetched == [None, "p2"]
 
 
 def test_paginator_limit_zero_returns_empty_dataframe_without_fetching() -> None:
@@ -227,13 +241,35 @@ def test_async_paginator_limit_int_truncated() -> None:
     _run(go())
 
 
-def test_async_paginator_limit_at_page_boundary_does_not_fetch_extra_page() -> None:
+def test_async_paginator_limit_at_page_boundary_confirms_truncation_via_next_page() -> None:
     async def go() -> None:
         paginator, fetched = _three_page_async()
         df = await paginator.to_pandas(limit=1)
         assert len(df) == 1
         assert df.attrs.get("polymarket_truncated") is True
-        assert fetched == [None]
+        assert fetched == [None, "p2"]
+
+    _run(go())
+
+
+def test_async_paginator_limit_at_exhausted_boundary_omits_truncation_marker() -> None:
+    async def go() -> None:
+        fetched: list[str | None] = []
+
+        async def fetch(cursor: str | None) -> Page[_Item]:
+            fetched.append(cursor)
+            if cursor is None:
+                return Page(
+                    items=(_Item(n=1, v=Decimal("0.1")),),
+                    has_more=True,
+                    next_cursor="p2",
+                )
+            return Page(items=(), has_more=False)
+
+        df = await AsyncPaginator(fetch=fetch).to_pandas(limit=1)
+        assert len(df) == 1
+        assert "polymarket_truncated" not in df.attrs
+        assert fetched == [None, "p2"]
 
     _run(go())
 

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -325,20 +325,20 @@ def test_keyset_parser_accepts_valid_next_cursor() -> None:
 @pytest.mark.parametrize(
     ("spec", "expected_max"),
     [
-        (gamma_actions.list_series_spec(), 49),
-        (gamma_actions.list_tags_spec(), 99),
-        (gamma_actions.list_teams_spec(), 99),
+        (gamma_actions.list_series_spec(), 50),
+        (gamma_actions.list_tags_spec(), 100),
+        (gamma_actions.list_teams_spec(), 100),
         (
             gamma_actions.list_comments_spec(parent_entity_id="1", parent_entity_type="Event"),
-            99,
+            100,
         ),
-        (gamma_actions.list_comments_by_user_address_spec(address="0x" + "a" * 40), 99),
+        (gamma_actions.list_comments_by_user_address_spec(address="0x" + "a" * 40), 100),
     ],
     ids=["series", "tags", "teams", "comments", "comments-by-user-address"],
 )
-def test_offset_specs_cap_page_size_below_server_limit(spec: object, expected_max: int) -> None:
-    # The dispatcher probes with page_size + 1, so each cap sits one below the
-    # server-side limit cap. Page sizes past the cap fail fast instead of the
-    # server clamping the probe and pagination stopping early.
+def test_offset_specs_cap_page_size_at_server_limit(spec: object, expected_max: int) -> None:
+    # Each cap matches the server-side limit cap. Page sizes past the cap fail
+    # fast instead of the server clamping the limit and pagination silently
+    # misbehaving.
     assert isinstance(spec, OffsetPaginatedSpec)
     assert spec.max_page_size == expected_max

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -320,3 +320,25 @@ def test_keyset_parser_accepts_valid_next_cursor() -> None:
     payload = spec.parse_page({"events": [], "next_cursor": "opaque"})
 
     assert payload.server_next_cursor == "opaque"
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected_max"),
+    [
+        (gamma_actions.list_series_spec(), 49),
+        (gamma_actions.list_tags_spec(), 99),
+        (gamma_actions.list_teams_spec(), 99),
+        (
+            gamma_actions.list_comments_spec(parent_entity_id="1", parent_entity_type="Event"),
+            99,
+        ),
+        (gamma_actions.list_comments_by_user_address_spec(address="0x" + "a" * 40), 99),
+    ],
+    ids=["series", "tags", "teams", "comments", "comments-by-user-address"],
+)
+def test_offset_specs_cap_page_size_below_server_limit(spec: object, expected_max: int) -> None:
+    # The dispatcher probes with page_size + 1, so each cap sits one below the
+    # server-side limit cap. Page sizes past the cap fail fast instead of the
+    # server clamping the probe and pagination stopping early.
+    assert isinstance(spec, OffsetPaginatedSpec)
+    assert spec.max_page_size == expected_max

--- a/tests/unit/test_paginate_transport.py
+++ b/tests/unit/test_paginate_transport.py
@@ -119,7 +119,7 @@ def _page_spec(
 
 def test_sync_paginate_offset_sends_limit_and_offset() -> None:
     captured: list[httpx.Request] = []
-    handler = _items_handler(captured, [list(range(0, 11))])
+    handler = _items_handler(captured, [list(range(0, 10))])
     with PublicClient() as client:
         _install_sync_data_transport(client, handler)
         page = sync_paginate_offset(
@@ -128,23 +128,12 @@ def test_sync_paginate_offset_sends_limit_and_offset() -> None:
 
     assert len(captured) == 1
     qs = parse_qs(urlparse(str(captured[0].url)).query)
-    assert qs["limit"] == ["11"]
+    assert qs["limit"] == ["10"]
     assert qs["offset"] == ["0"]
     assert qs["user"] == ["0xA"]
     assert page.items == tuple(range(10))
     assert page.has_more is True
     assert page.next_cursor is not None
-
-
-def test_sync_paginate_offset_trims_to_page_size() -> None:
-    captured: list[httpx.Request] = []
-    handler = _items_handler(captured, [list(range(15))])
-    with PublicClient() as client:
-        _install_sync_data_transport(client, handler)
-        page = sync_paginate_offset(client._ctx, _spec(), page_size=10).first_page()
-
-    assert page.items == tuple(range(10))
-    assert page.has_more is True
 
 
 def test_sync_paginate_offset_rejects_page_size_above_spec_max() -> None:
@@ -164,9 +153,10 @@ def test_async_paginate_offset_rejects_page_size_above_spec_max() -> None:
     asyncio.run(run())
 
 
-def test_sync_paginate_offset_continues_past_clamped_probe() -> None:
-    # A server that clamps the page_size + 1 probe returns exactly page_size
-    # rows. Pagination must continue to the next offset instead of stopping.
+def test_sync_paginate_offset_continues_past_full_page() -> None:
+    # A full page means another page may exist, so pagination continues to the
+    # next offset and terminates on the empty page. This also protects against
+    # servers that clamp the limit instead of erroring.
     captured: list[httpx.Request] = []
     handler = _items_handler(captured, [list(range(0, 10)), list(range(10, 20))])
     with PublicClient() as client:
@@ -195,7 +185,7 @@ def test_sync_paginate_offset_round_trip_next_cursor() -> None:
     captured: list[httpx.Request] = []
     handler = _items_handler(
         captured,
-        [list(range(0, 11)), list(range(10, 13))],
+        [list(range(0, 10)), list(range(10, 13))],
     )
     with PublicClient() as client:
         _install_sync_data_transport(client, handler)
@@ -207,12 +197,12 @@ def test_sync_paginate_offset_round_trip_next_cursor() -> None:
     assert len(captured) == 2
     qs1 = parse_qs(urlparse(str(captured[1].url)).query)
     assert qs1["offset"] == ["10"]
-    assert qs1["limit"] == ["11"]
+    assert qs1["limit"] == ["10"]
 
 
 def test_sync_paginate_offset_cursor_rejects_different_endpoint() -> None:
     captured: list[httpx.Request] = []
-    handler = _items_handler(captured, [list(range(11))])
+    handler = _items_handler(captured, [list(range(10))])
     with PublicClient() as client:
         _install_sync_data_transport(client, handler)
         paginator = sync_paginate_offset(client._ctx, _spec(path="/positions"), page_size=10)
@@ -227,7 +217,7 @@ def test_sync_paginate_offset_cursor_rejects_different_endpoint() -> None:
 
 def test_sync_paginate_offset_cursor_rejects_different_query() -> None:
     captured: list[httpx.Request] = []
-    handler = _items_handler(captured, [list(range(11))])
+    handler = _items_handler(captured, [list(range(10))])
     with PublicClient() as client:
         _install_sync_data_transport(client, handler)
         a_paginator = sync_paginate_offset(
@@ -244,7 +234,7 @@ def test_sync_paginate_offset_cursor_rejects_different_query() -> None:
 
 def test_sync_paginate_offset_next_cursor_decodes_to_expected_offset() -> None:
     captured: list[httpx.Request] = []
-    handler = _items_handler(captured, [list(range(11))])
+    handler = _items_handler(captured, [list(range(10))])
     with PublicClient() as client:
         _install_sync_data_transport(client, handler)
         spec = _spec(base_params={"user": "0xA"})
@@ -262,7 +252,7 @@ def test_sync_paginate_offset_next_cursor_decodes_to_expected_offset() -> None:
 def test_async_paginate_offset_sends_limit_and_offset() -> None:
     async def run() -> None:
         captured: list[httpx.Request] = []
-        handler = _items_handler(captured, [list(range(0, 11))])
+        handler = _items_handler(captured, [list(range(0, 10))])
         async with AsyncPublicClient() as client:
             _install_async_data_transport(client, handler)
             page = await async_paginate_offset(
@@ -271,7 +261,7 @@ def test_async_paginate_offset_sends_limit_and_offset() -> None:
 
         assert len(captured) == 1
         qs = parse_qs(urlparse(str(captured[0].url)).query)
-        assert qs["limit"] == ["11"]
+        assert qs["limit"] == ["10"]
         assert qs["offset"] == ["0"]
         assert qs["user"] == ["0xA"]
         assert page.items == tuple(range(10))
@@ -285,7 +275,7 @@ def test_async_paginate_offset_round_trip_next_cursor() -> None:
         captured: list[httpx.Request] = []
         handler = _items_handler(
             captured,
-            [list(range(0, 11)), list(range(10, 13))],
+            [list(range(0, 10)), list(range(10, 13))],
         )
         async with AsyncPublicClient() as client:
             _install_async_data_transport(client, handler)
@@ -298,7 +288,7 @@ def test_async_paginate_offset_round_trip_next_cursor() -> None:
         assert len(captured) == 2
         qs1 = parse_qs(urlparse(str(captured[1].url)).query)
         assert qs1["offset"] == ["10"]
-        assert qs1["limit"] == ["11"]
+        assert qs1["limit"] == ["10"]
 
     asyncio.run(run())
 
@@ -306,7 +296,7 @@ def test_async_paginate_offset_round_trip_next_cursor() -> None:
 def test_async_paginate_offset_cursor_rejects_different_endpoint() -> None:
     async def run() -> None:
         captured: list[httpx.Request] = []
-        handler = _items_handler(captured, [list(range(11))])
+        handler = _items_handler(captured, [list(range(10))])
         async with AsyncPublicClient() as client:
             _install_async_data_transport(client, handler)
             paginator = async_paginate_offset(client._ctx, _spec(path="/positions"), page_size=10)
@@ -322,7 +312,7 @@ def test_async_paginate_offset_cursor_rejects_different_endpoint() -> None:
 def test_async_paginate_offset_cursor_rejects_different_query() -> None:
     async def run() -> None:
         captured: list[httpx.Request] = []
-        handler = _items_handler(captured, [list(range(11))])
+        handler = _items_handler(captured, [list(range(10))])
         async with AsyncPublicClient() as client:
             _install_async_data_transport(client, handler)
             a_paginator = async_paginate_offset(

--- a/tests/unit/test_paginate_transport.py
+++ b/tests/unit/test_paginate_transport.py
@@ -32,12 +32,17 @@ def _items_handler(captured: list[httpx.Request], rows: list[list[int]]) -> http
     return httpx.MockTransport(handler)
 
 
-def _spec(path: str = "/positions", base_params: dict[str, str] | None = None):
+def _spec(
+    path: str = "/positions",
+    base_params: dict[str, str] | None = None,
+    max_page_size: int | None = None,
+):
     return OffsetPaginatedSpec[int](
         service="data",
         path=path,
         parse_items=lambda payload: tuple(payload),  # type: ignore[arg-type]
         base_params=base_params,
+        max_page_size=max_page_size,
     )
 
 
@@ -140,6 +145,38 @@ def test_sync_paginate_offset_trims_to_page_size() -> None:
 
     assert page.items == tuple(range(10))
     assert page.has_more is True
+
+
+def test_sync_paginate_offset_rejects_page_size_above_spec_max() -> None:
+    with (
+        PublicClient() as client,
+        pytest.raises(UserInputError, match="page_size must be at most 49"),
+    ):
+        sync_paginate_offset(client._ctx, _spec(max_page_size=49), page_size=50)
+
+
+def test_async_paginate_offset_rejects_page_size_above_spec_max() -> None:
+    async def run() -> None:
+        async with AsyncPublicClient() as client:
+            with pytest.raises(UserInputError, match="page_size must be at most 49"):
+                async_paginate_offset(client._ctx, _spec(max_page_size=49), page_size=50)
+
+    asyncio.run(run())
+
+
+def test_sync_paginate_offset_continues_past_clamped_probe() -> None:
+    # A server that clamps the page_size + 1 probe returns exactly page_size
+    # rows. Pagination must continue to the next offset instead of stopping.
+    captured: list[httpx.Request] = []
+    handler = _items_handler(captured, [list(range(0, 10)), list(range(10, 20))])
+    with PublicClient() as client:
+        _install_sync_data_transport(client, handler)
+        paginator = sync_paginate_offset(client._ctx, _spec(), page_size=10)
+        items = [item for page in paginator for item in page.items]
+
+    assert items == list(range(20))
+    offsets = [parse_qs(urlparse(str(request.url)).query)["offset"][0] for request in captured]
+    assert offsets == ["0", "10", "20"]
 
 
 def test_sync_paginate_offset_no_more_when_partial() -> None:

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -208,31 +208,10 @@ def test_fingerprint_differentiates_values() -> None:
     assert fingerprint_query({"user": "0xA"}) != fingerprint_query({"user": "0xB"})
 
 
-def test_compute_offset_page_emits_next_cursor_when_more() -> None:
-    items = tuple(range(11))
-    page = compute_offset_page(
-        service="data",
-        path="/positions",
-        base_params={"user": "0xA"},
-        offset=0,
-        page_size=10,
-        items=items,
-    )
-    assert page.items == tuple(range(10))
-    assert page.has_more is True
-    assert page.next_cursor is not None
-    assert decode_offset_cursor(
-        page.next_cursor,
-        expected_service="data",
-        expected_path="/positions",
-        expected_base_params={"user": "0xA"},
-    ) == (10, 10)
-
-
 def test_compute_offset_page_more_when_full() -> None:
-    # A full page without the probe row means the server may have clamped the
-    # page_size + 1 probe back to its limit cap, so pagination must continue
-    # instead of silently dropping the tail.
+    # Requests ask for exactly page_size rows, so a full page means another
+    # page may exist and pagination must continue instead of silently
+    # dropping the tail.
     page = compute_offset_page(
         service="data",
         path="/positions",

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -229,7 +229,10 @@ def test_compute_offset_page_emits_next_cursor_when_more() -> None:
     ) == (10, 10)
 
 
-def test_compute_offset_page_no_more_when_full() -> None:
+def test_compute_offset_page_more_when_full() -> None:
+    # A full page without the probe row means the server may have clamped the
+    # page_size + 1 probe back to its limit cap, so pagination must continue
+    # instead of silently dropping the tail.
     page = compute_offset_page(
         service="data",
         path="/positions",
@@ -239,8 +242,14 @@ def test_compute_offset_page_no_more_when_full() -> None:
         items=tuple(range(10)),
     )
     assert page.items == tuple(range(10))
-    assert page.has_more is False
-    assert page.next_cursor is None
+    assert page.has_more is True
+    assert page.next_cursor is not None
+    assert decode_offset_cursor(
+        page.next_cursor,
+        expected_service="data",
+        expected_path="/positions",
+        expected_base_params=None,
+    ) == (10, 10)
 
 
 def test_compute_offset_page_no_more_when_partial() -> None:


### PR DESCRIPTION
Fixes silent pagination truncation on all offset-paginated endpoints (DEV-450, includes the gamma scope originally split into #206).

## Problem

The upstream services cap `?limit` per endpoint (data now rejects past-cap with 400; gamma silently clamps). Offset pagination probed with `limit = page_size + 1` and decided `has_more = len(items) > page_size`, so any `page_size` at or above the cap made the probe come back clamped: the SDK saw a full page, reported `has_more=False`, and iteration stopped silently. Example: `list_closed_positions(user=..., page_size=50)` returned at most 50 items total with no error.

## Changes

- Drop the look-ahead probe in `dispatch.py`: offset requests ask for exactly `page_size` rows. `compute_offset_page` treats a full page as `has_more=True`; a collection ending exactly on a page boundary costs one extra empty final page. Once the probe is clamp-tolerant, the `+1` carries no information, and removing it means `page_size` can use the full upstream cap instead of cap-1.
- Add `max_page_size` to `OffsetPaginatedSpec` and enforce it in sync/async dispatch with `UserInputError`, mirroring the existing `KeysetPaginatedSpec` enforcement.
- Set caps at the exact upstream values:
  - data: `list_positions`, `list_activity`, `list_market_positions` 500; `list_closed_positions`, `list_builder_leaderboard`, `list_trader_leaderboard` 50; `list_trades` 10,000
  - gamma: `list_tags`, `list_comments`, `list_comments_by_user_address`, `list_teams` 100; `list_series` 50

Caps verified against the upstream limit-guard call sites on both services' current `main`. Keyset specs and page-based search are unaffected.

## Verification

- `make check` (ruff, format, pyright, 1879 unit tests, incl. parametrized cap coverage for all twelve specs, dispatch rejection sync/async, and full-page continuation walk)
- Live integration: `test_data_paginated.py` and `test_gamma_paginated.py` pass (37 passed, 1 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pagination behavior across many list endpoints; fixes data loss but alters request patterns and limit/truncation semantics for callers.
> 
> **Overview**
> Fixes **silent truncation** on offset-paginated data and gamma list endpoints when `page_size` hit upstream `limit` caps (probe/clamp made full pages look terminal).
> 
> **Offset pagination** no longer requests `limit = page_size + 1`. Requests use exactly `page_size`, and `compute_offset_page` treats a full page as `has_more=True` (may cost one extra empty request when totals are an exact multiple of `page_size`). **`OffsetPaginatedSpec`** gains **`max_page_size`**, enforced in sync/async dispatch with `UserInputError`; twelve specs set caps matching upstream (e.g. closed positions/leaderboards 50, positions/activity 500, trades 10k, gamma tags/comments 100).
> 
> **`to_pandas` / frame drains** with a `limit` on a page boundary now fetch the next page to decide truncation vs completeness, aligned with the full-page heuristic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02604b0e45d5bf67376e68a687c708c3fa55343d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->