### PR TITLE
fix: cap page_size on gamma offset-paginated endpoints

### DIFF
--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -598,6 +598,8 @@ def list_series_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/series",
+        # Upstream caps limit at 50 and the probe requests page_size + 1.
+        max_page_size=49,
         parse_items=Series.parse_response_list,
         base_params=params or None,
     )
@@ -621,6 +623,8 @@ def list_tags_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/tags",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Tag.parse_response_list,
         base_params=params or None,
     )
@@ -646,6 +650,8 @@ def list_teams_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/teams",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Team.parse_response_list,
         base_params=params or None,
     )
@@ -675,6 +681,8 @@ def list_comments_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path="/comments",
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Comment.parse_response_list,
         base_params=params,
     )
@@ -695,6 +703,8 @@ def list_comments_by_user_address_spec(
     return OffsetPaginatedSpec(
         service="gamma",
         path=path,
+        # Upstream caps limit at 100 and the probe requests page_size + 1.
+        max_page_size=99,
         parse_items=Comment.parse_response_list,
         base_params=params or None,
     )

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -320,3 +320,25 @@ def test_keyset_parser_accepts_valid_next_cursor() -> None:
     payload = spec.parse_page({"events": [], "next_cursor": "opaque"})
 
     assert payload.server_next_cursor == "opaque"
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected_max"),
+    [
+        (gamma_actions.list_series_spec(), 49),
+        (gamma_actions.list_tags_spec(), 99),
+        (gamma_actions.list_teams_spec(), 99),
+        (
+            gamma_actions.list_comments_spec(parent_entity_id="1", parent_entity_type="Event"),
+            99,
+        ),
+        (gamma_actions.list_comments_by_user_address_spec(address="0x" + "a" * 40), 99),
+    ],
+    ids=["series", "tags", "teams", "comments", "comments-by-user-address"],
+)
+def test_offset_specs_cap_page_size_below_server_limit(spec: object, expected_max: int) -> None:
+    # The dispatcher probes with page_size + 1, so each cap sits one below the
+    # server-side limit cap. Page sizes past the cap fail fast instead of the
+    # server clamping the probe and pagination stopping early.
+    assert isinstance(spec, OffsetPaginatedSpec)
+    assert spec.max_page_size == expected_max


### PR DESCRIPTION
Stacked on #205; follow-up applying the same input caps to the Gamma-backed offset specs (DEV-476).

## Problem

Every Gamma list endpoint silently clamps `?limit` at the query layer; past-cap limits never 400. Same failure mode as #205: a `page_size` at or above the cap made the `page_size + 1` probe come back clamped and pagination stopped silently. The clamp-tolerant `has_more` probe from #205 already covers these endpoints (shared `compute_offset_page`), so this PR adds the missing half: input caps so invalid page sizes fail fast with `UserInputError`.

Unlike the data service there is no strict-400 change planned upstream, and the caps have already drifted once (markets-tooling #1501 lowered them in May 2026).

## Changes

Set `max_page_size` (enforcement added in #205) on the five Gamma offset specs, one below each endpoint's server-side limit cap (probe headroom):

- `list_tags_spec`, `list_teams_spec`, `list_comments_spec`, `list_comments_by_user_address_spec`: 99 (server cap 100)
- `list_series_spec`: 49 (server cap 50) — `page_size=50` truncated silently before this change

Caps verified against the Gamma limit clamp helper and per-endpoint constants on current markets-tooling `main` (`model.AppendArgs`, `model/constants.go`); the by-user comments route clamps at the same 100 cap as `/comments`. `list_markets` / `list_events` are cursor-based and unaffected; search is page-based and out of scope.

## Merge order

Contains the #205 commit; merge #205 first, then this lands as the spec-values diff only.

## Verification

- `make check` (ruff, format, pyright, 1881 unit tests including the new parametrized gamma cap coverage)
- Live integration: `tests/integration/test_gamma_paginated.py` passes (19 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side pagination limits and tests only; no auth, data writes, or API contract changes beyond rejecting invalid page sizes earlier.
> 
> **Overview**
> Sets **`max_page_size`** on the five Gamma **`OffsetPaginatedSpec`** list helpers so oversized **`page_size`** values raise **`UserInputError`** instead of being silently clamped by the API and breaking the **`page_size + 1`** pagination probe.
> 
> **Series** is capped at **49** (upstream limit 50); **tags**, **teams**, **comments**, and **comments-by-user-address** at **99** (limit 100). Each cap is one below the server limit so the probe still fits within the clamp.
> 
> Adds a parametrized unit test asserting these **`max_page_size`** values on the affected specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52e2fd7dd25984bb83a80d18c665f868b1a5665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->