### PR TITLE
chore: sync uv.lock with the 0.2.0 release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -892,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-client"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "eth-abi" },


### PR DESCRIPTION
The 0.2.0 release-please merge bumped `pyproject.toml` to 0.2.0 but left `uv.lock` at 0.1.0, so `uv sync --locked` fails Static Checks on every push to main.

Regenerates the lockfile with `uv lock` (only the `polymarket-client` version entry changes). Verified locally with `uv sync --locked`.

Follow-up: the release workflow should keep `uv.lock` in sync when release-please bumps the version, tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only version alignment with no runtime or dependency resolution changes beyond the local package version string.
> 
> **Overview**
> Updates **`uv.lock`** so the editable **`polymarket-client`** package is recorded as **0.2.0** instead of **0.1.0**, matching **`pyproject.toml`** after the release-please bump.
> 
> This restores **`uv sync --locked`** in CI (Static Checks) when the lockfile and project version were out of sync; no dependency graph or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2286c68894391a37988ee73436e790203e25a24f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->