### PR TITLE
fix(relayer): self-heal deposit wallet nonce on submit rejection

### DIFF
--- a/src/polymarket/_internal/actions/combos.py
+++ b/src/polymarket/_internal/actions/combos.py
@@ -4,14 +4,17 @@ import httpx
 
 from polymarket._internal.actions.relayer.calls import TransactionCall
 from polymarket._internal.actions.relayer.gasless import (
+    build_signed_deposit_wallet_payload,
+    build_signed_deposit_wallet_payload_sync,
     build_signed_payload_for_wallet_type,
     build_signed_payload_for_wallet_type_sync,
     submit_gasless_with_retry,
     submit_gasless_with_retry_sync,
 )
+from polymarket._internal.actions.relayer.submit import onchain_nonce_from_submit_error
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
 from polymarket._internal.wallet import WalletType
-from polymarket.errors import UserInputError
+from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import RelayerExecuteResponse
 from polymarket.models.collateral_return import CollateralReturnPlanResponse
 from polymarket.transactions import GaslessTransactionHandle, SyncGaslessTransactionHandle
@@ -100,11 +103,24 @@ async def _submit_plan(
     ctx: AsyncSecureClientContext, *, plan_hash: str, call: TransactionCall
 ) -> RelayerExecuteResponse:
     envelope = await build_signed_payload_for_wallet_type(ctx, calls=[call], metadata=_METADATA)
-    data = await ctx.combos.post_json(
-        _SUBMIT_PATH,
-        json={"plan_hash": plan_hash, "envelope": envelope},
-        timeout=_REQUEST_TIMEOUT,
-    )
+    try:
+        data = await ctx.combos.post_json(
+            _SUBMIT_PATH,
+            json={"plan_hash": plan_hash, "envelope": envelope},
+            timeout=_REQUEST_TIMEOUT,
+        )
+    except RequestRejectedError as error:
+        nonce = onchain_nonce_from_submit_error(error)
+        if nonce is None or ctx.wallet_type != "DEPOSIT_WALLET":
+            raise
+        envelope = await build_signed_deposit_wallet_payload(
+            ctx, calls=[call], metadata=_METADATA, nonce=nonce
+        )
+        data = await ctx.combos.post_json(
+            _SUBMIT_PATH,
+            json={"plan_hash": plan_hash, "envelope": envelope},
+            timeout=_REQUEST_TIMEOUT,
+        )
     return RelayerExecuteResponse.parse_response(data)
 
 
@@ -112,11 +128,24 @@ def _submit_plan_sync(
     ctx: SyncSecureClientContext, *, plan_hash: str, call: TransactionCall
 ) -> RelayerExecuteResponse:
     envelope = build_signed_payload_for_wallet_type_sync(ctx, calls=[call], metadata=_METADATA)
-    data = ctx.combos.post_json(
-        _SUBMIT_PATH,
-        json={"plan_hash": plan_hash, "envelope": envelope},
-        timeout=_REQUEST_TIMEOUT,
-    )
+    try:
+        data = ctx.combos.post_json(
+            _SUBMIT_PATH,
+            json={"plan_hash": plan_hash, "envelope": envelope},
+            timeout=_REQUEST_TIMEOUT,
+        )
+    except RequestRejectedError as error:
+        nonce = onchain_nonce_from_submit_error(error)
+        if nonce is None or ctx.wallet_type != "DEPOSIT_WALLET":
+            raise
+        envelope = build_signed_deposit_wallet_payload_sync(
+            ctx, calls=[call], metadata=_METADATA, nonce=nonce
+        )
+        data = ctx.combos.post_json(
+            _SUBMIT_PATH,
+            json={"plan_hash": plan_hash, "envelope": envelope},
+            timeout=_REQUEST_TIMEOUT,
+        )
     return RelayerExecuteResponse.parse_response(data)
 
 

--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -28,11 +28,12 @@ from polymarket._internal.actions.relayer.submit import (
     GASLESS_SUBMIT_RETRY_ATTEMPTS,
     RelayerEnvelope,
     is_retryable_submit_error,
+    onchain_nonce_from_submit_error,
     submit_gasless,
     submit_gasless_sync,
 )
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
-from polymarket.errors import UserInputError
+from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import (
     RelayerExecuteResponse,
     RelayerTransactionType,
@@ -109,7 +110,16 @@ async def _submit_for_wallet_type(
     metadata: str,
 ) -> RelayerExecuteResponse:
     payload = await build_signed_payload_for_wallet_type(ctx, calls=calls, metadata=metadata)
-    return await submit_gasless(ctx.relayer, payload=payload)
+    try:
+        return await submit_gasless(ctx.relayer, payload=payload)
+    except RequestRejectedError as error:
+        nonce = onchain_nonce_from_submit_error(error)
+        if nonce is None or ctx.wallet_type != "DEPOSIT_WALLET":
+            raise
+        payload = await build_signed_deposit_wallet_payload(
+            ctx, calls=calls, metadata=metadata, nonce=nonce
+        )
+        return await submit_gasless(ctx.relayer, payload=payload)
 
 
 async def build_signed_payload_for_wallet_type(
@@ -136,16 +146,19 @@ async def build_signed_deposit_wallet_payload(
     *,
     calls: list[TransactionCall],
     metadata: str,
+    nonce: str | None = None,
 ) -> RelayerEnvelope:
-    params = await fetch_execute_params(
-        ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.WALLET
-    )
+    if nonce is None:
+        params = await fetch_execute_params(
+            ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.WALLET
+        )
+        nonce = params.nonce
     deadline = str(int(time.time()) + _DEPOSIT_WALLET_DEADLINE_S)
     signature = sign_deposit_wallet_batch(
         ctx.signer,
         wallet=ctx.wallet,
         calls=calls,
-        nonce=params.nonce,
+        nonce=nonce,
         deadline=deadline,
         chain_id=ctx.environment.chain_id,
     )
@@ -154,7 +167,7 @@ async def build_signed_deposit_wallet_payload(
         deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
-        nonce=params.nonce,
+        nonce=nonce,
         deadline=deadline,
         signature=signature,
         metadata=metadata,
@@ -451,7 +464,16 @@ def _submit_for_wallet_type_sync(
     metadata: str,
 ) -> RelayerExecuteResponse:
     payload = build_signed_payload_for_wallet_type_sync(ctx, calls=calls, metadata=metadata)
-    return submit_gasless_sync(ctx.relayer, payload=payload)
+    try:
+        return submit_gasless_sync(ctx.relayer, payload=payload)
+    except RequestRejectedError as error:
+        nonce = onchain_nonce_from_submit_error(error)
+        if nonce is None or ctx.wallet_type != "DEPOSIT_WALLET":
+            raise
+        payload = build_signed_deposit_wallet_payload_sync(
+            ctx, calls=calls, metadata=metadata, nonce=nonce
+        )
+        return submit_gasless_sync(ctx.relayer, payload=payload)
 
 
 def build_signed_payload_for_wallet_type_sync(
@@ -478,16 +500,19 @@ def build_signed_deposit_wallet_payload_sync(
     *,
     calls: list[TransactionCall],
     metadata: str,
+    nonce: str | None = None,
 ) -> RelayerEnvelope:
-    params = fetch_execute_params_sync(
-        ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.WALLET
-    )
+    if nonce is None:
+        params = fetch_execute_params_sync(
+            ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.WALLET
+        )
+        nonce = params.nonce
     deadline = str(int(time.time()) + _DEPOSIT_WALLET_DEADLINE_S)
     signature = sign_deposit_wallet_batch(
         ctx.signer,
         wallet=ctx.wallet,
         calls=calls,
-        nonce=params.nonce,
+        nonce=nonce,
         deadline=deadline,
         chain_id=ctx.environment.chain_id,
     )
@@ -496,7 +521,7 @@ def build_signed_deposit_wallet_payload_sync(
         deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
-        nonce=params.nonce,
+        nonce=nonce,
         deadline=deadline,
         signature=signature,
         metadata=metadata,

--- a/src/polymarket/_internal/actions/relayer/submit.py
+++ b/src/polymarket/_internal/actions/relayer/submit.py
@@ -51,10 +51,20 @@ def is_retryable_submit_error(error: BaseException) -> bool:
     return submitted < on_chain
 
 
+def onchain_nonce_from_submit_error(error: BaseException) -> str | None:
+    if not isinstance(error, RequestRejectedError) or error.status != 400:
+        return None
+    match = _NONCE_MISMATCH_RE.search(str(error))
+    if match is None:
+        return None
+    return match.group(2)
+
+
 __all__ = [
     "GASLESS_SUBMIT_RETRY_ATTEMPTS",
     "RelayerEnvelope",
     "is_retryable_submit_error",
+    "onchain_nonce_from_submit_error",
     "submit_gasless",
     "submit_gasless_sync",
 ]

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -292,3 +292,62 @@ def test_execute_resubmits_with_fresh_nonce_on_transient_wallet_busy() -> None:
         request for request in relayer_captured if urlparse(str(request.url)).path == _NONCE_PATH
     ]
     assert len(nonce_fetches) == 2
+
+
+def test_execute_self_heals_with_nonce_from_submit_error() -> None:
+    submit_bodies: list[Any] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        submit_bodies.append(json.loads(request.content.decode("utf-8")))
+        if len(submit_bodies) == 1:
+            return httpx.Response(
+                400,
+                json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                request=request,
+            )
+        return httpx.Response(200, json=_SUBMIT_OK, request=request)
+
+    async def run() -> None:
+        client = await make_deposit_client()
+        install_relayer_routes(client, [], _nonce_route(client, nonce="9"))
+        install_combos_handler(client, handler)
+        plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=str(client.wallet)))
+        try:
+            handle = await client.execute_collateral_return_plan(plan=plan)
+            assert handle.transaction_id == "tx-collateral-return"
+        finally:
+            await client.close()
+
+    asyncio.run(run())
+    assert len(submit_bodies) == 2
+    assert submit_bodies[1]["envelope"]["nonce"] == "2"
+
+
+def test_sync_execute_self_heals_with_nonce_from_submit_error() -> None:
+    submit_bodies: list[Any] = []
+
+    def relayer_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"address": "0x0", "nonce": "9"}, request=request)
+
+    def submit_handler(request: httpx.Request) -> httpx.Response:
+        submit_bodies.append(json.loads(request.content.decode("utf-8")))
+        if len(submit_bodies) == 1:
+            return httpx.Response(
+                400,
+                json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                request=request,
+            )
+        return httpx.Response(200, json=_SUBMIT_OK, request=request)
+
+    client = make_sync_deposit_client()
+    install_sync_relayer_handler(client, relayer_handler)
+    install_sync_combos_handler(client, submit_handler)
+    plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=str(client.wallet)))
+    try:
+        handle = client.execute_collateral_return_plan(plan=plan)
+        assert handle.transaction_id == "tx-collateral-return"
+    finally:
+        client.close()
+
+    assert len(submit_bodies) == 2
+    assert submit_bodies[1]["envelope"]["nonce"] == "2"

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -22,7 +22,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import AsyncSecureClient
-from polymarket.errors import UserInputError
+from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.transactions import TransactionHandle
 
 
@@ -352,6 +352,202 @@ def test_approve_erc20_retries_with_fresh_nonce_on_nonce_mismatch() -> None:
     assert submit_bodies[0]["nonce"] == "3"
     assert submit_bodies[1]["nonce"] == "9"
     assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]
+
+
+def test_approve_erc20_self_heals_with_nonce_from_submit_error() -> None:
+    captured: list[httpx.Request] = []
+    submit_attempts = 0
+
+    async def run() -> TransactionHandle:
+        nonlocal submit_attempts
+        client = await make_deposit_client()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal submit_attempts
+            captured.append(request)
+            path = urlparse(str(request.url)).path
+            if path == "/v1/account/transactions/params":
+                return httpx.Response(
+                    200,
+                    json={"address": client._ctx.signer.address, "nonce": "9"},
+                    request=request,
+                )
+            if path == "/submit":
+                submit_attempts += 1
+                if submit_attempts == 1:
+                    return httpx.Response(
+                        400,
+                        json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                        request=request,
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "state": "STATE_NEW",
+                        "transactionHash": None,
+                        "transactionID": "tx-healed",
+                    },
+                    request=request,
+                )
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        try:
+            return await client.approve_erc20(
+                token_address=TOKEN, spender_address=SPENDER, amount=1
+            )
+        finally:
+            await client.close()
+
+    handle = asyncio.run(run())
+    assert handle.transaction_id == "tx-healed"
+    assert submit_attempts == 2
+
+    params_calls = [
+        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
+    ]
+    assert len(params_calls) == 1
+
+    submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert submit_bodies[0]["nonce"] == "9"
+    assert submit_bodies[1]["nonce"] == "2"
+    assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]
+
+
+def test_approve_erc20_raises_unchanged_on_non_nonce_submit_error() -> None:
+    submit_attempts = 0
+
+    async def run() -> None:
+        nonlocal submit_attempts
+        client = await make_deposit_client()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal submit_attempts
+            path = urlparse(str(request.url)).path
+            if path == "/v1/account/transactions/params":
+                return httpx.Response(
+                    200,
+                    json={"address": client._ctx.signer.address, "nonce": "9"},
+                    request=request,
+                )
+            if path == "/submit":
+                submit_attempts += 1
+                return httpx.Response(
+                    400, json={"error": "invalid batch signature"}, request=request
+                )
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        try:
+            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        finally:
+            await client.close()
+
+    with pytest.raises(RequestRejectedError, match="invalid batch signature"):
+        asyncio.run(run())
+    assert submit_attempts == 1
+
+
+def test_approve_erc20_propagates_failure_of_healed_resubmit() -> None:
+    submit_attempts = 0
+
+    async def run() -> None:
+        nonlocal submit_attempts
+        client = await make_deposit_client()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal submit_attempts
+            path = urlparse(str(request.url)).path
+            if path == "/v1/account/transactions/params":
+                return httpx.Response(
+                    200,
+                    json={"address": client._ctx.signer.address, "nonce": "9"},
+                    request=request,
+                )
+            if path == "/submit":
+                submit_attempts += 1
+                if submit_attempts == 1:
+                    return httpx.Response(
+                        400,
+                        json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                        request=request,
+                    )
+                return httpx.Response(
+                    400, json={"error": "invalid batch signature"}, request=request
+                )
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        try:
+            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        finally:
+            await client.close()
+
+    with pytest.raises(RequestRejectedError, match="invalid batch signature"):
+        asyncio.run(run())
+    assert submit_attempts == 2
+
+
+def test_approve_erc20_heals_at_most_once_on_repeated_nonce_mismatch() -> None:
+    captured: list[httpx.Request] = []
+    submit_attempts = 0
+
+    async def run() -> None:
+        nonlocal submit_attempts
+        client = await make_deposit_client()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal submit_attempts
+            captured.append(request)
+            path = urlparse(str(request.url)).path
+            if path == "/v1/account/transactions/params":
+                return httpx.Response(
+                    200,
+                    json={"address": client._ctx.signer.address, "nonce": "9"},
+                    request=request,
+                )
+            if path == "/submit":
+                submit_attempts += 1
+                if submit_attempts == 1:
+                    return httpx.Response(
+                        400,
+                        json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                        request=request,
+                    )
+                if submit_attempts == 2:
+                    return httpx.Response(
+                        400,
+                        json={"error": "batch nonce 2 does not match on-chain nonce 1"},
+                        request=request,
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "state": "STATE_NEW",
+                        "transactionHash": None,
+                        "transactionID": "tx-should-not-happen",
+                    },
+                    request=request,
+                )
+            return httpx.Response(404, request=request)
+
+        install_relayer_handler(client, handler)
+        try:
+            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+        finally:
+            await client.close()
+
+    with pytest.raises(RequestRejectedError, match="does not match on-chain nonce 1"):
+        asyncio.run(run())
+    assert submit_attempts == 2
+
+    params_calls = [
+        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
+    ]
+    assert len(params_calls) == 1
+
+    submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert [body["nonce"] for body in submit_bodies] == ["9", "2"]
 
 
 def test_wait_polls_until_confirmed() -> None:

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -22,7 +22,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import AsyncSecureClient
-from polymarket.errors import RequestRejectedError, UserInputError
+from polymarket.errors import UserInputError
 from polymarket.transactions import TransactionHandle
 
 
@@ -403,151 +403,8 @@ def test_approve_erc20_self_heals_with_nonce_from_submit_error() -> None:
     assert handle.transaction_id == "tx-healed"
     assert submit_attempts == 2
 
-    params_calls = [
-        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
-    ]
-    assert len(params_calls) == 1
-
     submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
-    assert submit_bodies[0]["nonce"] == "9"
     assert submit_bodies[1]["nonce"] == "2"
-    assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]
-
-
-def test_approve_erc20_raises_unchanged_on_non_nonce_submit_error() -> None:
-    submit_attempts = 0
-
-    async def run() -> None:
-        nonlocal submit_attempts
-        client = await make_deposit_client()
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal submit_attempts
-            path = urlparse(str(request.url)).path
-            if path == "/v1/account/transactions/params":
-                return httpx.Response(
-                    200,
-                    json={"address": client._ctx.signer.address, "nonce": "9"},
-                    request=request,
-                )
-            if path == "/submit":
-                submit_attempts += 1
-                return httpx.Response(
-                    400, json={"error": "invalid batch signature"}, request=request
-                )
-            return httpx.Response(404, request=request)
-
-        install_relayer_handler(client, handler)
-        try:
-            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
-        finally:
-            await client.close()
-
-    with pytest.raises(RequestRejectedError, match="invalid batch signature"):
-        asyncio.run(run())
-    assert submit_attempts == 1
-
-
-def test_approve_erc20_propagates_failure_of_healed_resubmit() -> None:
-    submit_attempts = 0
-
-    async def run() -> None:
-        nonlocal submit_attempts
-        client = await make_deposit_client()
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal submit_attempts
-            path = urlparse(str(request.url)).path
-            if path == "/v1/account/transactions/params":
-                return httpx.Response(
-                    200,
-                    json={"address": client._ctx.signer.address, "nonce": "9"},
-                    request=request,
-                )
-            if path == "/submit":
-                submit_attempts += 1
-                if submit_attempts == 1:
-                    return httpx.Response(
-                        400,
-                        json={"error": "batch nonce 9 does not match on-chain nonce 2"},
-                        request=request,
-                    )
-                return httpx.Response(
-                    400, json={"error": "invalid batch signature"}, request=request
-                )
-            return httpx.Response(404, request=request)
-
-        install_relayer_handler(client, handler)
-        try:
-            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
-        finally:
-            await client.close()
-
-    with pytest.raises(RequestRejectedError, match="invalid batch signature"):
-        asyncio.run(run())
-    assert submit_attempts == 2
-
-
-def test_approve_erc20_heals_at_most_once_on_repeated_nonce_mismatch() -> None:
-    captured: list[httpx.Request] = []
-    submit_attempts = 0
-
-    async def run() -> None:
-        nonlocal submit_attempts
-        client = await make_deposit_client()
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal submit_attempts
-            captured.append(request)
-            path = urlparse(str(request.url)).path
-            if path == "/v1/account/transactions/params":
-                return httpx.Response(
-                    200,
-                    json={"address": client._ctx.signer.address, "nonce": "9"},
-                    request=request,
-                )
-            if path == "/submit":
-                submit_attempts += 1
-                if submit_attempts == 1:
-                    return httpx.Response(
-                        400,
-                        json={"error": "batch nonce 9 does not match on-chain nonce 2"},
-                        request=request,
-                    )
-                if submit_attempts == 2:
-                    return httpx.Response(
-                        400,
-                        json={"error": "batch nonce 2 does not match on-chain nonce 1"},
-                        request=request,
-                    )
-                return httpx.Response(
-                    200,
-                    json={
-                        "state": "STATE_NEW",
-                        "transactionHash": None,
-                        "transactionID": "tx-should-not-happen",
-                    },
-                    request=request,
-                )
-            return httpx.Response(404, request=request)
-
-        install_relayer_handler(client, handler)
-        try:
-            await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
-        finally:
-            await client.close()
-
-    with pytest.raises(RequestRejectedError, match="does not match on-chain nonce 1"):
-        asyncio.run(run())
-    assert submit_attempts == 2
-
-    params_calls = [
-        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
-    ]
-    assert len(params_calls) == 1
-
-    submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
-    assert [body["nonce"] for body in submit_bodies] == ["9", "2"]
 
 
 def test_wait_polls_until_confirmed() -> None:

--- a/tests/unit/test_relayer_submit_poll.py
+++ b/tests/unit/test_relayer_submit_poll.py
@@ -8,7 +8,6 @@ from polymarket._internal.actions.relayer.poll import poll_until_terminal
 from polymarket._internal.actions.relayer.submit import (
     RelayerEnvelope,
     is_retryable_submit_error,
-    onchain_nonce_from_submit_error,
     submit_gasless,
 )
 from polymarket.clients._transport import AsyncTransport
@@ -106,22 +105,6 @@ def test_is_retryable_submit_error_classification() -> None:
 
     assert is_retryable_submit_error(RateLimitError("slow down"))
     assert not is_retryable_submit_error(UnexpectedResponseError("bad json"))
-
-
-def test_onchain_nonce_from_submit_error_extraction() -> None:
-    behind = RequestRejectedError("batch nonce 5 does not match on-chain nonce 7", status=400)
-    assert onchain_nonce_from_submit_error(behind) == "7"
-
-    ahead = RequestRejectedError("batch nonce 9 does not match on-chain nonce 7", status=400)
-    assert onchain_nonce_from_submit_error(ahead) == "7"
-
-    unrelated = RequestRejectedError("totally unrelated", status=400)
-    assert onchain_nonce_from_submit_error(unrelated) is None
-
-    server_error = RequestRejectedError("batch nonce 5 does not match on-chain nonce 7", status=500)
-    assert onchain_nonce_from_submit_error(server_error) is None
-
-    assert onchain_nonce_from_submit_error(RateLimitError("slow down")) is None
 
 
 def test_execute_params_rejects_empty_nonce() -> None:

--- a/tests/unit/test_relayer_submit_poll.py
+++ b/tests/unit/test_relayer_submit_poll.py
@@ -8,6 +8,7 @@ from polymarket._internal.actions.relayer.poll import poll_until_terminal
 from polymarket._internal.actions.relayer.submit import (
     RelayerEnvelope,
     is_retryable_submit_error,
+    onchain_nonce_from_submit_error,
     submit_gasless,
 )
 from polymarket.clients._transport import AsyncTransport
@@ -105,6 +106,22 @@ def test_is_retryable_submit_error_classification() -> None:
 
     assert is_retryable_submit_error(RateLimitError("slow down"))
     assert not is_retryable_submit_error(UnexpectedResponseError("bad json"))
+
+
+def test_onchain_nonce_from_submit_error_extraction() -> None:
+    behind = RequestRejectedError("batch nonce 5 does not match on-chain nonce 7", status=400)
+    assert onchain_nonce_from_submit_error(behind) == "7"
+
+    ahead = RequestRejectedError("batch nonce 9 does not match on-chain nonce 7", status=400)
+    assert onchain_nonce_from_submit_error(ahead) == "7"
+
+    unrelated = RequestRejectedError("totally unrelated", status=400)
+    assert onchain_nonce_from_submit_error(unrelated) is None
+
+    server_error = RequestRejectedError("batch nonce 5 does not match on-chain nonce 7", status=500)
+    assert onchain_nonce_from_submit_error(server_error) is None
+
+    assert onchain_nonce_from_submit_error(RateLimitError("slow down")) is None
 
 
 def test_execute_params_rejects_empty_nonce() -> None:

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -770,3 +770,45 @@ def test_gasless_submit_retries_on_retryable_400_then_succeeds() -> None:
     assert handle.transaction_id == "tx-retry"
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     assert len(submit_calls) == 2
+
+
+def test_gasless_submit_self_heals_with_nonce_from_submit_error() -> None:
+    captured: list[httpx.Request] = []
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = urlparse(str(request.url)).path
+        if path == "/v1/account/transactions/params":
+            return httpx.Response(200, json={"address": "0xRELAY", "nonce": "9"}, request=request)
+        if path == "/submit":
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(
+                    400,
+                    json={"error": "batch nonce 9 does not match on-chain nonce 2"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "state": "STATE_NEW",
+                    "transactionHash": None,
+                    "transactionID": "tx-healed",
+                },
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    with make_sync_deposit_client() as client:
+        install_sync_relayer_handler(client, handler)
+        handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
+
+    assert handle.transaction_id == "tx-healed"
+    params_calls = [
+        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
+    ]
+    assert len(params_calls) == 1
+    submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
+    assert [body["nonce"] for body in submit_bodies] == ["9", "2"]
+    assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -805,10 +805,6 @@ def test_gasless_submit_self_heals_with_nonce_from_submit_error() -> None:
         handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
 
     assert handle.transaction_id == "tx-healed"
-    params_calls = [
-        r for r in captured if urlparse(str(r.url)).path == "/v1/account/transactions/params"
-    ]
-    assert len(params_calls) == 1
     submit_bodies = [request_json(r) for r in captured if urlparse(str(r.url)).path == "/submit"]
-    assert [body["nonce"] for body in submit_bodies] == ["9", "2"]
-    assert submit_bodies[0]["signature"] != submit_bodies[1]["signature"]
+    assert len(submit_bodies) == 2
+    assert submit_bodies[1]["nonce"] == "2"


### PR DESCRIPTION
DEV-494.

When the relayer rejects a deposit-wallet gasless /submit with "batch nonce X does not match on-chain nonce Y" (wrong nonce from /v1/account/transactions/params for EOAs with two deposit wallets), the SDK re-signs the batch with the nonce reported in the error and resubmits once. All other errors propagate unchanged.

The same heal covers the collateral-return submit, since combos-rfq proxies the relayer rejection verbatim. Scope note: there it heals the simulation-passes/relayer-rejects race window only — the two-wallet cohort's deterministic wrong nonce still fails the service's Tenderly simulation with a 409 before reaching the relayer, so that cohort needs the server-side fix (CHA-381).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signing and submission for deposit-wallet gasless flows; behavior is narrowly scoped to one error pattern and wallet type, with a single retry.
> 
> **Overview**
> When a **deposit wallet** gasless submit fails with a 400 whose message matches `batch nonce X does not match on-chain nonce Y`, the SDK now **re-signs once** using the **on-chain nonce from the error** and resubmits instead of failing or only relying on a fresh `/v1/account/transactions/params` fetch.
> 
> `onchain_nonce_from_submit_error` parses that nonce from `RequestRejectedError`; `build_signed_deposit_wallet_payload` (async/sync) accepts an optional `nonce` to skip refetching. The same catch-and-resubmit path applies to relayer `/submit` (`gasless.py`) and collateral-return combos submit (`combos.py`). **Proxy/Safe and other errors are unchanged.**
> 
> Unit tests cover async/sync approve ERC20, collateral return execute, and sync gasless workflows when params return a stale nonce but the rejection exposes the correct on-chain value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08b6ab6017cdf50f3a026493763736ed0b070b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->