### PR TITLE
chore: update uv.lock for 0.3.0b1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -892,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-client"
-version = "0.2.0"
+version = "0.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "eth-abi" },


### PR DESCRIPTION
Regenerates uv.lock after the version bump to 0.3.0b1, fixing the `uv sync --locked` CI failure on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only version alignment with no runtime or dependency changes.
> 
> **Overview**
> Updates **`uv.lock`** so the editable **`polymarket-client`** entry matches **`0.3.0b1`** (was **`0.2.0`**), keeping the lockfile in sync with the version bump and restoring **`uv sync --locked`** in CI.
> 
> No dependency graph or hash changes beyond that version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8247de307f98ef887d4ca8944473f5f858ba8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->