### PR TITLE
chore: remove stale release-as pin from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,7 @@
       "changelog-path": "CHANGELOG.md",
       "versioning": "prerelease",
       "prerelease": true,
-      "prerelease-type": "b",
-      "release-as": "0.3.0-b1"
+      "prerelease-type": "b"
     }
   }
 }


### PR DESCRIPTION
The `release-as: 0.3.0-b1` pin was added for the previous release (#210) and never removed, so release-please keeps proposing 0.3.0-b1 (#217) even though the `polymarket-client-v0.3.0-b1` tag already exists and 0.3.0b1 is already on PyPI. Merging #217 as-is would fail on tag creation / PyPI upload.

Removing the pin lets release-please compute the next prerelease version (0.3.0-b2) for the two fixes landed since the tag (d711cd1, c426bc7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation config only; no runtime or library behavior changes.
> 
> **Overview**
> Removes the **`release-as`: `0.3.0-b1`** entry from `release-please-config.json` so release-please is no longer forced to propose that version.
> 
> With **`prerelease`** / **`prerelease-type`: `b`** unchanged, the next release PR should pick up the next beta (e.g. **0.3.0-b2**) instead of re-opening **0.3.0-b1**, which is already tagged and on PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4422eee6e488a718b45e073608b1a42bf1d49263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->