### PR TITLE
docs: clarify async-only WebSocket features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@
 
 ## Client Sync/Async Design
 
-- The default public clients should be synchronous: use `PublicClient` and `SecureClient` for normal imports, docs, examples, notebooks, scripts, and basic bot usage.
+- For request/response workflows supported by both client modes, the default public clients should be synchronous: use `PublicClient` and `SecureClient` for normal imports, docs, examples, notebooks, scripts, and basic bot usage.
 - Async clients should be explicit alternatives named with an `Async` prefix, such as `AsyncPublicClient` and `AsyncSecureClient`.
-- Keep sync and async method names the same where possible: sync methods return values directly, async methods return awaitables and are called with `await`.
+- WebSocket-backed features are intentionally async-only. This includes realtime subscriptions and any Perps or combo workflow that requires a persistent WebSocket connection or session. Expose these workflows through the `Async` clients and use the async clients in their docs and examples.
+- Do not add synchronous facades, placeholder methods, or event-loop bridges solely to create sync parity for WebSocket-only features.
+- Keep sync and async method names the same for features implemented in both modes: sync methods return values directly, async methods return awaitables and are called with `await`. Async-only WebSocket features do not require a matching sync method.
 - Avoid mixed-mode clients with flags such as `async_mode=True`, and avoid adding `_async` method variants to synchronous clients by default.
 - Share business logic between sync and async implementations. Request construction, URL/path selection, auth/signing, serialization, validation, response parsing, models, and endpoint namespace structure should be reusable.
 - Keep the transport boundary separate: synchronous clients should use a synchronous transport, and async clients should use an asynchronous transport.


### PR DESCRIPTION
## Summary

- keep synchronous clients as the default for request/response workflows supported in both modes
- document WebSocket-backed subscriptions and applicable Perps/combo workflows as intentionally async-only
- clarify that async-only WebSocket features do not need sync placeholders, facades, or event-loop bridges
- require async clients in documentation and examples for those workflows

## Why

The previous guidance implied that every async capability should have a synchronous equivalent. Persistent WebSocket connections and sessions are not viable through the SDK's synchronous interface, so that interpretation incorrectly flags intentional async-only features such as realtime subscriptions.

## Developer impact

Future reviews should require sync/async parity for shared request/response APIs while allowing WebSocket-dependent functionality to remain on `AsyncPublicClient` and `AsyncSecureClient`.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance; no runtime or API behavior changes.
> 
> **Overview**
> Updates **Client Sync/Async Design** in `AGENTS.md` so sync defaults apply only to **request/response** APIs that exist in both modes, not to every async capability.
> 
> **WebSocket-backed** work (realtime subscriptions, Perps/combo flows that need a persistent connection) is documented as **async-only** on `AsyncPublicClient` / `AsyncSecureClient`, with docs and examples required to use those clients. The guide explicitly forbids sync facades, placeholder methods, or event-loop bridges just to fake sync parity, and states that async-only WebSocket features **do not** need matching sync method names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d8f386effb0bacb81e22110dcef28b187a6263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->