### PR TITLE
fix: include deposits and withdrawals in list_activity by default

### DIFF
--- a/src/polymarket/_internal/actions/data.py
+++ b/src/polymarket/_internal/actions/data.py
@@ -432,11 +432,7 @@ def list_activity_spec(
 
     # The service defaults excludeDepositsWithdrawals=true and drops DEPOSIT and
     # WITHDRAWAL from the type filter even when requested explicitly, so opt out
-    # of the exclusion whenever the caller asks for those types.
-    exclude_deposits_withdrawals: bool | None = None
-    if activity_types is not None and {"DEPOSIT", "WITHDRAWAL"} & set(activity_types):
-        exclude_deposits_withdrawals = False
-
+    # unconditionally and let the type filter decide which rows come back.
     return OffsetPaginatedSpec(
         service="data",
         path="/activity",
@@ -448,7 +444,7 @@ def list_activity_spec(
                 "market": market,
                 "eventId": event_id,
                 "type": activity_types,
-                "excludeDepositsWithdrawals": exclude_deposits_withdrawals,
+                "excludeDepositsWithdrawals": False,
                 "start": start,
                 "end": end,
                 "sortBy": sort_by,

--- a/tests/unit/test_data_paginated_specs.py
+++ b/tests/unit/test_data_paginated_specs.py
@@ -210,7 +210,15 @@ def test_list_activity_spec_disables_deposit_withdrawal_exclusion(
     }
 
 
-def test_list_activity_spec_keeps_exclusion_default_for_other_types() -> None:
+def test_list_activity_spec_disables_exclusion_by_default() -> None:
+    spec = data_actions.list_activity_spec(user="0xWALLET")
+    assert spec.base_params == {
+        "user": "0xWALLET",
+        "excludeDepositsWithdrawals": False,
+    }
+
+
+def test_list_activity_spec_disables_exclusion_for_other_types() -> None:
     spec = data_actions.list_activity_spec(
         user="0xWALLET",
         activity_types=["TAKER_REBATE", "MAKER_REBATE"],
@@ -218,6 +226,7 @@ def test_list_activity_spec_keeps_exclusion_default_for_other_types() -> None:
     assert spec.base_params == {
         "user": "0xWALLET",
         "type": "TAKER_REBATE,MAKER_REBATE",
+        "excludeDepositsWithdrawals": False,
     }
 
 
@@ -241,6 +250,7 @@ def test_list_activity_spec_serializes_filters() -> None:
     assert spec.base_params == {
         "user": "0xWALLET",
         "type": "TRADE,REWARD",
+        "excludeDepositsWithdrawals": False,
         "sortBy": "TIMESTAMP",
         "sortDirection": "DESC",
     }


### PR DESCRIPTION
Twin of Polymarket/ts-sdk#246. list_activity now always sends excludeDepositsWithdrawals=false instead of only when the type filter includes DEPOSIT or WITHDRAWAL, so a plain list_activity(user=...) call returns all activity types, deposits and withdrawals included. The activity_types filter alone decides which rows come back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side query-parameter change for read-only activity listing; no auth or write paths.
> 
> **Overview**
> **`list_activity`** now always passes **`excludeDepositsWithdrawals=false`** to the data API, instead of only when **`activity_types`** includes **`DEPOSIT`** or **`WITHDRAWAL`**.
> 
> Because the upstream service defaults to excluding deposits and withdrawals, an unfiltered **`list_activity(user=...)`** call now returns the full activity feed (including cash movements). When callers set **`activity_types`**, that filter alone controls which rows are returned; the exclusion flag no longer stays at the service default for non-deposit/withdrawal filters.
> 
> Unit tests were updated to expect **`excludeDepositsWithdrawals: False`** for the default case, deposit/withdrawal filters, and other activity types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 581c9ac88eebc503272ed4ba0b7fadd875e89a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->