### PR TITLE
feat: prepare Python SDK for stable 0.3.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "package-name": "polymarket-client",
       "changelog-path": "CHANGELOG.md",
       "versioning": "prerelease",
-      "prerelease": true,
+      "prerelease": false,
       "prerelease-type": "b"
     }
   }


### PR DESCRIPTION
Graduates the Python SDK from beta prereleases to the stable `0.3.0`.

- Sets `"prerelease": false` in `release-please-config.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single release-automation flag change with no runtime SDK or security impact; only affects how the next version is tagged and published.
> 
> **Overview**
> **Graduates the Python SDK** from beta prereleases to the next **stable** release (**`0.3.0`**) by turning off release-please’s prerelease publishing mode.
> 
> In `release-please-config.json`, **`prerelease`** is set from **`true`** to **`false`**. The **`prerelease`** versioning strategy and **`b`** prerelease type stay in place so future beta cycles can still be configured the same way. After merge, release-please should refresh its release PR so the manifest and packaging target **`0.3.0`** instead of a **`0.3.0-b*`** prerelease (mirroring how earlier betas graduated to stable **`0.1.0`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f67eeb11a1880250e46338ae5185ee3fa605106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->