### PR TITLE
feat: support isolated margin adjustments

### DIFF
--- a/src/polymarket/_internal/actions/perps/trading.py
+++ b/src/polymarket/_internal/actions/perps/trading.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from polymarket.errors import UserInputError
 from polymarket.models.perps.requests import (
+    DecimalInput,
     PerpsOrderRequest,
     PerpsPositionTpSlTrigger,
     PerpsTpSlTrigger,
@@ -110,6 +111,14 @@ def update_leverage_op(*, instrument_id: int, leverage: int, cross_margin: bool)
     return ["updateLeverage", [instrument_id, leverage, cross_margin]]
 
 
+def update_margin_op(*, instrument_id: int, amount: DecimalInput) -> list[Any]:
+    if isinstance(instrument_id, bool) or not isinstance(instrument_id, int):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise UserInputError("instrument_id must be an int")
+    if instrument_id < 0:
+        raise UserInputError("instrument_id must be non-negative")
+    return ["updateMargin", [instrument_id, to_decimal_string("amount", amount)]]
+
+
 def to_command_body_op(op: Sequence[Any]) -> dict[str, Any]:
     """Convert a signed positional op into the keyed frame body op."""
     op_type = op[0]
@@ -136,6 +145,9 @@ def to_command_body_op(op: Sequence[Any]) -> dict[str, Any]:
             "type": op_type,
             "args": {"cross": cross_margin, "iid": instrument_id, "lev": leverage},
         }
+    if op_type == "updateMargin":
+        instrument_id, amount = op[1]
+        return {"type": op_type, "args": {"amt": amount, "iid": instrument_id}}
     raise RuntimeError(f"Unsupported Perps command: {op_type!r}")
 
 
@@ -171,4 +183,5 @@ __all__ = [
     "to_raw_order",
     "to_raw_tp_sl_order",
     "update_leverage_op",
+    "update_margin_op",
 ]

--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -28,6 +28,7 @@ from polymarket._internal.actions.perps.trading import (
     to_raw_order,
     to_raw_tp_sl_order,
     update_leverage_op,
+    update_margin_op,
 )
 from polymarket._internal.streams.perps.heartbeat import PerpsWebSocketHeartbeat
 from polymarket._internal.streams.reconnect import ReconnectScheduler
@@ -549,6 +550,18 @@ class PerpsSession:
             op,
             parse=PerpsUpdateLeverageResult.parse_response,
             timeout_message="Perps update leverage response timed out.",
+        )
+
+    async def update_margin(self, *, instrument_id: int, amount: DecimalInput) -> None:
+        """Adjust isolated margin for an instrument position.
+
+        Positive amounts add margin; negative amounts remove it.
+        """
+        op = update_margin_op(instrument_id=instrument_id, amount=amount)
+        await self._send_signed_command(
+            op,
+            parse=_parse_session_ack,
+            timeout_message="Perps update margin response timed out.",
         )
 
     async def fetch_balances(self) -> tuple[PerpsBalance, ...]:

--- a/tests/unit/test_perps_session.py
+++ b/tests/unit/test_perps_session.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -15,7 +16,7 @@ from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket._internal.perps_session import PerpsSession
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import RequestRejectedError, TransportError
+from polymarket.errors import RequestRejectedError, TransportError, UserInputError
 from polymarket.models.perps.credentials import PerpsCredentials
 from polymarket.models.perps.events import (
     PerpsFillEvent,
@@ -459,6 +460,83 @@ def test_cancel_all_orders_uses_signed_rest_endpoint() -> None:
     unscoped_body = json.loads(captured[1].content)
     assert unscoped_body["op"] == {"type": "cancelAll", "args": {}}
     assert "exp" not in unscoped_body
+
+
+def test_update_margin_sends_signed_command_and_completes() -> None:
+    commands: list[dict[str, Any]] = []
+
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        async for raw in ws:
+            message = json.loads(raw)
+            if _is_ping(message):
+                continue
+            commands.append(message)
+            await ws.send(json.dumps({"id": message["id"], "data": {"status": "ok"}}))
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            result = await session.update_margin(
+                instrument_id=3, amount=Decimal("100.000000000000000001")
+            )
+            assert result is None
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+    assert commands[0]["op"] == {
+        "type": "updateMargin",
+        "args": {"amt": "100.000000000000000001", "iid": 3},
+    }
+    assert commands[0]["req"] == "post"
+    assert commands[0]["sig"].startswith("0x") and len(commands[0]["sig"]) == 132
+
+
+def test_update_margin_rejection_surfaces_request_rejected_error() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        async for raw in ws:
+            message = json.loads(raw)
+            if _is_ping(message):
+                continue
+            assert message["op"] == {
+                "type": "updateMargin",
+                "args": {"amt": "-25.00", "iid": 3},
+            }
+            await ws.send(
+                json.dumps(
+                    {
+                        "id": message["id"],
+                        "data": {"status": "err", "error": "margin_below_required_initial"},
+                    }
+                )
+            )
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            with pytest.raises(RequestRejectedError, match="margin_below_required_initial"):
+                await session.update_margin(instrument_id=3, amount="-25.00")
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
+def test_update_margin_validates_public_inputs_before_sending() -> None:
+    async def run() -> None:
+        session = PerpsSession(
+            chain_id=137,
+            credentials=_CREDENTIALS,
+            rest_url="http://127.0.0.1:9",
+            ws_url="ws://127.0.0.1:9",
+        )
+        try:
+            with pytest.raises(UserInputError, match="non-negative"):
+                await session.update_margin(instrument_id=-1, amount="1")
+            with pytest.raises(UserInputError, match="amount must be a valid decimal"):
+                await session.update_margin(instrument_id=1, amount="not-a-decimal")
+            with pytest.raises(UserInputError, match="amount must be finite"):
+                await session.update_margin(instrument_id=1, amount="NaN")
+        finally:
+            await session.close()
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
 
 
 def test_sequence_gap_emits_resync_event_before_update() -> None:

--- a/tests/unit/test_perps_signing_golden.py
+++ b/tests/unit/test_perps_signing_golden.py
@@ -114,6 +114,17 @@ _OP_VECTORS: list[dict[str, Any]] = [
         ),
     },
     {
+        "name": "updateMargin",
+        "op": ["updateMargin", [3, "-25.000000000000000001"]],
+        "salt": 8,
+        "timestamp": 1751500000006,
+        "data": "0x1bceee4cd50ae288f5ae7e993deeea51fe9dd41b5eff27840455ed72e72d4f4c",
+        "signature": (
+            "0xfd6ec2ee47423b3f87adfc64eadd9764180e05102efadb112403016a446d072d"
+            "497ec201b2df1e7944f465c9c734d3698b80dbe51a42eb8167a7a54e4249dfc81b"
+        ),
+    },
+    {
         "name": "deleteProxy",
         "op": ["deleteProxy", ["0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"]],
         "salt": 55,

--- a/tests/unit/test_perps_trading_commands.py
+++ b/tests/unit/test_perps_trading_commands.py
@@ -1,5 +1,6 @@
 """Perps trading command construction tests."""
 
+from decimal import Decimal
 from typing import Any, cast
 
 import pytest
@@ -14,6 +15,7 @@ from polymarket._internal.actions.perps.trading import (
     to_raw_order,
     to_raw_tp_sl_order,
     update_leverage_op,
+    update_margin_op,
 )
 from polymarket.errors import UserInputError
 from polymarket.models.perps.requests import (
@@ -147,6 +149,24 @@ def test_cancel_and_leverage_ops() -> None:
     assert to_command_body_op(
         update_leverage_op(instrument_id=3, leverage=20, cross_margin=True)
     ) == {"type": "updateLeverage", "args": {"cross": True, "iid": 3, "lev": 20}}
+
+
+@pytest.mark.parametrize(
+    ("amount", "wire_amount"),
+    [
+        (Decimal("100.000000000000000001"), "100.000000000000000001"),
+        ("-25.000000000000000001", "-25.000000000000000001"),
+    ],
+)
+def test_update_margin_op_preserves_signed_decimal_amount(
+    amount: Decimal | str, wire_amount: str
+) -> None:
+    op = update_margin_op(instrument_id=3, amount=amount)
+    assert op == ["updateMargin", [3, wire_amount]]
+    assert to_command_body_op(op) == {
+        "type": "updateMargin",
+        "args": {"amt": wire_amount, "iid": 3},
+    }
 
 
 def test_gtc_order_requires_price() -> None:


### PR DESCRIPTION
## Summary

- add async `PerpsSession.update_margin` for positive and negative isolated-margin adjustments
- preserve decimal precision across command serialization and signing
- validate public inputs and surface rejected acknowledgements through existing Perps errors

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration"` (1,982 tests)
- `uv build`

Live mutation testing was not performed because production feature-flag enablement was not independently confirmed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Signed trading commands that move margin can affect liquidation risk; changes are scoped to a new op parallel to `updateLeverage` with solid test coverage.
> 
> **Overview**
> Adds **isolated margin adjustments** on `PerpsSession`: callers can add or remove margin per instrument with signed `updateMargin` WebSocket commands.
> 
> The trading layer introduces `update_margin_op` and wires `to_command_body_op` to emit `amt` / `iid` args. Amounts go through `to_decimal_string` so signed decimals keep full precision on the wire and in EIP-712 signing. Input checks cover non-negative `instrument_id` and valid finite decimals; server rejections (e.g. `margin_below_required_initial`) surface as `RequestRejectedError` like other session commands.
> 
> Unit coverage includes command serialization, a TypeScript-aligned signing golden vector, and session tests for happy path, rejection, and pre-send validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7155918966e59d1eb0dee777f977a5a8a57f27a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->