### PR TITLE
docs(repo): add review method guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,20 @@
 
 - Use `uv` for dependency management, testing, and builds.
 
+## Review Method
+
+- Review from the developer workflow inward. Start by understanding what the consumer is trying to accomplish and inspect realistic usage examples.
+- Build a complete mental model before judging the implementation. Clarify terminology, lifecycle, ownership, and failure behavior.
+- Review the public contract first: naming, symmetry, defaults, state representation, validation, errors, and call-site ergonomics.
+- Separate SDK behavior, integrator behavior, documentation examples, and backend behavior. Attach findings to the layer that owns them.
+- Compare questionable code with established repository patterns before requesting a change.
+- Evaluate findings by practical impact. Downgrade or discard concerns when the risk is bounded and the proposed complexity is not justified.
+- Prefer tests that prove meaningful boundaries. Favor one live integration workflow over multiple mocks when a safe test environment exists.
+- Use mocks for conditions that cannot reasonably be produced through integration testing.
+- Distinguish demonstrated bugs, contract problems, missing regression coverage, and optional hardening.
+- Revisit initial findings as understanding improves rather than defending the first interpretation.
+- Keep review comments short, human, line-specific, and actionable.
+
 ## SDK Design
 
 - Keep the PyPI distribution name as `polymarket-client` and the import package as `polymarket` unless explicitly changed.


### PR DESCRIPTION
## Summary

- add a workflow-first review method to `AGENTS.md`
- clarify ownership, practical-impact, and testing-boundary expectations
- require concise actionable comments and reassessment as context improves

## Verification

- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions with no runtime, API, or security impact.
> 
> **Overview**
> Adds a new **Review Method** section to `AGENTS.md` between Tooling and SDK Design, defining how agents should approach code review.
> 
> The guidance pushes a workflow-first mindset: understand consumer goals and realistic usage before diving into implementation, build a mental model of terminology/lifecycle/ownership/failures, and prioritize the public contract (naming, defaults, validation, errors, ergonomics). It also asks reviewers to attribute issues to the right layer (SDK vs integrator vs docs vs backend), weigh findings by practical impact, prefer integration tests over mocks when safe, and keep comments short and actionable while revisiting early conclusions as context improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb094035a7bdaf09ce9ad94b85e33531a89741f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->