### PR TITLE
docs(repo): document tick-size platform invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@
 - Do not rename existing variables, functions, or classes unless the operator explicitly asks for it in the prompt. Keep PRs lean; if a name looks wrong, propose the rename as a separate change instead of bundling it.
 - Avoid reuse that does not carry semantic or domain-specific value. Do not add boolean mode flags or generic helpers that hide distinct behavior behind one function; prefer separate explicit helpers whose names describe the behavior they implement.
 
+## Platform Invariants
+
+- A market's minimum tick size may become finer, such as `0.01` to `0.001`, but it cannot become coarser, such as `0.001` to `0.01`. SDK caching and recovery logic may rely on this monotonic behavior and should not add defensive handling for tick-size coarsening.
+
 ## Client Sync/Async Design
 
 - For request/response workflows supported by both client modes, the default public clients should be synchronous: use `PublicClient` and `SecureClient` for normal imports, docs, examples, notebooks, scripts, and basic bot usage.


### PR DESCRIPTION
## Summary

- document that market minimum tick sizes may become finer but cannot become coarser
- clarify that SDK caching and recovery logic should not defend against impossible coarsening transitions

## Verification

- `git diff --check`
- Documentation-only change; tests not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a **Platform Invariants** section to `AGENTS.md` so agents and contributors share the same assumptions about market tick sizes.
> 
> It states that a market’s minimum tick size may only move **finer** (e.g. `0.01` → `0.001`), never **coarser**, and that SDK caching and recovery logic may depend on that monotonicity—**without** building defensive handling for impossible coarsening transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6021381ec2731414e9350b255954ea2b25c5b2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->