### PR TITLE
refactor(models): expose CLOB market read types

### DIFF
--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,12 +1,13 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from typing import cast
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError, field_validator
 
 from polymarket._internal.request import QueryParamValue
 from polymarket._internal.validation import require_nonempty
 from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob import (
     LastTradePrice,
@@ -16,33 +17,69 @@ from polymarket.models.clob import (
     PriceHistoryPoint,
     PriceRequest,
 )
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderSide, TokenId
 
 
 class _MidpointResponse(BaseModel):
-    mid: _DecimalFromString
+    mid: Decimal
+
+    @field_validator("mid", mode="before")
+    @classmethod
+    def _parse_mid(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class _PriceResponse(BaseModel):
-    price: _DecimalFromString
+    price: Decimal
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class _SpreadResponse(BaseModel):
-    spread: _DecimalFromString
+    spread: Decimal
+
+    @field_validator("spread", mode="before")
+    @classmethod
+    def _parse_spread(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
-_SpreadsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
-_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, _DecimalFromString]])
+_MidpointsAdapter = TypeAdapter(dict[TokenId, Decimal])
+_SpreadsAdapter = TypeAdapter(dict[TokenId, Decimal])
+_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, Decimal]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])
+
+
+def _parse_decimal_mapping(data: object) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    return {
+        key: parse_decimal_string(value)
+        for key, value in cast(Mapping[object, object], data).items()
+    }
+
+
+def _parse_prices_mapping(data: object) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    parsed: dict[object, object] = {}
+    for token_id, prices in cast(Mapping[object, object], data).items():
+        if not isinstance(prices, Mapping):
+            parsed[token_id] = prices
+            continue
+        parsed[token_id] = {
+            side: parse_decimal_string(value)
+            for side, value in cast(Mapping[object, object], prices).items()
+        }
+    return parsed
 
 
 def _require_string_token_id(token_id: object) -> str:
@@ -112,8 +149,8 @@ def build_midpoints_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict
 
 def parse_midpoints(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _MidpointsAdapter.validate_python(data)
-    except ValidationError as error:
+        return _MidpointsAdapter.validate_python(_parse_decimal_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("midpoints response did not match expected shape") from error
 
 
@@ -134,8 +171,8 @@ def build_prices_request(*, requests: Sequence[PriceRequest]) -> tuple[str, list
 
 def parse_prices(data: object) -> dict[TokenId, dict[OrderSide, Decimal]]:
     try:
-        return _PricesAdapter.validate_python(data)
-    except ValidationError as error:
+        return _PricesAdapter.validate_python(_parse_prices_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("prices response did not match expected shape") from error
 
 
@@ -176,8 +213,8 @@ def build_spreads_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict[s
 
 def parse_spreads(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _SpreadsAdapter.validate_python(data)
-    except ValidationError as error:
+        return _SpreadsAdapter.validate_python(_parse_decimal_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("spreads response did not match expected shape") from error
 
 

--- a/src/polymarket/models/clob/last_trade.py
+++ b/src/polymarket/models/clob/last_trade.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
+from pydantic import field_validator
+
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderSide, TokenId
 
 
 class LastTradePrice(BaseModel):
-    price: _DecimalFromString
+    price: Decimal
     side: OrderSide
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class LastTradePriceForToken(BaseModel):
     token_id: TokenId
-    price: _DecimalFromString
+    price: Decimal
     side: OrderSide
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 __all__ = ["LastTradePrice", "LastTradePriceForToken"]

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import Field, field_validator
 
 from polymarket._frames_bridge import frames_func as _frames_func
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, TokenId
 
@@ -17,8 +19,13 @@ _DecimalMode = Literal["decimal", "float"]
 
 
 class OrderBookLevel(BaseModel):
-    price: _DecimalFromString
-    size: _DecimalFromString
+    price: Decimal
+    size: Decimal
+
+    @field_validator("price", "size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class OrderBook(BaseModel):
@@ -30,21 +37,31 @@ class OrderBook(BaseModel):
         description="CTF condition id for the market represented by this order book.",
     )
     token_id: TokenId = Field(validation_alias="asset_id")
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     bids: tuple[OrderBookLevel, ...]
     """Ascending price order, lowest bid first."""
     asks: tuple[OrderBookLevel, ...]
     """Descending price order, highest ask first."""
-    min_order_size: _DecimalFromString
-    tick_size: _DecimalFromString
+    min_order_size: Decimal
+    tick_size: Decimal
     neg_risk: bool
-    last_trade_price: _DecimalFromString | None = None
+    last_trade_price: Decimal | None = None
     hash: str
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
+
+    @field_validator("min_order_size", "tick_size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
     @field_validator("last_trade_price", mode="before")
     @classmethod
     def _parse_last_trade_price(cls, value: object) -> object:
-        return None if value in (None, "") else value
+        return parse_decimal_string(None if value == "" else value)
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import MappingProxyType
 from typing import assert_type
 
 import pytest
@@ -143,6 +144,15 @@ def test_parse_midpoints_rejects_numeric_value() -> None:
         parse_midpoints({"1": 0.5})  # type: ignore[dict-item]
 
 
+def test_parse_midpoints_rejects_numeric_value_in_generic_mapping() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_midpoints(MappingProxyType({"1": 0.5}))
+
+
+def test_parse_midpoints_accepts_existing_decimal_value() -> None:
+    assert parse_midpoints({"1": Decimal("0.5")}) == {TokenId("1"): Decimal("0.5")}
+
+
 def test_parse_midpoint_rejects_numeric_mid_value() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_midpoint({"mid": 0.5})
@@ -233,6 +243,21 @@ def test_parse_prices_returns_nested_decimal_dict() -> None:
     assert result == {TokenId("1"): {"BUY": Decimal("0.52"), "SELL": Decimal("0.53")}}
 
 
+def test_parse_prices_rejects_numeric_value() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_prices({"1": {"BUY": 0.52}})  # type: ignore[dict-item]
+
+
+def test_parse_prices_rejects_numeric_value_in_nested_generic_mapping() -> None:
+    prices = MappingProxyType({"BUY": 0.52})
+    with pytest.raises(UnexpectedResponseError):
+        parse_prices(MappingProxyType({"1": prices}))
+
+
+def test_parse_prices_accepts_existing_decimal_value() -> None:
+    assert parse_prices({"1": {"BUY": Decimal("0.52")}}) == {TokenId("1"): {"BUY": Decimal("0.52")}}
+
+
 def test_parse_prices_rejects_invalid_side_key() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_prices({"1": {"HOLD": "0.5"}})
@@ -285,6 +310,12 @@ def test_parse_order_book_accepts_null_timestamp_and_null_last_trade_price() -> 
     assert book.last_trade_price is None
 
 
+def test_parse_order_book_accepts_empty_last_trade_price() -> None:
+    book = parse_order_book({**_ORDER_BOOK_PAYLOAD, "last_trade_price": ""})
+
+    assert book.last_trade_price is None
+
+
 def test_parse_order_book_accepts_missing_timestamp_and_last_trade_price() -> None:
     payload = {
         k: v for k, v in _ORDER_BOOK_PAYLOAD.items() if k not in ("timestamp", "last_trade_price")
@@ -305,6 +336,14 @@ def test_parse_order_book_rejects_malformed_timestamp() -> None:
 
 @pytest.mark.parametrize("bad_value", [" 1716000000000", "1716000000000 ", "+1", "-1"])
 def test_parse_order_book_rejects_loose_numeric_timestamp_strings(bad_value: str) -> None:
+    payload = {**_ORDER_BOOK_PAYLOAD, "timestamp": bad_value}
+
+    with pytest.raises(UnexpectedResponseError):
+        parse_order_book(payload)
+
+
+@pytest.mark.parametrize("bad_value", [1716000000000, 1716000000000.0, True])
+def test_parse_order_book_rejects_non_string_timestamp_values(bad_value: object) -> None:
     payload = {**_ORDER_BOOK_PAYLOAD, "timestamp": bad_value}
 
     with pytest.raises(UnexpectedResponseError):
@@ -412,6 +451,15 @@ def test_parse_spreads_returns_decimal_keyed_by_token_id() -> None:
     assert result == {TokenId("1"): Decimal("0.02")}
 
 
+def test_parse_spreads_rejects_numeric_value() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_spreads({"1": 0.02})  # type: ignore[dict-item]
+
+
+def test_parse_spreads_accepts_existing_decimal_value() -> None:
+    assert parse_spreads({"1": Decimal("0.02")}) == {TokenId("1"): Decimal("0.02")}
+
+
 def test_build_last_trade_price_request_targets_last_trade_price_path() -> None:
     path, params = build_last_trade_price_request(token_id="123")
 
@@ -424,6 +472,11 @@ def test_parse_last_trade_price_returns_model() -> None:
 
     assert result.price == Decimal("0.53")
     assert result.side == "BUY"
+
+
+def test_parse_last_trade_price_rejects_numeric_price() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_last_trade_price({"price": 0.53, "side": "BUY"})
 
 
 def test_parse_last_trade_price_rejects_invalid_side() -> None:

--- a/tests/unit/test_decimal_field_contract.py
+++ b/tests/unit/test_decimal_field_contract.py
@@ -1,10 +1,13 @@
+import inspect
+from datetime import datetime
 from decimal import Decimal
 from typing import get_type_hints
 
 import pytest
 
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.clob.order_book import OrderBookLevel
+from polymarket.models.clob.last_trade import LastTradePrice, LastTradePriceForToken
+from polymarket.models.clob.order_book import OrderBook, OrderBookLevel
 from polymarket.models.rtds_events import CryptoPricesChainlinkTwapPayload, PriceUpdatePayload
 
 
@@ -14,9 +17,28 @@ class TestStrictStringFieldsExposeBareDecimal:
         assert OrderBookLevel.model_fields["size"].annotation is Decimal
 
     def test_get_type_hints_resolves_to_bare_decimal(self) -> None:
-        hints = get_type_hints(OrderBookLevel)
+        hints = get_type_hints(OrderBookLevel, include_extras=True)
         assert hints["price"] is Decimal
         assert hints["size"] is Decimal
+
+    @pytest.mark.parametrize(
+        ("model", "field", "annotation"),
+        [
+            (OrderBookLevel, "price", Decimal),
+            (OrderBookLevel, "size", Decimal),
+            (OrderBook, "min_order_size", Decimal),
+            (OrderBook, "tick_size", Decimal),
+            (OrderBook, "last_trade_price", Decimal | None),
+            (OrderBook, "timestamp", datetime | None),
+            (LastTradePrice, "price", Decimal),
+            (LastTradePriceForToken, "price", Decimal),
+        ],
+    )
+    def test_market_read_annotations_are_canonical(
+        self, model: type[object], field: str, annotation: object
+    ) -> None:
+        assert get_type_hints(model, include_extras=True)[field] == annotation
+        assert inspect.signature(model).parameters[field].annotation == annotation
 
 
 class TestStrictStringValidatorAcceptsAndRejects:


### PR DESCRIPTION
## Summary
- expose order-book and last-trade values with canonical field types
- preserve strict decimal-string and epoch-millisecond response parsing
- keep internal midpoint, price, and spread adapters strict for generic mappings

## Stack
3 of 13 for DEV-537.

## Verification
- 136 focused tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all CLOB market-read parsing paths; behavior is intentionally strict but any mismatch with live API shapes could break clients relying on these models.
> 
> **Overview**
> CLOB **order book** and **last trade** models now expose **`Decimal`** and **`datetime | None`** on fields instead of private `_DecimalFromString` / `EpochMsTimestamp` aliases, with **`parse_decimal_string`** and epoch-ms helpers wired through **`field_validator`** so API string payloads still parse the same way.
> 
> **`clob` action parsers** for midpoints, spreads, and nested prices run new **`_parse_decimal_mapping`** / **`_parse_prices_mapping`** pre-steps before **`TypeAdapter`** validation, and treat **`ValueError`** from strict decimal parsing as **`UnexpectedResponseError`**. Empty **`last_trade_price`** strings still map to **`None`**.
> 
> Tests expand the **decimal field contract** across more models and add coverage for generic mappings, pre-parsed **`Decimal`** values, numeric rejections, and non-string timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b9a7cf042d37e8014a158f91836c0199a36e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->