### PR TITLE
refactor(models): expose CLOB account value types

### DIFF
--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
 from pydantic import BeforeValidator, Field, field_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    ExpirationTimestamp,
-    RequiredEpochOrIsoTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_expiration_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
@@ -57,15 +59,23 @@ class OpenOrder(BaseModel):
     owner: str
     maker_address: str = Field(validation_alias="maker_address")
     side: OrderSide
-    price: _DecimalFromString
-    original_size: _DecimalFromString = Field(validation_alias="original_size")
-    size_matched: _DecimalFromString = Field(validation_alias="size_matched")
+    price: Decimal
+    original_size: Decimal = Field(validation_alias="original_size")
+    size_matched: Decimal = Field(validation_alias="size_matched")
     outcome: str
     order_type: str = Field(validation_alias="order_type")
     status: str
     associate_trades: tuple[str, ...] = Field(default=(), validation_alias="associate_trades")
-    created_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="created_at")
-    expires_at: ExpirationTimestamp = Field(default=None, validation_alias="expiration")
+    created_at: datetime = Field(validation_alias="created_at")
+    expires_at: datetime | None = Field(default=None, validation_alias="expiration")
+
+    _validate_decimals = field_validator("price", "original_size", "size_matched", mode="before")(
+        parse_decimal_string
+    )
+    _validate_created_at = field_validator("created_at", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
+    _validate_expires_at = field_validator("expires_at", mode="before")(_parse_expiration_timestamp)
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid
@@ -93,10 +103,14 @@ class MakerOrder(BaseModel):
     maker_address: str = Field(validation_alias="maker_address")
     owner: str
     side: OrderSide
-    price: _DecimalFromString
-    matched_amount: _DecimalFromString = Field(validation_alias="matched_amount")
+    price: Decimal
+    matched_amount: Decimal = Field(validation_alias="matched_amount")
     outcome: str
-    fee_rate_bps: _DecimalFromString | None = Field(default=None, validation_alias="fee_rate_bps")
+    fee_rate_bps: Decimal | None = Field(default=None, validation_alias="fee_rate_bps")
+
+    _validate_decimals = field_validator("price", "matched_amount", "fee_rate_bps", mode="before")(
+        parse_decimal_string
+    )
 
     @field_validator("fee_rate_bps", mode="before")
     @classmethod
@@ -121,16 +135,24 @@ class ClobTrade(BaseModel):
     taker_order_id: str = Field(validation_alias="taker_order_id")
     side: OrderSide
     trader_side: Literal["TAKER", "MAKER"] = Field(validation_alias="trader_side")
-    price: _DecimalFromString
-    size: _DecimalFromString
+    price: Decimal
+    size: Decimal
     outcome: str
-    status: TradeStatusField
-    fee_rate_bps: _DecimalFromString = Field(validation_alias="fee_rate_bps")
+    status: TradeStatus
+    fee_rate_bps: Decimal = Field(validation_alias="fee_rate_bps")
     bucket_index: int = Field(validation_alias="bucket_index")
     transaction_hash: str = Field(validation_alias="transaction_hash")
     maker_orders: tuple[MakerOrder, ...] = Field(validation_alias="maker_orders")
-    matched_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="match_time")
-    updated_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="last_update")
+    matched_at: datetime = Field(validation_alias="match_time")
+    updated_at: datetime = Field(validation_alias="last_update")
+
+    _validate_decimals = field_validator("price", "size", "fee_rate_bps", mode="before")(
+        parse_decimal_string
+    )
+    _validate_status = field_validator("status", mode="before")(_normalize_trade_status)
+    _validate_timestamps = field_validator("matched_at", "updated_at", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid
@@ -156,7 +178,11 @@ class Notification(BaseModel):
     owner: str
     type: int
     payload: Any = None
-    timestamp: RequiredEpochOrIsoTimestamp
+    timestamp: datetime
+
+    _validate_timestamp = field_validator("timestamp", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
 
     @field_validator("id", mode="before")
     @classmethod

--- a/tests/unit/test_account_models.py
+++ b/tests/unit/test_account_models.py
@@ -1,5 +1,7 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_type_hints
 
 import pytest
 
@@ -10,6 +12,7 @@ from polymarket.models.clob.account import (
     MakerOrder,
     Notification,
     OpenOrder,
+    TradeStatus,
 )
 
 
@@ -74,6 +77,131 @@ def _clob_trade_payload(**overrides: object) -> dict[str, object]:
     }
     base.update(overrides)
     return base
+
+
+def test_account_model_annotations_are_canonical() -> None:
+    expected = {
+        OpenOrder: {
+            "price": Decimal,
+            "original_size": Decimal,
+            "size_matched": Decimal,
+            "created_at": datetime,
+            "expires_at": datetime | None,
+        },
+        MakerOrder: {
+            "price": Decimal,
+            "matched_amount": Decimal,
+            "fee_rate_bps": Decimal | None,
+        },
+        ClobTrade: {
+            "price": Decimal,
+            "size": Decimal,
+            "status": TradeStatus,
+            "fee_rate_bps": Decimal,
+            "matched_at": datetime,
+            "updated_at": datetime,
+        },
+        Notification: {"timestamp": datetime},
+    }
+
+    for model, fields in expected.items():
+        hints = get_type_hints(model, include_extras=True)
+        for field, annotation in fields.items():
+            assert hints[field] == annotation
+            assert model.model_fields[field].annotation == annotation
+
+
+def test_account_model_signatures_use_canonical_annotations() -> None:
+    expected = {
+        OpenOrder: {
+            "price": Decimal,
+            "original_size": Decimal,
+            "size_matched": Decimal,
+            "created_at": datetime,
+            "expiration": datetime | None,
+        },
+        MakerOrder: {
+            "price": Decimal,
+            "matched_amount": Decimal,
+            "fee_rate_bps": Decimal | None,
+        },
+        ClobTrade: {
+            "price": Decimal,
+            "size": Decimal,
+            "status": TradeStatus,
+            "fee_rate_bps": Decimal,
+            "match_time": datetime,
+            "last_update": datetime,
+        },
+        Notification: {"timestamp": datetime},
+    }
+
+    for model, fields in expected.items():
+        parameters = inspect.signature(model).parameters
+        for field, annotation in fields.items():
+            assert parameters[field].annotation == annotation
+
+
+@pytest.mark.parametrize("field", ["price", "original_size", "size_matched"])
+def test_open_order_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    order = OpenOrder.parse_response(_open_order_payload(**{field: Decimal("1.25")}))
+    assert getattr(order, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        OpenOrder.parse_response(_open_order_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize("field", ["price", "matched_amount", "fee_rate_bps"])
+def test_maker_order_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    maker = MakerOrder.parse_response(_maker_order_payload(**{field: Decimal("1.25")}))
+    assert getattr(maker, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        MakerOrder.parse_response(_maker_order_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize("field", ["price", "size", "fee_rate_bps"])
+def test_clob_trade_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    trade = ClobTrade.parse_response(_clob_trade_payload(**{field: Decimal("1.25")}))
+    assert getattr(trade, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["MATCHED", "MATCHED_NOT_BROADCASTED", "MINED", "CONFIRMED", "RETRYING", "FAILED"],
+)
+def test_clob_trade_normalizes_prefixed_statuses(status: TradeStatus) -> None:
+    trade = ClobTrade.parse_response(_clob_trade_payload(status=f"TRADE_STATUS_{status}"))
+    assert trade.status == status
+
+
+def test_clob_trade_rejects_unknown_status() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(status="TRADE_STATUS_UNKNOWN"))
+
+
+@pytest.mark.parametrize("created_at", [None, ""])
+def test_open_order_requires_created_at(created_at: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        OpenOrder.parse_response(_open_order_payload(created_at=created_at))
+
+
+@pytest.mark.parametrize("field", ["match_time", "last_update"])
+@pytest.mark.parametrize("value", [None, ""])
+def test_clob_trade_requires_timestamps(field: str, value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(**{field: value}))
+
+
+@pytest.mark.parametrize("timestamp", [None, ""])
+def test_notification_requires_timestamp(timestamp: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        Notification.parse_response(
+            {"id": 1, "owner": "0xOWNER", "type": 0, "payload": None, "timestamp": timestamp}
+        )
 
 
 def test_open_order_parses_epoch_ms_timestamps() -> None:


### PR DESCRIPTION
## Summary
- expose account and trade values as canonical `Decimal`, `datetime`, and `TradeStatus` fields
- move strict wire parsing to model-level validators
- preserve fee, expiration, timestamp, and prefixed-status behavior

## Stack
2 of 13 for DEV-537. Depends on the preceding collateral annotation PR.

## Verification
- 53 focused account tests and 24 user-stream compatibility tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing for orders, trades, and notifications; behavior is intended to stay the same but stricter decimal and timestamp validation could surface new parse errors on bad API payloads.
> 
> **Overview**
> CLOB account models (`OpenOrder`, `MakerOrder`, `ClobTrade`, `Notification`) now declare **canonical** `Decimal`, `datetime`, and `TradeStatus` on their fields instead of `Annotated` wire-helper types like `_DecimalFromString` or `RequiredEpochOrIsoTimestamp`.
> 
> Strict API parsing moves to explicit `field_validator(..., mode="before")` hooks: shared `parse_decimal_string` for money fields, CLOB timestamp helpers for required/optional expirations, and `_normalize_trade_status` on `ClobTrade.status` (field type is plain `TradeStatus` rather than `TradeStatusField`).
> 
> Unit tests lock in the new public typing (hints, `model_fields`, constructor signatures) and add coverage for decimal coercion rules, prefixed trade statuses, and required timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e7b28e17cfb0e1993904c306806604f7eed6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->