### PR TITLE
refactor(models): expose collateral value types

### DIFF
--- a/src/polymarket/models/collateral_return.py
+++ b/src/polymarket/models/collateral_return.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import Field, field_serializer, field_validator
+from pydantic import Field, field_validator
 
 from polymarket.models._validators import (
     parse_decimal_string,
     parse_e6_decimal_string,
-    serialize_e6_decimal_string,
 )
 from polymarket.models.base import BaseModel
 from polymarket.models.types import (
@@ -55,7 +54,6 @@ class CollateralReturnOperation(BaseModel):
     amount: Decimal
 
     _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
-    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
     @field_validator("kind", mode="before")
     @classmethod
@@ -80,7 +78,6 @@ class CollateralReturnPositionAmount(BaseModel):
     amount: Decimal
 
     _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
-    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
 
 class CollateralReturnPositionSummary(BaseModel):

--- a/src/polymarket/models/collateral_return.py
+++ b/src/polymarket/models/collateral_return.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_serializer, field_validator
 
-from polymarket.models._validators import DecimalFromE6String, DecimalFromString
+from polymarket.models._validators import (
+    parse_decimal_string,
+    parse_e6_decimal_string,
+    serialize_e6_decimal_string,
+)
 from polymarket.models.base import BaseModel
 from polymarket.models.types import (
     ComboConditionId,
@@ -47,7 +52,10 @@ class CollateralReturnOperation(BaseModel):
     event_id: EventId | None = None
     position_id: PositionId | None = None
     condition_index: int = 0
-    amount: DecimalFromE6String
+    amount: Decimal
+
+    _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
+    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
     @field_validator("kind", mode="before")
     @classmethod
@@ -69,7 +77,10 @@ class CollateralReturnPositionAmount(BaseModel):
     """A position and the amount of it a plan touches."""
 
     position_id: PositionId
-    amount: DecimalFromE6String
+    amount: Decimal
+
+    _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
+    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
 
 class CollateralReturnPositionSummary(BaseModel):
@@ -103,14 +114,14 @@ class CollateralReturnPlanResponse(BaseModel):
     chain_id: int
     wallet: EvmAddress
     block_number: int
-    starting_pusd: DecimalFromString
-    net_pusd_out: DecimalFromString
-    final_pusd: DecimalFromString
+    starting_pusd: Decimal
+    net_pusd_out: Decimal
+    final_pusd: Decimal
     operations: tuple[CollateralReturnOperation, ...]
     operation_count: int
     truncated: bool
     estimated_cost: float
-    required_pusd_input: DecimalFromString
+    required_pusd_input: Decimal
     required_positions: tuple[CollateralReturnPositionAmount, ...]
     # Tolerate older service builds that predate the summary field.
     position_summary: CollateralReturnPositionSummary = Field(
@@ -118,6 +129,14 @@ class CollateralReturnPlanResponse(BaseModel):
     )
     candidate_position_ids: tuple[PositionId, ...]
     router_call: CollateralReturnRouterCall
+
+    _parse_decimal_fields = field_validator(
+        "starting_pusd",
+        "net_pusd_out",
+        "final_pusd",
+        "required_pusd_input",
+        mode="before",
+    )(parse_decimal_string)
 
 
 __all__ = [

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -199,20 +199,6 @@ def test_plan_tolerates_missing_position_summary() -> None:
     assert plan.position_summary.created == ()
 
 
-def test_plan_json_round_trips_scaled_amounts() -> None:
-    plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=_OTHER_WALLET))
-
-    python_dump = plan.model_dump()
-    json_dump = plan.model_dump(mode="json")
-    restored = CollateralReturnPlanResponse.model_validate_json(plan.model_dump_json())
-
-    assert python_dump["operations"][0]["amount"] == Decimal("1")
-    assert python_dump["required_positions"][0]["amount"] == Decimal("1")
-    assert json_dump["operations"][0]["amount"] == "1000000"
-    assert json_dump["required_positions"][0]["amount"] == "1000000"
-    assert restored == plan
-
-
 def test_execute_submits_router_call_for_deposit_wallet() -> None:
     submit_captured: list[httpx.Request] = []
 

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -1,9 +1,10 @@
 # pyright: reportPrivateUsage=false
 import asyncio
 import dataclasses
+import inspect
 import json
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 from urllib.parse import urlparse
 
 import httpx
@@ -26,6 +27,10 @@ from polymarket.errors import (
     RequestRejectedError,
     UnexpectedResponseError,
     UserInputError,
+)
+from polymarket.models.collateral_return import (
+    CollateralReturnOperation,
+    CollateralReturnPositionAmount,
 )
 
 _PLAN_HASH = "0x" + "ab" * 32
@@ -90,6 +95,24 @@ def test_plan_parses_wire_shape() -> None:
     assert merge.amount == Decimal("1")  # e6 base units scaled to collateral units
 
 
+def test_decimal_fields_expose_canonical_annotations() -> None:
+    affected_fields = (
+        (CollateralReturnOperation, ("amount",)),
+        (CollateralReturnPositionAmount, ("amount",)),
+        (
+            CollateralReturnPlanResponse,
+            ("starting_pusd", "net_pusd_out", "final_pusd", "required_pusd_input"),
+        ),
+    )
+
+    for model, fields in affected_fields:
+        hints = get_type_hints(model, include_extras=True)
+        parameters = inspect.signature(model).parameters
+        for field in fields:
+            assert hints[field] is Decimal
+            assert parameters[field].annotation is Decimal
+
+
 def test_plan_parses_unknown_kinds_as_plain_strings() -> None:
     plan = CollateralReturnPlanResponse.parse_response(
         _plan_payload(
@@ -107,14 +130,49 @@ def test_plan_parses_unknown_kinds_as_plain_strings() -> None:
     assert on_event.kind is CollateralReturnOperationKind.MERGE_ON_EVENT
 
 
-def test_plan_rejects_malformed_base_unit_amounts() -> None:
-    for amount in ("1.5", "-1000000"):
-        with pytest.raises(UnexpectedResponseError):
-            CollateralReturnPlanResponse.parse_response(
-                _plan_payload(
-                    wallet=_OTHER_WALLET, operations=[{"kind": "merge", "amount": amount}]
-                )
+@pytest.mark.parametrize(
+    ("wire_amount", "expected"),
+    [
+        ("0", Decimal("0.000000")),
+        ("1", Decimal("0.000001")),
+        ("1000001", Decimal("1.000001")),
+    ],
+)
+def test_plan_parses_base_unit_amount_edges(wire_amount: str, expected: Decimal) -> None:
+    plan = CollateralReturnPlanResponse.parse_response(
+        _plan_payload(
+            wallet=_OTHER_WALLET,
+            operations=[{"kind": "merge", "amount": wire_amount}],
+            required_positions=[{"position_id": "42", "amount": wire_amount}],
+        )
+    )
+
+    assert plan.operations[0].amount == expected
+    assert plan.required_positions[0].amount == expected
+
+
+@pytest.mark.parametrize("amount", ["1.5", "-1000000", "+1000000", "1e6", 1000000, True])
+def test_plan_rejects_malformed_base_unit_amounts(amount: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        CollateralReturnPlanResponse.parse_response(
+            _plan_payload(wallet=_OTHER_WALLET, operations=[{"kind": "merge", "amount": amount}])
+        )
+
+
+def test_plan_keeps_strict_decimal_strings_distinct_from_base_units() -> None:
+    plan = CollateralReturnPlanResponse.parse_response(
+        _plan_payload(wallet=_OTHER_WALLET, starting_pusd="-1.5")
+    )
+
+    assert plan.starting_pusd == Decimal("-1.5")
+
+    with pytest.raises(UnexpectedResponseError):
+        CollateralReturnPlanResponse.parse_response(
+            _plan_payload(
+                wallet=_OTHER_WALLET,
+                operations=[{"kind": "merge", "amount": "-1.5"}],
             )
+        )
 
 
 def test_plan_requires_service_fields() -> None:
@@ -144,8 +202,14 @@ def test_plan_tolerates_missing_position_summary() -> None:
 def test_plan_json_round_trips_scaled_amounts() -> None:
     plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=_OTHER_WALLET))
 
+    python_dump = plan.model_dump()
+    json_dump = plan.model_dump(mode="json")
     restored = CollateralReturnPlanResponse.model_validate_json(plan.model_dump_json())
 
+    assert python_dump["operations"][0]["amount"] == Decimal("1")
+    assert python_dump["required_positions"][0]["amount"] == Decimal("1")
+    assert json_dump["operations"][0]["amount"] == "1000000"
+    assert json_dump["required_positions"][0]["amount"] == "1000000"
     assert restored == plan
 
 


### PR DESCRIPTION
## Summary
- expose collateral amounts as canonical `Decimal` fields
- move strict string and E6 response parsing to model-level validators
- remove upstream E6 JSON serialization that is not used by the plan or execution request paths

## Stack
1 of 13 for DEV-537.

## Verification
- 23 focused tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`