### PR TITLE
refactor(models): expose Perps event value types

### DIFF
--- a/src/polymarket/models/perps/events.py
+++ b/src/polymarket/models/perps/events.py
@@ -1,12 +1,16 @@
 """Perps realtime event models."""
 
 import re
+from datetime import datetime
 from typing import Annotated, Any, Literal, cast
 
-from pydantic import Field, TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.perps._validators import OptionalPerpsTimestamp, PerpsTimestamp
+from polymarket.models.perps._validators import (
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.perps.account import PerpsBalance, PerpsFundingPayment, PerpsPortfolio
 from polymarket.models.perps.funds import PerpsDepositUpdate, PerpsWithdrawalUpdate
 from polymarket.models.perps.market import (
@@ -43,68 +47,75 @@ _SESSION_CHANNEL_TYPES: dict[str, str] = {
 _NOTIFICATIONS_CHANNEL = "notifications"
 
 
-class PerpsTradeEvent(BaseModel):
+class _PerpsEventEnvelope(BaseModel):
+    @field_validator("timestamp", mode="before", check_fields=False)
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+
+class PerpsTradeEvent(_PerpsEventEnvelope):
     """Public trades printed in one update for a subscribed instrument."""
 
     topic: Literal["perps.trades"] = "perps.trades"
     type: Literal["trade"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: list[PerpsTrade]
 
 
-class PerpsBboEvent(BaseModel):
+class PerpsBboEvent(_PerpsEventEnvelope):
     """A best bid/ask update for a subscribed instrument."""
 
     topic: Literal["perps.bbo"] = "perps.bbo"
     type: Literal["bbo"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBbo
 
 
-class PerpsBookEvent(BaseModel):
+class PerpsBookEvent(_PerpsEventEnvelope):
     """An order book delta for a subscribed instrument."""
 
     topic: Literal["perps.book"] = "perps.book"
     type: Literal["book"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBookUpdate
 
 
-class PerpsTickerEvent(BaseModel):
+class PerpsTickerEvent(_PerpsEventEnvelope):
     """A ticker update for a subscribed instrument."""
 
     topic: Literal["perps.tickers"] = "perps.tickers"
     type: Literal["ticker"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsTickerUpdate
 
 
-class PerpsStatisticEvent(BaseModel):
+class PerpsStatisticEvent(_PerpsEventEnvelope):
     """A trading statistics update for a subscribed instrument."""
 
     topic: Literal["perps.statistics"] = "perps.statistics"
     type: Literal["statistic"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsStatistic
 
 
-class PerpsCandleEvent(BaseModel):
+class PerpsCandleEvent(_PerpsEventEnvelope):
     """A candle batch for a subscribed instrument and interval."""
 
     topic: Literal["perps.candles"] = "perps.candles"
     type: Literal["candle"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsCandleBatch
 
@@ -122,72 +133,72 @@ PerpsMarketEvent = Annotated[
 _MARKET_EVENT_ADAPTER: TypeAdapter[PerpsMarketEvent] = TypeAdapter(PerpsMarketEvent)
 
 
-class PerpsBalanceEvent(BaseModel):
+class PerpsBalanceEvent(_PerpsEventEnvelope):
     """A balance update for the session account."""
 
     type: Literal["balance"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBalance
 
 
-class PerpsPortfolioEvent(BaseModel):
+class PerpsPortfolioEvent(_PerpsEventEnvelope):
     """A portfolio snapshot update for the session account."""
 
     type: Literal["portfolio"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsPortfolio
 
 
-class PerpsOrderEvent(BaseModel):
+class PerpsOrderEvent(_PerpsEventEnvelope):
     """An order lifecycle update for the session account."""
 
     type: Literal["order"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsOrder
 
 
-class PerpsFillEvent(BaseModel):
+class PerpsFillEvent(_PerpsEventEnvelope):
     """Fill updates in one frame for the session account."""
 
     type: Literal["fill"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: list[PerpsFill]
 
 
-class PerpsFundingEvent(BaseModel):
+class PerpsFundingEvent(_PerpsEventEnvelope):
     """A funding payment update for the session account."""
 
     type: Literal["funding"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsFundingPayment
 
 
-class PerpsDepositEvent(BaseModel):
+class PerpsDepositEvent(_PerpsEventEnvelope):
     """A deposit status update for the session account."""
 
     type: Literal["deposit"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsDepositUpdate
 
 
-class PerpsWithdrawalEvent(BaseModel):
+class PerpsWithdrawalEvent(_PerpsEventEnvelope):
     """A withdrawal status update for the session account."""
 
     type: Literal["withdrawal"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsWithdrawalUpdate
 
@@ -200,22 +211,22 @@ class PerpsTpSlUpdate(BaseModel):
     reason: str | None = None
 
 
-class PerpsTpSlEvent(BaseModel):
+class PerpsTpSlEvent(_PerpsEventEnvelope):
     """A take-profit/stop-loss lifecycle update for the session account."""
 
     type: Literal["tpsl"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsTpSlUpdate
 
 
-class PerpsNotificationEvent(BaseModel):
+class PerpsNotificationEvent(_PerpsEventEnvelope):
     """An account notification for the session account."""
 
     type: Literal["notification"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsNotification
 
@@ -234,7 +245,12 @@ class PerpsResyncEvent(BaseModel):
     channel: str | None = None
     previous_sequence: int | None = None
     sequence: int | None = None
-    timestamp: OptionalPerpsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 PerpsSessionEvent = (

--- a/src/polymarket/models/perps/notifications.py
+++ b/src/polymarket/models/perps/notifications.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentId,
@@ -37,10 +39,15 @@ class PerpsPositionChangeNotification(BaseModel):
     type: Literal["position_opened", "position_increased", "position_reduced"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    avg_price: _Decimal
+    size: Decimal
+    avg_price: Decimal
     leverage: int
     order_type: PerpsNotificationOrderType | None = None
+
+    @field_validator("size", "avg_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPositionClosedNotification(BaseModel):
@@ -50,10 +57,15 @@ class PerpsPositionClosedNotification(BaseModel):
     type: Literal["position_closed"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    avg_price: _Decimal
-    pnl: _Decimal
+    size: Decimal
+    avg_price: Decimal
+    pnl: Decimal
     order_type: PerpsNotificationOrderType | None = None
+
+    @field_validator("size", "avg_price", "pnl", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsLimitOrderCanceledNotification(BaseModel):
@@ -63,8 +75,13 @@ class PerpsLimitOrderCanceledNotification(BaseModel):
     type: Literal["limit_order_canceled"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    price: _Decimal
+    size: Decimal
+    price: Decimal
+
+    @field_validator("size", "price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsIsolatedLiquidationWarningNotification(BaseModel):
@@ -74,8 +91,13 @@ class PerpsIsolatedLiquidationWarningNotification(BaseModel):
     type: Literal["liquidation_warning"]
     margin_type: Literal["isolated"]
     instrument_id: PerpsInstrumentId
-    mark_price: _Decimal
-    liquidation_price: _Decimal = Field(validation_alias="liq_price")
+    mark_price: Decimal
+    liquidation_price: Decimal = Field(validation_alias="liq_price")
+
+    @field_validator("mark_price", "liquidation_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsCrossLiquidationWarningNotification(BaseModel):
@@ -84,8 +106,13 @@ class PerpsCrossLiquidationWarningNotification(BaseModel):
     id: PerpsNotificationId
     type: Literal["liquidation_warning"]
     margin_type: Literal["cross"]
-    mark_price: _Decimal
+    mark_price: Decimal
     affected_instruments: tuple[PerpsInstrumentId, ...]
+
+    @field_validator("mark_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 PerpsLiquidationWarningNotification = Annotated[
@@ -101,10 +128,15 @@ class PerpsPositionLiquidatedNotification(BaseModel):
     type: Literal["position_liquidated"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size_closed: _Decimal
-    pnl: _Decimal | None
+    size_closed: Decimal
+    pnl: Decimal | None
     margin_type: PerpsMarginType
     via_backstop: bool
+
+    @field_validator("size_closed", "pnl", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 PerpsNotification = Annotated[
@@ -121,8 +153,18 @@ class PerpsNotificationEntry(BaseModel):
     """One notification with its account-scoped read state."""
 
     notification: PerpsNotification
-    read_at: OptionalPerpsTimestamp = None
-    timestamp: PerpsTimestamp = Field(validation_alias="ts")
+    read_at: datetime | None = None
+    timestamp: datetime = Field(validation_alias="ts")
+
+    @field_validator("read_at", mode="before")
+    @classmethod
+    def _validate_read_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/test_perps_events.py
+++ b/tests/unit/test_perps_events.py
@@ -1,19 +1,27 @@
 """Perps realtime event parsing tests."""
 
+import inspect
+from collections import UserDict
+from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_args, get_type_hints
 
 import pytest
 from pydantic import ValidationError
+from pydantic.fields import FieldInfo
 
 from polymarket.models.perps.events import (
     PerpsBookEvent,
     PerpsCandleEvent,
     PerpsDepositEvent,
+    PerpsMarketEvent,
     PerpsNotificationEvent,
     PerpsOrderEvent,
     PerpsResyncEvent,
     PerpsTickerEvent,
     PerpsTpSlEvent,
+    PerpsTradeEvent,
+    _SessionUpdateEvent,  # pyright: ignore[reportPrivateUsage]
     parse_perps_market_event,
     parse_perps_market_events,
     parse_perps_session_event,
@@ -21,6 +29,9 @@ from polymarket.models.perps.events import (
 from polymarket.models.perps.notifications import (
     PerpsCrossLiquidationWarningNotification,
     PerpsIsolatedLiquidationWarningNotification,
+    PerpsLiquidationWarningNotification,
+    PerpsNotification,
+    PerpsNotificationEntry,
     PerpsPositionChangeNotification,
     PerpsPositionClosedNotification,
     PerpsPositionLiquidatedNotification,
@@ -191,20 +202,23 @@ def _notification_frame(notification: dict[str, object]) -> dict[str, object]:
     return {"ch": "notifications", "ts": 1751500000000, "sq": 42, "data": notification}
 
 
+def _position_change_notification(**overrides: object) -> dict[str, object]:
+    notification: dict[str, object] = {
+        "id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0",
+        "type": "position_increased",
+        "instrument_id": 3,
+        "side": "short",
+        "size": "1.5",
+        "avg_price": "99.5",
+        "leverage": 4,
+    }
+    notification.update(overrides)
+    return notification
+
+
 def test_session_notification_event_parses_position_change() -> None:
     event = parse_perps_session_event(
-        _notification_frame(
-            {
-                "id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0",
-                "type": "position_increased",
-                "instrument_id": 3,
-                "side": "short",
-                "size": "1.5",
-                "avg_price": "99.5",
-                "leverage": 4,
-                "order_type": "stop_loss",
-            }
-        )
+        _notification_frame(_position_change_notification(order_type="stop_loss"))
     )
     assert isinstance(event, PerpsNotificationEvent)
     assert event.sequence == 42
@@ -296,6 +310,159 @@ def test_session_notification_with_unknown_type_fails_validation() -> None:
                 {"id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0", "type": "new_notification_kind"}
             )
         )
+
+
+@pytest.mark.parametrize("value", [True, [], object()])
+def test_notification_decimal_fields_keep_exact_perps_validation(value: object) -> None:
+    with pytest.raises(ValidationError, match="expected decimal-ish value"):
+        parse_perps_session_event(_notification_frame(_position_change_notification(size=value)))
+
+
+def test_notification_decimal_fields_accept_numbers_via_exact_string_conversion() -> None:
+    event = parse_perps_session_event(
+        _notification_frame(_position_change_notification(size=2, avg_price=99.25))
+    )
+    assert isinstance(event, PerpsNotificationEvent)
+    assert isinstance(event.payload, PerpsPositionChangeNotification)
+    assert event.payload.size == Decimal("2")
+    assert event.payload.avg_price == Decimal("99.25")
+
+
+@pytest.mark.parametrize("timestamp", [None, True, 1751500000000.0, "1751500000000"])
+def test_required_event_timestamp_keeps_exact_epoch_ms_validation(timestamp: object) -> None:
+    frame = _notification_frame(_position_change_notification())
+    frame["ts"] = timestamp
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        parse_perps_session_event(frame)
+
+
+def test_required_event_timestamp_rejects_invalid_value_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEvent.model_validate(
+            UserDict(
+                {
+                    "type": "notification",
+                    "channel": "notifications",
+                    "timestamp": "1751500000000",
+                    "sequence": 42,
+                    "payload": _position_change_notification(),
+                }
+            )
+        )
+
+
+def test_resync_optional_timestamp_preserves_missing_none_and_epoch_ms_semantics() -> None:
+    missing = PerpsResyncEvent.model_validate({"reason": "reconnect"})
+    explicit_none = PerpsResyncEvent.model_validate({"reason": "reconnect", "timestamp": None})
+    epoch = PerpsResyncEvent.model_validate({"reason": "sequence_gap", "timestamp": 1751500000000})
+
+    assert missing.timestamp is None
+    assert explicit_none.timestamp is None
+    assert epoch.timestamp == datetime.fromtimestamp(1751500000, tz=UTC)
+
+
+@pytest.mark.parametrize("timestamp", [True, 1751500000000.0, "1751500000000"])
+def test_resync_optional_timestamp_rejects_non_epoch_ms_values(timestamp: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsResyncEvent.model_validate({"reason": "reconnect", "timestamp": timestamp})
+
+
+def test_resync_timestamp_rejects_invalid_value_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsResyncEvent.model_validate(
+            UserDict({"reason": "reconnect", "timestamp": "1751500000000"})
+        )
+
+
+def test_notification_entry_timestamp_aliases_keep_optional_read_semantics() -> None:
+    entry = PerpsNotificationEntry.model_validate(
+        {
+            "notification": _position_change_notification(),
+            "read_at": None,
+            "ts": 1751500000000,
+        }
+    )
+    named = PerpsNotificationEntry.model_validate(
+        {
+            "notification": _position_change_notification(),
+            "timestamp": 1751500000000,
+        }
+    )
+
+    assert entry.read_at is None
+    assert entry.timestamp == datetime.fromtimestamp(1751500000, tz=UTC)
+    assert named.timestamp == entry.timestamp
+
+
+@pytest.mark.parametrize("field", ["read_at", "ts"])
+def test_notification_entry_timestamp_aliases_reject_bool(field: str) -> None:
+    data: dict[str, object] = {
+        "notification": _position_change_notification(),
+        "ts": 1751500000000,
+    }
+    data[field] = True
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEntry.model_validate(data)
+
+
+def test_notification_entry_rejects_invalid_timestamp_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEntry.model_validate(
+            UserDict(
+                {
+                    "notification": _position_change_notification(),
+                    "ts": "1751500000000",
+                }
+            )
+        )
+
+
+def test_perps_notification_and_event_annotations_expose_canonical_types() -> None:
+    position_hints = get_type_hints(PerpsPositionChangeNotification, include_extras=True)
+    liquidated_hints = get_type_hints(PerpsPositionLiquidatedNotification, include_extras=True)
+    entry_hints = get_type_hints(PerpsNotificationEntry, include_extras=True)
+    trade_hints = get_type_hints(PerpsTradeEvent, include_extras=True)
+    resync_hints = get_type_hints(PerpsResyncEvent, include_extras=True)
+
+    assert position_hints["size"] is Decimal
+    assert position_hints["avg_price"] is Decimal
+    assert liquidated_hints["pnl"] == Decimal | None
+    assert entry_hints["read_at"] == datetime | None
+    assert entry_hints["timestamp"] is datetime
+    assert trade_hints["timestamp"] is datetime
+    assert resync_hints["timestamp"] == datetime | None
+
+
+def test_discriminated_union_metadata_survives_annotation_migration() -> None:
+    aliases = (
+        (PerpsLiquidationWarningNotification, "margin_type"),
+        (PerpsNotification, "type"),
+        (PerpsMarketEvent, "type"),
+        (_SessionUpdateEvent, "type"),
+    )
+    for annotation, discriminator in aliases:
+        metadata = get_args(annotation)[1:]
+        assert any(
+            isinstance(item, FieldInfo) and item.discriminator == discriminator for item in metadata
+        )
+
+    notification_hints = get_type_hints(PerpsNotificationEvent, include_extras=True)
+    assert notification_hints["payload"] == PerpsNotification
+
+
+def test_model_signatures_expose_canonical_types_and_timestamp_alias() -> None:
+    notification_params = inspect.signature(PerpsPositionChangeNotification).parameters
+    entry_params = inspect.signature(PerpsNotificationEntry).parameters
+    trade_params = inspect.signature(PerpsTradeEvent).parameters
+    resync_params = inspect.signature(PerpsResyncEvent).parameters
+
+    assert notification_params["size"].annotation is Decimal
+    assert notification_params["avg_price"].annotation is Decimal
+    assert entry_params["read_at"].annotation == datetime | None
+    assert entry_params["ts"].annotation is datetime
+    assert "timestamp" not in entry_params
+    assert trade_params["timestamp"].annotation is datetime
+    assert resync_params["timestamp"].annotation == datetime | None
 
 
 def test_notifications_resync_frame_parses_as_server_resync_event() -> None:

--- a/tests/unit/test_perps_session.py
+++ b/tests/unit/test_perps_session.py
@@ -608,6 +608,28 @@ def test_notification_sequence_gaps_do_not_emit_local_resync() -> None:
     asyncio.run(asyncio.wait_for(run(), timeout=10.0))
 
 
+def test_malformed_notification_decimal_is_dropped_without_disrupting_dispatch() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        malformed = _notification_update(10, "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0")
+        malformed["data"]["size"] = True
+        await ws.send(json.dumps(malformed))
+        await ws.send(json.dumps(_order_update(1, sequence=1)))
+        with contextlib.suppress(Exception):
+            async for _ in ws:
+                pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            event = await asyncio.wait_for(session.__anext__(), timeout=5.0)
+            assert isinstance(event, PerpsOrderEvent)
+            assert event.payload.id == 1
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(session.__anext__(), timeout=0.1)
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
 def test_server_notifications_resync_frame_emits_server_resync_event() -> None:
     async def handler(ws: ServerConnection) -> None:
         await _handshake(ws)


### PR DESCRIPTION
## Summary
- expose Perps notification and event-envelope fields with canonical types
- preserve strict mapping validation and all event discriminators
- move decimal and timestamp parsing to field validators for precise errors

## Stack
12 of 13 for DEV-537.

## Verification
- 57 focused tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Perps WebSocket event and notification parsing; behavior is heavily tested but any validation drift could drop or mis-parse realtime frames.
> 
> **Overview**
> Perps realtime **event envelopes** and **notification** models now declare **`datetime`** and **`Decimal`** on fields instead of `PerpsTimestamp` / `_Decimal` aliases, so public types and IDE hints match runtime values.
> 
> Shared **`_PerpsEventEnvelope`** centralizes required epoch-ms timestamp validation for market and session events; **`PerpsResyncEvent`** and **`PerpsNotificationEntry`** use explicit validators for optional vs required timestamps. Notification payloads coerce decimals via **`field_validator`** calling the same `_coerce_decimalish` / epoch-ms helpers, keeping strict wire rules (reject bools, string epoch-ms, etc.).
> 
> Tests lock in annotation/signature shape, discriminated unions, mapping validation, and that a malformed notification frame is dropped without blocking later session events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b295cf99a0046aaf337c9f0f17600e462ac6b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->