### PR TITLE
refactor(models): expose rewards value types

### DIFF
--- a/src/polymarket/models/clob/rewards.py
+++ b/src/polymarket/models/clob/rewards.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import TypeAlias
 
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, TokenId, validate_ctf_condition_id
 
@@ -53,10 +54,13 @@ class CurrentRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
-    total_rewards: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_rewards"
-    )
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
+    total_rewards: Decimal | None = Field(default=None, validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -72,22 +76,27 @@ class CurrentRewardConfig(BaseModel):
 class CurrentReward(BaseModel):
     condition_id: CtfConditionId = Field(validation_alias="condition_id")
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="rewards_min_size"
-    )
+    rewards_min_size: Decimal | None = Field(default=None, validation_alias="rewards_min_size")
     rewards_config: tuple[CurrentRewardConfig, ...] = Field(
         default=(), validation_alias="rewards_config"
     )
-    sponsored_daily_rate: _DecimalFromNumberOrString | None = Field(
+    sponsored_daily_rate: Decimal | None = Field(
         default=None, validation_alias="sponsored_daily_rate"
     )
     sponsors_count: int | None = Field(default=None, validation_alias="sponsors_count")
-    native_daily_rate: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="native_daily_rate"
+    native_daily_rate: Decimal | None = Field(default=None, validation_alias="native_daily_rate")
+    total_daily_rate: Decimal | None = Field(default=None, validation_alias="total_daily_rate")
+
+    @field_validator(
+        "rewards_min_size",
+        "sponsored_daily_rate",
+        "native_daily_rate",
+        "total_daily_rate",
+        mode="before",
     )
-    total_daily_rate: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_daily_rate"
-    )
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod
@@ -99,10 +108,13 @@ class MarketRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
-    total_rewards: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_rewards"
-    )
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
+    total_rewards: Decimal | None = Field(default=None, validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -118,7 +130,12 @@ class MarketRewardConfig(BaseModel):
 class MarketRewardToken(BaseModel):
     token_id: TokenId = Field(validation_alias="token_id")
     outcome: str
-    price: _DecimalFromNumberOrString
+    price: Decimal
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class MarketReward(BaseModel):
@@ -128,9 +145,7 @@ class MarketReward(BaseModel):
     event_slug: str | None = Field(default=None, validation_alias="event_slug")
     image: str | None = None
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="rewards_min_size"
-    )
+    rewards_min_size: Decimal | None = Field(default=None, validation_alias="rewards_min_size")
     market_competitiveness: float | None = Field(
         default=None, validation_alias="market_competitiveness"
     )
@@ -138,6 +153,11 @@ class MarketReward(BaseModel):
     rewards_config: tuple[MarketRewardConfig, ...] = Field(
         default=(), validation_alias="rewards_config"
     )
+
+    @field_validator("rewards_min_size", mode="before")
+    @classmethod
+    def _parse_rewards_min_size(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod
@@ -147,11 +167,16 @@ class MarketReward(BaseModel):
 
 class UserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
     condition_id: CtfConditionId = Field(validation_alias="condition_id")
     date: datetime
-    earnings: _DecimalFromNumberOrString
+    earnings: Decimal
     maker_address: str = Field(validation_alias="maker_address")
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("date", mode="before")
     @classmethod
@@ -166,10 +191,15 @@ class UserEarning(BaseModel):
 
 class TotalUserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
     date: datetime
-    earnings: _DecimalFromNumberOrString
+    earnings: Decimal
     maker_address: str = Field(validation_alias="maker_address")
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("date", mode="before")
     @classmethod
@@ -180,9 +210,14 @@ class TotalUserEarning(BaseModel):
 class UserRewardsConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     end_date: datetime = Field(validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
     start_date: datetime = Field(validation_alias="start_date")
-    total_rewards: _DecimalFromNumberOrString = Field(validation_alias="total_rewards")
+    total_rewards: Decimal = Field(validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", "end_date", mode="before")
     @classmethod
@@ -192,8 +227,13 @@ class UserRewardsConfig(BaseModel):
 
 class EarningBreakdown(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
-    earnings: _DecimalFromNumberOrString
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
+    earnings: Decimal
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class UserRewardsEarning(BaseModel):
@@ -208,8 +248,13 @@ class UserRewardsEarning(BaseModel):
     question: str
     rewards_config: tuple[UserRewardsConfig, ...] = Field(validation_alias="rewards_config")
     rewards_max_spread: float = Field(validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString = Field(validation_alias="rewards_min_size")
+    rewards_min_size: Decimal = Field(validation_alias="rewards_min_size")
     tokens: tuple[MarketRewardToken, ...]
+
+    @field_validator("rewards_min_size", mode="before")
+    @classmethod
+    def _parse_rewards_min_size(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod

--- a/tests/unit/test_rewards_models.py
+++ b/tests/unit/test_rewards_models.py
@@ -1,17 +1,19 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_type_hints
 
 import pytest
 
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.clob._validators import (
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
-)
+from polymarket.models.base import BaseModel
 from polymarket.models.clob.rewards import (
     CurrentReward,
+    CurrentRewardConfig,
     EarningBreakdown,
     MarketReward,
     MarketRewardConfig,
+    MarketRewardToken,
     TotalUserEarning,
     UserEarning,
     UserRewardsConfig,
@@ -182,39 +184,93 @@ def test_user_earning_rejects_out_of_range_epoch() -> None:
         )
 
 
-def test_decimalish_string_accepts_int() -> None:
-    from pydantic import BaseModel as _Base
+def test_reward_decimal_fields_expose_canonical_annotations_and_signatures() -> None:
+    fields_by_model: tuple[tuple[type[BaseModel], dict[str, object]], ...] = (
+        (
+            CurrentRewardConfig,
+            {"rate_per_day": Decimal, "total_rewards": Decimal | None},
+        ),
+        (
+            CurrentReward,
+            {
+                "rewards_min_size": Decimal | None,
+                "sponsored_daily_rate": Decimal | None,
+                "native_daily_rate": Decimal | None,
+                "total_daily_rate": Decimal | None,
+            },
+        ),
+        (
+            MarketRewardConfig,
+            {"rate_per_day": Decimal, "total_rewards": Decimal | None},
+        ),
+        (MarketRewardToken, {"price": Decimal}),
+        (MarketReward, {"rewards_min_size": Decimal | None}),
+        (UserEarning, {"asset_rate": Decimal, "earnings": Decimal}),
+        (TotalUserEarning, {"asset_rate": Decimal, "earnings": Decimal}),
+        (UserRewardsConfig, {"rate_per_day": Decimal, "total_rewards": Decimal}),
+        (EarningBreakdown, {"asset_rate": Decimal, "earnings": Decimal}),
+        (UserRewardsEarning, {"rewards_min_size": Decimal}),
+    )
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    assert Foo.model_validate({"v": 10}).v == Decimal("10")
-
-
-def test_decimalish_string_accepts_float_via_str() -> None:
-    from pydantic import BaseModel as _Base
-
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    assert Foo.model_validate({"v": 0.1}).v == Decimal("0.1")
+    for model, expected_fields in fields_by_model:
+        hints = get_type_hints(model)
+        parameters = inspect.signature(model).parameters
+        for field, annotation in expected_fields.items():
+            assert hints[field] == annotation
+            assert parameters[field].annotation == annotation
 
 
-def test_decimalish_string_accepts_decimal_string() -> None:
-    from pydantic import BaseModel as _Base
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (10, Decimal("10")),
+        (0.1, Decimal("0.1")),
+        ("0.001", Decimal("0.001")),
+        (Decimal("1.25"), Decimal("1.25")),
+    ],
+)
+def test_reward_decimal_fields_accept_number_string_and_decimal(
+    value: int | float | str | Decimal, expected: Decimal
+) -> None:
+    token = MarketRewardToken.parse_response(
+        {"token_id": "8501497", "outcome": "Yes", "price": value}
+    )
+    assert token.price == expected
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
 
-    assert Foo.model_validate({"v": "0.001"}).v == Decimal("0.001")
+def test_reward_decimal_fields_reject_bool() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        MarketRewardToken.parse_response({"token_id": "8501497", "outcome": "Yes", "price": True})
 
 
-def test_decimalish_string_rejects_bool() -> None:
-    from pydantic import BaseModel as _Base
-    from pydantic import ValidationError
+@pytest.mark.parametrize(
+    ("model", "payload", "field"),
+    [
+        (
+            CurrentRewardConfig,
+            {"asset_address": "0xUSDC", "start_date": 1700000000000, "rate_per_day": "1"},
+            "total_rewards",
+        ),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "rewards_min_size"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "sponsored_daily_rate"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "native_daily_rate"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "total_daily_rate"),
+        (
+            MarketRewardConfig,
+            {"asset_address": "0xUSDC", "start_date": 1700000000000, "rate_per_day": "1"},
+            "total_rewards",
+        ),
+        (
+            MarketReward,
+            {"condition_id": _CONDITION_ID, "question": "Q?", "tokens": []},
+            "rewards_min_size",
+        ),
+    ],
+)
+def test_optional_reward_decimals_accept_none_but_reject_empty_string(
+    model: type[BaseModel], payload: dict[str, object], field: str
+) -> None:
+    assert getattr(model.parse_response(payload | {field: None}), field) is None
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    with pytest.raises(ValidationError):
-        Foo.model_validate({"v": True})
+    with pytest.raises(UnexpectedResponseError):
+        model.parse_response(payload | {field: ""})


### PR DESCRIPTION
## Summary
- expose reward amounts as canonical `Decimal` fields
- preserve number-or-string parsing without adding stream-specific empty-string behavior
- replace private-alias tests with exported model contracts

## Stack
5 of 13 for DEV-537.

## Verification
- 37 focused and transport tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Model-layer typing and validator wiring only; parsing rules are tightened slightly for optional empty strings but otherwise aligned with existing decimal coercion.
> 
> **Overview**
> CLOB **rewards** models now declare monetary fields as plain **`Decimal`** (and **`Decimal | None`**) instead of the private **`_DecimalFromNumberOrString`** alias, so exported types and constructor signatures match what callers see.
> 
> Parsing still accepts ints, floats, strings, and **`Decimal`** via shared **`_coerce_decimalish`** **`field_validator`** hooks on each affected model; optional decimals keep **`None`** but **reject empty strings** (no stream-style `""` → **`None`** on these REST models).
> 
> Tests drop ad-hoc alias fixtures in favor of **annotation/signature contracts** across reward models plus coercion and optional-field edge cases on real **`parse_response`** paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d83f59432b2ae3e1bf04b9315404cc58eb1352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->