### PR TITLE
refactor(models): expose market stream value types

### DIFF
--- a/src/polymarket/models/clob/market_events.py
+++ b/src/polymarket/models/clob/market_events.py
@@ -1,12 +1,14 @@
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
 
-from pydantic import BeforeValidator, Field, TypeAdapter, field_validator
+from pydantic import Field, TypeAdapter, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsTimestamp,
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
-    _OptionalDecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _coerce_optional_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import CtfConditionId, TokenId, validate_optional_ctf_condition_id
@@ -14,9 +16,6 @@ from polymarket.models.types import CtfConditionId, TokenId, validate_optional_c
 
 def _uppercase_order_side(value: object) -> object:
     return value.upper() if isinstance(value, str) else value
-
-
-_OrderSide = Annotated[Literal["BUY", "SELL"], BeforeValidator(_uppercase_order_side)]
 
 
 class MarketEventMessage(BaseModel):
@@ -29,12 +28,27 @@ class MarketEventMessage(BaseModel):
 
 class PriceChange(BaseModel):
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: _DecimalFromNumberOrString
-    size: _DecimalFromNumberOrString
-    side: _OrderSide
+    price: Decimal
+    size: Decimal
+    side: Literal["BUY", "SELL"]
     hash: str | None = None
-    best_bid: _OptionalDecimalFromNumberOrString = None
-    best_ask: _OptionalDecimalFromNumberOrString = None
+    best_bid: Decimal | None = None
+    best_ask: Decimal | None = None
+
+    @field_validator("price", "size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("best_bid", "best_ask", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_order_side(value)
 
 
 # --- Payloads (the variant-specific data; lifted out of the wire's top level) ---
@@ -46,45 +60,105 @@ class MarketBookPayload(BaseModel):
     bids: tuple[OrderBookLevel, ...]
     asks: tuple[OrderBookLevel, ...]
     hash: str | None = None
-    timestamp: EpochMsTimestamp = None
-    min_order_size: _OptionalDecimalFromNumberOrString = None
-    tick_size: _OptionalDecimalFromNumberOrString = None
+    timestamp: datetime | None = None
+    min_order_size: Decimal | None = None
+    tick_size: Decimal | None = None
     neg_risk: bool | None = None
-    last_trade_price: _OptionalDecimalFromNumberOrString = None
+    last_trade_price: Decimal | None = None
+
+    @field_validator("min_order_size", "tick_size", "last_trade_price", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketPriceChangePayload(BaseModel):
     market: str
     price_changes: tuple[PriceChange, ...]
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketLastTradePricePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: _DecimalFromNumberOrString
-    size: _OptionalDecimalFromNumberOrString = None
-    side: _OrderSide
-    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
+    price: Decimal
+    size: Decimal | None = None
+    side: Literal["BUY", "SELL"]
+    fee_rate_bps: Decimal | None = None
     transaction_hash: str | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("size", "fee_rate_bps", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_order_side(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketTickSizeChangePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    old_tick_size: _OptionalDecimalFromNumberOrString = None
-    new_tick_size: _DecimalFromNumberOrString
-    timestamp: EpochMsTimestamp = None
+    old_tick_size: Decimal | None = None
+    new_tick_size: Decimal
+    timestamp: datetime | None = None
+
+    @field_validator("new_tick_size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("old_tick_size", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketBestBidAskPayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    best_bid: _OptionalDecimalFromNumberOrString = None
-    best_ask: _OptionalDecimalFromNumberOrString = None
-    spread: _OptionalDecimalFromNumberOrString = None
-    timestamp: EpochMsTimestamp = None
+    best_bid: Decimal | None = None
+    best_ask: Decimal | None = None
+    spread: Decimal | None = None
+    timestamp: datetime | None = None
+
+    @field_validator("best_bid", "best_ask", "spread", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class NewMarketPayload(BaseModel):
@@ -96,17 +170,17 @@ class NewMarketPayload(BaseModel):
     token_ids: tuple[TokenId, ...] | None = Field(default=None, validation_alias="assets_ids")
     outcomes: tuple[str, ...] | None = None
     event_message: MarketEventMessage | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     tags: tuple[str, ...] | None = None
     condition_id: CtfConditionId | None = None
     active: bool | None = None
     clob_token_ids: tuple[str, ...] | None = None
     sports_market_type: str | None = None
-    line: _OptionalDecimalFromNumberOrString = None
-    game_start_time: EpochMsTimestamp = None
-    order_price_min_tick_size: _OptionalDecimalFromNumberOrString = None
+    line: Decimal | None = None
+    game_start_time: datetime | None = None
+    order_price_min_tick_size: Decimal | None = None
     group_item_title: str | None = None
-    taker_base_fee: _OptionalDecimalFromNumberOrString = None
+    taker_base_fee: Decimal | None = None
     fees_enabled: bool | None = None
     fee_schedule: object | None = None
 
@@ -114,6 +188,16 @@ class NewMarketPayload(BaseModel):
     @classmethod
     def _validate_condition_id(cls, value: object) -> CtfConditionId | None:
         return validate_optional_ctf_condition_id(value)
+
+    @field_validator("line", "order_price_min_tick_size", "taker_base_fee", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", "game_start_time", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketResolvedPayload(BaseModel):
@@ -123,8 +207,13 @@ class MarketResolvedPayload(BaseModel):
     winning_token_id: TokenId | None = Field(default=None, validation_alias="winning_asset_id")
     winning_outcome: str | None = None
     event_message: MarketEventMessage | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     tags: tuple[str, ...] | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 # --- Envelope: every event is {topic, type, payload} ---

--- a/tests/unit/test_streams_market_events.py
+++ b/tests/unit/test_streams_market_events.py
@@ -1,16 +1,24 @@
-from typing import Any
+import inspect
+from datetime import datetime
+from decimal import Decimal
+from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
 
 import pytest
 from pydantic import ValidationError
 
 from polymarket.models.clob.market_events import (
     MarketBestBidAskEvent,
+    MarketBestBidAskPayload,
     MarketBookEvent,
+    MarketBookPayload,
+    MarketEvent,
     MarketLastTradePriceEvent,
+    MarketLastTradePricePayload,
     MarketPriceChangeEvent,
     MarketResolvedEvent,
     MarketTickSizeChangeEvent,
     NewMarketEvent,
+    PriceChange,
     parse_market_event,
 )
 
@@ -296,3 +304,47 @@ def test_empty_string_required_decimal_rejected() -> None:
     payload = dict(_LAST_TRADE) | {"price": ""}
     with pytest.raises(ValidationError):
         parse_market_event(payload)
+
+
+def test_market_payload_annotations_expose_canonical_types() -> None:
+    price_change_hints = get_type_hints(PriceChange, include_extras=True)
+    assert price_change_hints["price"] is Decimal
+    assert price_change_hints["best_bid"] == (Decimal | None)
+    assert price_change_hints["side"] == Literal["BUY", "SELL"]
+
+    book_hints = get_type_hints(MarketBookPayload, include_extras=True)
+    assert book_hints["timestamp"] == (datetime | None)
+    assert book_hints["tick_size"] == (Decimal | None)
+
+
+def test_market_payload_constructor_signatures_expose_canonical_types() -> None:
+    price_change_parameters = inspect.signature(PriceChange).parameters
+    assert price_change_parameters["price"].annotation is Decimal
+    assert price_change_parameters["best_bid"].annotation == (Decimal | None)
+    assert price_change_parameters["side"].annotation == Literal["BUY", "SELL"]
+
+    last_trade_parameters = inspect.signature(MarketLastTradePricePayload).parameters
+    assert last_trade_parameters["timestamp"].annotation == (datetime | None)
+    assert last_trade_parameters["fee_rate_bps"].annotation == (Decimal | None)
+
+
+def test_market_event_keeps_discriminated_union_metadata() -> None:
+    assert get_origin(MarketEvent) is Annotated
+    event_union, metadata = get_args(MarketEvent)
+    assert get_args(event_union) == (
+        MarketBookEvent,
+        MarketPriceChangeEvent,
+        MarketLastTradePriceEvent,
+        MarketTickSizeChangeEvent,
+        MarketBestBidAskEvent,
+        NewMarketEvent,
+        MarketResolvedEvent,
+    )
+    assert metadata.discriminator == "type"
+
+
+def test_optional_market_decimal_annotations_are_consistent() -> None:
+    hints = get_type_hints(MarketBestBidAskPayload, include_extras=True)
+    assert hints["best_bid"] == (Decimal | None)
+    assert hints["best_ask"] == (Decimal | None)
+    assert hints["spread"] == (Decimal | None)


### PR DESCRIPTION
## Summary
- expose market-stream decimals, timestamps, and sides as canonical types
- move wire coercion into explicit field validators
- preserve optional empty strings, strict timestamps, and event discriminators

## Stack
6 of 13 for DEV-537.

## Verification
- 81 focused tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing for all market WebSocket payloads; behavior is intended to be equivalent but mistakes in validators could break stream consumers.
> 
> **Overview**
> Market stream payload models now declare **`Decimal`**, **`datetime | None`**, and **`Literal["BUY", "SELL"]`** on fields instead of hiding those shapes behind `Annotated` / `BeforeValidator` aliases (`EpochMsTimestamp`, `_DecimalFromNumberOrString`, etc.).
> 
> Wire coercion is unchanged in behavior but moved into explicit **`@field_validator(..., mode="before")`** hooks that call shared helpers (`_coerce_decimalish`, `_coerce_optional_decimalish`, `_parse_epoch_ms_timestamp`, side uppercasing). Optional decimals still treat **`""`** as absent; required decimals and strict epoch-ms strings stay strict.
> 
> Tests add assertions that **`get_type_hints`**, constructor signatures, and the **`MarketEvent`** discriminated union metadata expose the canonical types and **`type`** discriminator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ce860013ecf1538bc66bb199f482769667a351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->