### PR TITLE
refactor(models): expose Perps order value types

### DIFF
--- a/src/polymarket/models/perps/orders.py
+++ b/src/polymarket/models/perps/orders.py
@@ -1,14 +1,16 @@
 """Perps order and fill models."""
 
+from datetime import datetime
+from decimal import Decimal
 from typing import Any, Literal, cast
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentId,
@@ -39,10 +41,15 @@ class PerpsTpSlOrderFields(BaseModel):
 
     kind: PerpsTpSlKind
     scope: PerpsTpSlScope
-    trigger_price: _Decimal = Field(validation_alias="trp")
+    trigger_price: Decimal = Field(validation_alias="trp")
     parent_order_id: PerpsOrderId | None = Field(default=None, validation_alias="parent_oid")
-    armed_quantity: _Decimal | None = Field(default=None, validation_alias="armed_qty")
+    armed_quantity: Decimal | None = Field(default=None, validation_alias="armed_qty")
     slippage_bps: int | None = Field(default=None, validation_alias="slip_bps")
+
+    @field_validator("trigger_price", "armed_quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsOrder(BaseModel):
@@ -51,16 +58,16 @@ class PerpsOrder(BaseModel):
     id: PerpsOrderId = Field(validation_alias=AliasChoices("order_id", "oid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: OrderSide = Field(validation_alias="buy")
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
     time_in_force: PerpsTimeInForce = Field(validation_alias="tif")
     post_only: bool = Field(validation_alias=AliasChoices("post_only", "po"))
     reduce_only: bool = Field(validation_alias="ro")
     status: PerpsOrderStatus
-    resting_quantity: _Decimal = Field(validation_alias=AliasChoices("resting_quantity", "rest"))
-    filled_quantity: _Decimal = Field(validation_alias=AliasChoices("filled_quantity", "fill"))
-    created_at: PerpsTimestamp = Field(validation_alias=AliasChoices("created_timestamp", "cts"))
-    updated_at: PerpsTimestamp = Field(validation_alias=AliasChoices("updated_timestamp", "uts"))
+    resting_quantity: Decimal = Field(validation_alias=AliasChoices("resting_quantity", "rest"))
+    filled_quantity: Decimal = Field(validation_alias=AliasChoices("filled_quantity", "fill"))
+    created_at: datetime = Field(validation_alias=AliasChoices("created_timestamp", "cts"))
+    updated_at: datetime = Field(validation_alias=AliasChoices("updated_timestamp", "uts"))
     client_order_id: str | None = Field(
         default=None, validation_alias=AliasChoices("client_order_id", "coid")
     )
@@ -78,6 +85,16 @@ class PerpsOrder(BaseModel):
         normalized["buy"] = _side_from_buy(normalized["buy"])
         return normalized
 
+    @field_validator("price", "quantity", "resting_quantity", "filled_quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_timestamps(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
 
 class PerpsFill(BaseModel):
     """One fill on a Perps order for the account."""
@@ -86,20 +103,43 @@ class PerpsFill(BaseModel):
     order_id: PerpsOrderId = Field(validation_alias=AliasChoices("order_id", "oid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: PerpsSide
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
     taker: bool
-    fee: _Decimal
+    fee: Decimal
     fee_asset: str = Field(validation_alias=AliasChoices("fee_asset", "fea"))
-    previous_size: _Decimal = Field(validation_alias=AliasChoices("previous_size", "psz"))
-    previous_entry_price: _Decimal = Field(
+    previous_size: Decimal = Field(validation_alias=AliasChoices("previous_size", "psz"))
+    previous_entry_price: Decimal = Field(
         validation_alias=AliasChoices("previous_entry_price", "pep")
     )
-    pnl: _Decimal
+    pnl: Decimal
     liquidation: bool = Field(validation_alias=AliasChoices("liquidation", "liq"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
-    hash: OptionalTxHash = None
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    hash: str | None = None
     client_order_id: str | None = Field(default=None, validation_alias="coid")
+
+    @field_validator(
+        "price",
+        "quantity",
+        "fee",
+        "previous_size",
+        "previous_entry_price",
+        "pnl",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _normalize_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 def _default_ack_error(data: object) -> object:

--- a/tests/unit/test_perps_order_models.py
+++ b/tests/unit/test_perps_order_models.py
@@ -1,0 +1,237 @@
+"""Perps order and fill model validation tests."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+
+from polymarket.errors import UnexpectedResponseError
+from polymarket.models.perps.orders import PerpsFill, PerpsOrder, PerpsTpSlOrderFields
+
+
+def _compact_order(**overrides: object) -> dict[str, object]:
+    return {
+        "oid": 5,
+        "iid": 1,
+        "buy": True,
+        "p": "0.5",
+        "qty": "10",
+        "tif": "gtc",
+        "po": False,
+        "ro": True,
+        "status": "open",
+        "rest": "10",
+        "fill": "0",
+        "cts": 1751500000000,
+        "uts": 1751500000001,
+        **overrides,
+    }
+
+
+def _expanded_order(**overrides: object) -> dict[str, object]:
+    return {
+        "order_id": 5,
+        "instrument_id": 1,
+        "buy": False,
+        "price": "0.5",
+        "quantity": "10",
+        "tif": "gtc",
+        "post_only": False,
+        "ro": True,
+        "status": "open",
+        "resting_quantity": "10",
+        "filled_quantity": "0",
+        "created_timestamp": 1751500000000,
+        "updated_timestamp": 1751500000001,
+        **overrides,
+    }
+
+
+def _compact_fill(**overrides: object) -> dict[str, object]:
+    return {
+        "tid": 9,
+        "oid": 5,
+        "iid": 1,
+        "side": "long",
+        "p": "100.5",
+        "qty": "2",
+        "taker": True,
+        "fee": "0.01",
+        "fea": "USDC",
+        "psz": "0",
+        "pep": "0",
+        "pnl": "1.25",
+        "liq": False,
+        "ts": 1751500000000,
+        **overrides,
+    }
+
+
+def _expanded_fill(**overrides: object) -> dict[str, object]:
+    return {
+        "trade_id": 9,
+        "order_id": 5,
+        "instrument_id": 1,
+        "side": "short",
+        "price": "100.5",
+        "quantity": "2",
+        "taker": False,
+        "fee": "0.01",
+        "fee_asset": "USDC",
+        "previous_size": "3",
+        "previous_entry_price": "99",
+        "pnl": "-1.25",
+        "liquidation": False,
+        "timestamp": 1751500000000,
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize(
+    ("model", "expected", "signature_names"),
+    [
+        (
+            PerpsTpSlOrderFields,
+            {"trigger_price": Decimal, "armed_quantity": Decimal | None},
+            {"trigger_price": "trp", "armed_quantity": "armed_qty"},
+        ),
+        (
+            PerpsOrder,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "resting_quantity": Decimal,
+                "filled_quantity": Decimal,
+                "created_at": datetime,
+                "updated_at": datetime,
+            },
+            {},
+        ),
+        (
+            PerpsFill,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "fee": Decimal,
+                "previous_size": Decimal,
+                "previous_entry_price": Decimal,
+                "pnl": Decimal,
+                "timestamp": datetime,
+                "hash": str | None,
+            },
+            {},
+        ),
+    ],
+)
+def test_annotations_and_signatures_expose_canonical_types(
+    model: type[PerpsTpSlOrderFields] | type[PerpsOrder] | type[PerpsFill],
+    expected: dict[str, object],
+    signature_names: dict[str, str],
+) -> None:
+    hints = get_type_hints(model, include_extras=True)
+    parameters = inspect.signature(model).parameters
+
+    for field, annotation in expected.items():
+        assert hints[field] == annotation
+        assert model.model_fields[field].annotation == annotation
+        assert parameters[signature_names.get(field, field)].annotation == annotation
+
+
+def test_order_preserves_compact_and_expanded_aliases_and_buy_normalization() -> None:
+    compact = PerpsOrder.parse_response(_compact_order())
+    expanded = PerpsOrder.parse_response(_expanded_order())
+
+    assert compact.side == "BUY"
+    assert expanded.side == "SELL"
+    assert compact.price == expanded.price == Decimal("0.5")
+    assert compact.created_at == expanded.created_at == datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+def test_order_parses_nested_tpsl_decimals() -> None:
+    order = PerpsOrder.parse_response(
+        _compact_order(
+            tpsl={
+                "kind": "tp",
+                "scope": "position",
+                "trp": 105,
+                "armed_qty": 1.5,
+            }
+        )
+    )
+
+    assert order.tp_sl is not None
+    assert order.tp_sl.trigger_price == Decimal("105")
+    assert order.tp_sl.armed_quantity == Decimal("1.5")
+
+
+@pytest.mark.parametrize("field", ["trp", "armed_qty"])
+def test_tpsl_decimal_fields_reject_bool(field: str) -> None:
+    payload: dict[str, object] = {
+        "kind": "tp",
+        "scope": "position",
+        "trp": "105",
+        "armed_qty": "1.5",
+    }
+    payload[field] = True
+
+    with pytest.raises(UnexpectedResponseError):
+        PerpsTpSlOrderFields.parse_response(payload)
+
+
+@pytest.mark.parametrize("field", ["p", "qty", "rest", "fill"])
+def test_order_decimal_fields_reject_bool(field: str) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(**{field: True}))
+
+
+@pytest.mark.parametrize("field", ["cts", "uts"])
+@pytest.mark.parametrize("value", [True, 1751500000000.0, "1751500000000", None])
+def test_order_timestamps_remain_strict_epoch_milliseconds(field: str, value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(**{field: value}))
+
+
+def test_order_rejects_pre_normalized_side_in_buy_field() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(buy="BUY"))
+
+
+def test_order_timestamps_accept_datetime_instances() -> None:
+    timestamp = datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+    order = PerpsOrder.parse_response(_compact_order(cts=timestamp, uts=timestamp))
+
+    assert order.created_at is timestamp
+    assert order.updated_at is timestamp
+
+
+def test_fill_preserves_compact_and_expanded_aliases_and_numeric_conversion() -> None:
+    compact = PerpsFill.parse_response(_compact_fill(p=100.5, qty=2))
+    expanded = PerpsFill.parse_response(_expanded_fill())
+
+    assert compact.price == expanded.price == Decimal("100.5")
+    assert compact.quantity == expanded.quantity == Decimal("2")
+    assert compact.timestamp == expanded.timestamp == datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_fill_normalizes_placeholder_hashes(placeholder: str) -> None:
+    assert PerpsFill.parse_response(_compact_fill(hash=placeholder)).hash is None
+
+
+def test_fill_preserves_transaction_hash() -> None:
+    transaction_hash = "0x" + "1" * 64
+    assert PerpsFill.parse_response(_compact_fill(hash=transaction_hash)).hash == transaction_hash
+
+
+@pytest.mark.parametrize("field", ["p", "qty", "fee", "psz", "pep", "pnl"])
+def test_fill_decimal_fields_reject_bool(field: str) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsFill.parse_response(_compact_fill(**{field: False}))
+
+
+@pytest.mark.parametrize("value", [True, 1751500000000.0, "1751500000000", None])
+def test_fill_timestamp_remains_strict_epoch_milliseconds(value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsFill.parse_response(_compact_fill(ts=value))


### PR DESCRIPTION
## Summary
- expose Perps order and fill values with canonical types
- preserve compact aliases, side normalization, strict timestamps, and hash sentinels
- add focused model-contract tests

## Stack
11 of 13 for DEV-537.

## Verification
- 70 focused and compatibility tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Model-layer typing and validator wiring only; parsing semantics are preserved and covered by new unit tests.
> 
> **Overview**
> **Perps order and fill models** now advertise **canonical Python types** on their public fields: `Decimal` for prices/quantities/fees, `datetime` for timestamps, and `str | None` for fill transaction hashes. Parsing still goes through the same shared helpers (`_coerce_decimalish`, `_require_epoch_ms`, `_parse_tx_hash`), but via explicit `@field_validator` hooks instead of `Annotated` aliases like `_Decimal`, `PerpsTimestamp`, and `OptionalTxHash`.
> 
> **`PerpsTpSlOrderFields`** gets the same decimal coercion on `trigger_price` and `armed_quantity`. Existing wire behavior is unchanged: compact vs expanded aliases, bool `buy` → `BUY`/`SELL`, strict epoch-ms timestamps (with `datetime` passthrough), and empty/`0x` hash normalization to `None`.
> 
> Adds **`tests/unit/test_perps_order_models.py`** to assert type hints/signatures, alias parsing, decimal/timestamp/hash rules, and rejection of invalid inputs (e.g. bools in decimal fields, pre-normalized `"BUY"` in `buy`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39bb8ba9d917e4aec722c7b51ca234e2086ac097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->