### PR TITLE
refactor(models): remove validation-only aliases

### DIFF
--- a/src/polymarket/models/_validators.py
+++ b/src/polymarket/models/_validators.py
@@ -32,8 +32,3 @@ def parse_e6_decimal_string(value: object) -> object:
         msg = f"invalid base-unit integer string: {value!r}"
         raise ValueError(msg)
     return Decimal(value).scaleb(-6)
-
-
-def serialize_e6_decimal_string(value: Decimal) -> str:
-    """Serialize a scaled amount back to the base-unit integer string the wire carries."""
-    return str(int(value.scaleb(6)))

--- a/src/polymarket/models/_validators.py
+++ b/src/polymarket/models/_validators.py
@@ -1,9 +1,6 @@
 """Field validators shared across SDK model packages."""
 
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator, PlainSerializer
 
 
 def parse_decimal_string(value: object) -> object:
@@ -40,23 +37,3 @@ def parse_e6_decimal_string(value: object) -> object:
 def serialize_e6_decimal_string(value: Decimal) -> str:
     """Serialize a scaled amount back to the base-unit integer string the wire carries."""
     return str(int(value.scaleb(6)))
-
-
-if TYPE_CHECKING:
-    DecimalFromString = Decimal
-    DecimalFromE6String = Decimal
-else:
-    DecimalFromString = Annotated[Decimal, BeforeValidator(parse_decimal_string)]
-    # JSON dumps write the wire's base-unit integer string so a dumped model
-    # re-validates to the same amount instead of being rescaled a second time.
-    DecimalFromE6String = Annotated[
-        Decimal,
-        BeforeValidator(parse_e6_decimal_string),
-        PlainSerializer(serialize_e6_decimal_string, return_type=str, when_used="json"),
-    ]
-
-
-__all__ = [
-    "DecimalFromE6String",
-    "DecimalFromString",
-]

--- a/src/polymarket/models/clob/_validators.py
+++ b/src/polymarket/models/clob/_validators.py
@@ -1,13 +1,5 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator
-
-# Re-exported under the historical private name for the CLOB model modules.
-from polymarket.models._validators import (  # noqa: F401
-    DecimalFromString as _DecimalFromString,  # pyright: ignore[reportUnusedImport]
-)
 
 
 def _coerce_decimalish(value: object) -> object:
@@ -195,37 +187,14 @@ def _parse_expiration_timestamp(value: object) -> object:
     return _parse_epoch_seconds_timestamp(value)
 
 
-if TYPE_CHECKING:
-    _DecimalFromNumberOrString = Decimal
-    _OptionalDecimalFromNumberOrString = Decimal | None
-else:
-    _DecimalFromNumberOrString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
-    # The validator must wrap the whole optional annotation: on a
-    # ``Decimal | None`` union, a BeforeValidator attached only to the Decimal
-    # member cannot map "" to None (the None branch still sees the original "").
-    _OptionalDecimalFromNumberOrString = Annotated[
-        Decimal | None, BeforeValidator(_coerce_optional_decimalish)
-    ]
-
-EpochMsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms_timestamp)]
-EpochMsOrIsoTimestamp = Annotated[
-    datetime | None, BeforeValidator(_parse_epoch_ms_or_iso_timestamp)
-]
-EpochOrIsoTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_or_iso_timestamp)]
-RequiredEpochOrIsoTimestamp = Annotated[datetime, BeforeValidator(_require_epoch_or_iso_timestamp)]
-EpochSecondsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_seconds_timestamp)]
-EpochSecondsOrMsTimestamp = Annotated[
-    datetime | None, BeforeValidator(_parse_epoch_seconds_or_ms_timestamp)
-]
-ExpirationTimestamp = Annotated[datetime | None, BeforeValidator(_parse_expiration_timestamp)]
-
-
 __all__ = [
-    "EpochMsOrIsoTimestamp",
-    "EpochMsTimestamp",
-    "EpochOrIsoTimestamp",
-    "EpochSecondsOrMsTimestamp",
-    "EpochSecondsTimestamp",
-    "ExpirationTimestamp",
-    "RequiredEpochOrIsoTimestamp",
+    "_coerce_decimalish",
+    "_coerce_optional_decimalish",
+    "_parse_epoch_ms_or_iso_timestamp",
+    "_parse_epoch_ms_timestamp",
+    "_parse_epoch_or_iso_timestamp",
+    "_parse_epoch_seconds_or_ms_timestamp",
+    "_parse_epoch_seconds_timestamp",
+    "_parse_expiration_timestamp",
+    "_require_epoch_or_iso_timestamp",
 ]

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Annotated, Any, Literal, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast
 
-from pydantic import BeforeValidator, Field, field_validator
+from pydantic import Field, field_validator
 
 from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
@@ -39,9 +39,6 @@ def _normalize_trade_status(value: object) -> object:
     if isinstance(value, str) and value.startswith("TRADE_STATUS_"):
         return value[len("TRADE_STATUS_") :]
     return value
-
-
-TradeStatusField = Annotated[TradeStatus, BeforeValidator(_normalize_trade_status)]
 
 
 class OpenOrder(BaseModel):

--- a/src/polymarket/models/perps/_validators.py
+++ b/src/polymarket/models/perps/_validators.py
@@ -1,8 +1,5 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator
 
 
 def _coerce_decimalish(value: object) -> object:
@@ -46,19 +43,9 @@ def _parse_tx_hash(value: object) -> object:
     return value
 
 
-if TYPE_CHECKING:
-    _Decimal = Decimal
-else:
-    _Decimal = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
-
-PerpsTimestamp = Annotated[datetime, BeforeValidator(_require_epoch_ms)]
-OptionalPerpsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms)]
-OptionalTxHash = Annotated[str | None, BeforeValidator(_parse_tx_hash)]
-
-
 __all__ = [
-    "OptionalPerpsTimestamp",
-    "OptionalTxHash",
-    "PerpsTimestamp",
-    "_Decimal",
+    "_coerce_decimalish",
+    "_parse_epoch_ms",
+    "_parse_tx_hash",
+    "_require_epoch_ms",
 ]

--- a/tests/unit/test_public_model_annotations.py
+++ b/tests/unit/test_public_model_annotations.py
@@ -1,0 +1,84 @@
+import inspect
+from types import ModuleType
+from typing import cast, get_args, get_type_hints
+
+from pydantic import BaseModel
+from pydantic.functional_serializers import PlainSerializer
+from pydantic.functional_validators import BeforeValidator
+
+import polymarket
+import polymarket.models
+import polymarket.models.clob
+import polymarket.models.perps
+import polymarket.streams
+
+_PUBLIC_MODULES = (
+    polymarket,
+    polymarket.models,
+    polymarket.models.clob,
+    polymarket.models.perps,
+    polymarket.streams,
+)
+
+_REMOVED_ALIASES = (
+    "DecimalFromE6String",
+    "DecimalFromString",
+    "EpochMsOrIsoTimestamp",
+    "EpochMsTimestamp",
+    "EpochOrIsoTimestamp",
+    "EpochSecondsOrMsTimestamp",
+    "EpochSecondsTimestamp",
+    "ExpirationTimestamp",
+    "OptionalPerpsTimestamp",
+    "OptionalTxHash",
+    "PerpsTimestamp",
+    "RequiredEpochOrIsoTimestamp",
+    "TradeStatusField",
+    "_DecimalFromNumberOrString",
+    "_DecimalFromString",
+    "_OptionalDecimalFromNumberOrString",
+)
+
+
+def _public_models(module: ModuleType) -> set[type[BaseModel]]:
+    models: set[type[BaseModel]] = set()
+    exports = cast(tuple[str, ...], module.__dict__["__all__"])
+    for name in exports:
+        value: object = getattr(module, name)
+        if isinstance(value, type) and issubclass(value, BaseModel):
+            models.add(value)
+    return models
+
+
+def _all_public_models() -> set[type[BaseModel]]:
+    models: set[type[BaseModel]] = set()
+    for module in _PUBLIC_MODULES:
+        models.update(_public_models(module))
+    return models
+
+
+def _contains_validation_metadata(annotation: object) -> bool:
+    if isinstance(annotation, BeforeValidator | PlainSerializer):
+        return True
+    return any(_contains_validation_metadata(arg) for arg in get_args(annotation))
+
+
+def test_public_model_fields_expose_canonical_annotations() -> None:
+    for model in _all_public_models():
+        hints = get_type_hints(model, include_extras=True)
+        signature = inspect.signature(model)
+        for field in model.model_fields:
+            annotation = hints[field]
+            assert not _contains_validation_metadata(annotation), f"{model.__name__}.{field}"
+
+        for parameter in signature.parameters.values():
+            assert not _contains_validation_metadata(parameter.annotation), (
+                f"{model.__name__}({parameter.name}=...)"
+            )
+
+
+def test_public_model_source_annotations_do_not_use_removed_aliases() -> None:
+    for model in _all_public_models():
+        source_annotations = repr(model.__dict__.get("__annotations__", {}))
+        for alias in _REMOVED_ALIASES:
+            assert alias not in source_annotations, f"{model.__name__} still uses {alias}"


### PR DESCRIPTION
## Summary
- remove obsolete validation-bearing aliases and `TYPE_CHECKING` branches
- remove the unused E6 serializer helper while retaining response parsing
- enforce canonical annotations and signatures across every exported Pydantic model

## Stack
13 of 13 for DEV-537. This is the final cleanup PR.

## Verification
- `make check`: 2,196 passed, 184 deselected
- `uv build`
- `make api-reference`
- no `BeforeValidator`, `PlainSerializer`, or removed validation aliases remain in public model annotations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only cleanup with regression tests; parsing behavior is intended to stay on field validators rather than changing wire semantics.
> 
> **Overview**
> Removes **Pydantic `Annotated` aliases** (`DecimalFromString`, `DecimalFromE6String`, epoch timestamp types, perps decimal/timestamp aliases, `TradeStatusField`, etc.) from shared and package `_validators` modules. Those modules now **export only the underlying parser/coercion functions**; wire-format handling stays on models via **`field_validator(..., mode="before")`** with **canonical field types** (`Decimal`, `datetime`, `TradeStatus`, …).
> 
> **`account.py`** drops `TradeStatusField` in favor of `status: TradeStatus` plus a before-validator that normalizes prefixed REST statuses.
> 
> Adds **`test_public_model_annotations.py`** to guard exported models: resolved annotations and constructor signatures must not contain `BeforeValidator`/`PlainSerializer`, and class `__annotations__` must not reference the removed alias names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5dd9c6bb0d054cf1c5b55b353e4b591936d4c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->