### PR TITLE
refactor(models): expose Perps account value types

### DIFF
--- a/src/polymarket/models/perps/account.py
+++ b/src/polymarket/models/perps/account.py
@@ -1,12 +1,17 @@
 """Perps account models."""
 
 from collections.abc import Sequence
-from typing import Annotated, cast
+from datetime import datetime
+from decimal import Decimal
+from typing import cast
 
-from pydantic import AliasChoices, BeforeValidator, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.perps._validators import PerpsTimestamp, _Decimal
+from polymarket.models.perps._validators import (
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.perps.types import PerpsEntityId, PerpsInstrumentId
 
 # Proxy key expiries above this magnitude are nanoseconds; convert to ms.
@@ -17,20 +22,37 @@ class PerpsBalance(BaseModel):
     """One asset balance in the Perps account."""
 
     asset: str
-    balance: _Decimal
-    value: _Decimal
+    balance: Decimal
+    value: Decimal
+
+    @field_validator("balance", "value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsAccountStats(BaseModel):
     """Rolling 7-day trading statistics for the Perps account."""
 
-    volume_7d: _Decimal
-    taker_volume_7d: _Decimal
-    maker_volume_7d: _Decimal
-    account_maker_share_7d: _Decimal
-    entity_maker_share_7d: _Decimal | None = None
+    volume_7d: Decimal
+    taker_volume_7d: Decimal
+    maker_volume_7d: Decimal
+    account_maker_share_7d: Decimal
+    entity_maker_share_7d: Decimal | None = None
     entity_id: PerpsEntityId | None = None
     entity_name: str | None = None
+
+    @field_validator(
+        "volume_7d",
+        "taker_volume_7d",
+        "maker_volume_7d",
+        "account_maker_share_7d",
+        "entity_maker_share_7d",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPosition(BaseModel):
@@ -38,26 +60,53 @@ class PerpsPosition(BaseModel):
 
     instrument_id: PerpsInstrumentId
     symbol: str
-    size: _Decimal
-    entry_price: _Decimal
+    size: Decimal
+    entry_price: Decimal
     leverage: int
     cross: bool
-    initial_margin: _Decimal
-    maintenance_margin: _Decimal
-    position_value: _Decimal
-    liquidation_price: _Decimal
-    unrealized_pnl: _Decimal
-    return_on_equity: _Decimal
-    cumulative_funding: _Decimal
+    initial_margin: Decimal
+    maintenance_margin: Decimal
+    position_value: Decimal
+    liquidation_price: Decimal
+    unrealized_pnl: Decimal
+    return_on_equity: Decimal
+    cumulative_funding: Decimal
+
+    @field_validator(
+        "size",
+        "entry_price",
+        "initial_margin",
+        "maintenance_margin",
+        "position_value",
+        "liquidation_price",
+        "unrealized_pnl",
+        "return_on_equity",
+        "cumulative_funding",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsMarginSummary(BaseModel):
     """Account-wide margin totals."""
 
-    total_account_value: _Decimal
-    total_initial_margin: _Decimal
-    total_maintenance_margin: _Decimal
-    total_position_value: _Decimal
+    total_account_value: Decimal
+    total_initial_margin: Decimal
+    total_maintenance_margin: Decimal
+    total_position_value: Decimal
+
+    @field_validator(
+        "total_account_value",
+        "total_initial_margin",
+        "total_maintenance_margin",
+        "total_position_value",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPortfolio(BaseModel):
@@ -65,20 +114,40 @@ class PerpsPortfolio(BaseModel):
 
     positions: tuple[PerpsPosition, ...]
     margin: PerpsMarginSummary
-    withdrawable: _Decimal
+    withdrawable: Decimal
     in_liquidation: bool
-    timestamp: PerpsTimestamp
+    timestamp: datetime
+
+    @field_validator("withdrawable", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsFundingPayment(BaseModel):
     """One funding payment applied to a position."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
-    size: _Decimal = Field(validation_alias=AliasChoices("size", "sz"))
-    funding_rate: _Decimal = Field(validation_alias=AliasChoices("funding_rate", "fr"))
+    size: Decimal = Field(validation_alias=AliasChoices("size", "sz"))
+    funding_rate: Decimal = Field(validation_alias=AliasChoices("funding_rate", "fr"))
     funding_asset: str = Field(validation_alias=AliasChoices("funding_asset", "fua"))
-    funding: _Decimal = Field(validation_alias=AliasChoices("funding", "fund"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    funding: Decimal = Field(validation_alias=AliasChoices("funding", "fund"))
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+
+    @field_validator("size", "funding_rate", "funding", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsAccountConfig(BaseModel):
@@ -92,8 +161,8 @@ class PerpsAccountConfig(BaseModel):
 class PerpsEquityPoint(BaseModel):
     """One account equity observation."""
 
-    timestamp: PerpsTimestamp
-    equity: _Decimal
+    timestamp: datetime
+    equity: Decimal
 
     @model_validator(mode="before")
     @classmethod
@@ -105,12 +174,22 @@ class PerpsEquityPoint(BaseModel):
             return list(entries)
         return {"timestamp": entries[0], "equity": entries[1]}
 
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("equity", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
 
 class PerpsPnlPoint(BaseModel):
     """One account profit-and-loss observation."""
 
-    timestamp: PerpsTimestamp
-    pnl: _Decimal
+    timestamp: datetime
+    pnl: Decimal
 
     @model_validator(mode="before")
     @classmethod
@@ -121,6 +200,16 @@ class PerpsPnlPoint(BaseModel):
         if len(entries) != 2:
             return list(entries)
         return {"timestamp": entries[0], "pnl": entries[1]}
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("pnl", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 def _normalize_proxy_expiry(value: object) -> object:
@@ -136,9 +225,12 @@ class PerpsProxyKey(BaseModel):
 
     proxy: str
     label: str | None = None
-    expires_at: Annotated[PerpsTimestamp, BeforeValidator(_normalize_proxy_expiry)] = Field(
-        validation_alias="expiry"
-    )
+    expires_at: datetime = Field(validation_alias="expiry")
+
+    @field_validator("expires_at", mode="before")
+    @classmethod
+    def _parse_expiry(cls, value: object) -> object:
+        return _require_epoch_ms(_normalize_proxy_expiry(value))
 
 
 class PerpsCredentialsInfo(BaseModel):

--- a/src/polymarket/models/perps/funds.py
+++ b/src/polymarket/models/perps/funds.py
@@ -1,13 +1,16 @@
 """Perps deposit and withdrawal models."""
 
-from pydantic import Field
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsDepositStatus,
@@ -21,25 +24,48 @@ class PerpsDeposit(BaseModel):
 
     hash: str
     asset: str
-    amount: _Decimal
+    amount: Decimal
     status: PerpsDepositStatus
     from_address: str = Field(validation_alias="from")
     to: str
     confirmations: int
     required_confirmations: int
-    created_at: PerpsTimestamp = Field(validation_alias="created_timestamp")
-    confirmed_at: OptionalPerpsTimestamp = Field(
-        default=None, validation_alias="confirmed_timestamp"
-    )
+    created_at: datetime = Field(validation_alias="created_timestamp")
+    confirmed_at: datetime | None = Field(default=None, validation_alias="confirmed_timestamp")
+
+    @field_validator("amount", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_created_at(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("confirmed_at", mode="before")
+    @classmethod
+    def _parse_confirmed_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsDepositUpdate(BaseModel):
     """Streaming status update for one Perps deposit."""
 
-    hash: OptionalTxHash = None
+    hash: str | None = None
     asset: str
-    amount: _Decimal
+    amount: Decimal
     status: PerpsDepositStatus
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
+
+    @field_validator("amount", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsWithdrawal(BaseModel):
@@ -47,17 +73,35 @@ class PerpsWithdrawal(BaseModel):
 
     withdrawal_id: PerpsWithdrawalId = Field(validation_alias="withdraw_id")
     asset: str
-    amount: _Decimal
-    fee: _Decimal
+    amount: Decimal
+    fee: Decimal
     status: PerpsWithdrawalStatus
     to: str
-    hash: OptionalTxHash = None
+    hash: str | None = None
     confirmations: int
     required_confirmations: int
-    created_at: PerpsTimestamp = Field(validation_alias="created_timestamp")
-    confirmed_at: OptionalPerpsTimestamp = Field(
-        default=None, validation_alias="confirmed_timestamp"
-    )
+    created_at: datetime = Field(validation_alias="created_timestamp")
+    confirmed_at: datetime | None = Field(default=None, validation_alias="confirmed_timestamp")
+
+    @field_validator("amount", "fee", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_created_at(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("confirmed_at", mode="before")
+    @classmethod
+    def _parse_confirmed_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsWithdrawalUpdate(BaseModel):
@@ -65,11 +109,21 @@ class PerpsWithdrawalUpdate(BaseModel):
 
     withdrawal_id: PerpsWithdrawalId = Field(validation_alias="withdraw_id")
     asset: str
-    amount: _Decimal
-    fee: _Decimal
+    amount: Decimal
+    fee: Decimal
     status: PerpsWithdrawalStatus
     to: str
-    hash: OptionalTxHash = None
+    hash: str | None = None
+
+    @field_validator("amount", "fee", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 __all__ = [

--- a/tests/unit/test_perps_account_models.py
+++ b/tests/unit/test_perps_account_models.py
@@ -1,0 +1,242 @@
+"""Perps account and funds model validation contracts."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+
+from polymarket.errors import UnexpectedResponseError
+from polymarket.models.perps.account import (
+    PerpsAccountStats,
+    PerpsBalance,
+    PerpsEquityPoint,
+    PerpsFundingPayment,
+    PerpsMarginSummary,
+    PerpsPnlPoint,
+    PerpsPortfolio,
+    PerpsPosition,
+    PerpsProxyKey,
+)
+from polymarket.models.perps.funds import (
+    PerpsDeposit,
+    PerpsDepositUpdate,
+    PerpsWithdrawal,
+    PerpsWithdrawalUpdate,
+)
+
+_EPOCH_MS = 1_747_660_800_123
+_TIMESTAMP = datetime(2025, 5, 19, 13, 20, 0, 123000, tzinfo=UTC)
+
+
+def test_account_and_funds_annotations_expose_canonical_types_with_extras() -> None:
+    expected_fields = {
+        PerpsBalance: {"balance": Decimal, "value": Decimal},
+        PerpsAccountStats: {
+            "volume_7d": Decimal,
+            "taker_volume_7d": Decimal,
+            "maker_volume_7d": Decimal,
+            "account_maker_share_7d": Decimal,
+            "entity_maker_share_7d": Decimal | None,
+        },
+        PerpsPosition: {
+            "size": Decimal,
+            "entry_price": Decimal,
+            "initial_margin": Decimal,
+            "maintenance_margin": Decimal,
+            "position_value": Decimal,
+            "liquidation_price": Decimal,
+            "unrealized_pnl": Decimal,
+            "return_on_equity": Decimal,
+            "cumulative_funding": Decimal,
+        },
+        PerpsMarginSummary: {
+            "total_account_value": Decimal,
+            "total_initial_margin": Decimal,
+            "total_maintenance_margin": Decimal,
+            "total_position_value": Decimal,
+        },
+        PerpsPortfolio: {"withdrawable": Decimal, "timestamp": datetime},
+        PerpsFundingPayment: {
+            "size": Decimal,
+            "funding_rate": Decimal,
+            "funding": Decimal,
+            "timestamp": datetime,
+        },
+        PerpsEquityPoint: {"timestamp": datetime, "equity": Decimal},
+        PerpsPnlPoint: {"timestamp": datetime, "pnl": Decimal},
+        PerpsProxyKey: {"expires_at": datetime},
+        PerpsDeposit: {
+            "amount": Decimal,
+            "created_at": datetime,
+            "confirmed_at": datetime | None,
+        },
+        PerpsDepositUpdate: {"hash": str | None, "amount": Decimal},
+        PerpsWithdrawal: {
+            "amount": Decimal,
+            "fee": Decimal,
+            "hash": str | None,
+            "created_at": datetime,
+            "confirmed_at": datetime | None,
+        },
+        PerpsWithdrawalUpdate: {
+            "amount": Decimal,
+            "fee": Decimal,
+            "hash": str | None,
+        },
+    }
+
+    for model, expected in expected_fields.items():
+        hints = get_type_hints(model, include_extras=True)
+        assert {field: hints[field] for field in expected} == expected
+
+
+def test_model_signatures_expose_canonical_types_and_wire_aliases() -> None:
+    balance = inspect.signature(PerpsBalance).parameters
+    assert balance["balance"].annotation is Decimal
+
+    funding = inspect.signature(PerpsFundingPayment).parameters
+    assert funding["funding"].annotation is Decimal
+    assert funding["timestamp"].annotation is datetime
+
+    proxy = inspect.signature(PerpsProxyKey).parameters
+    assert "expiry" in proxy
+    assert proxy["expiry"].annotation is datetime
+
+    deposit = inspect.signature(PerpsDeposit).parameters
+    assert deposit["amount"].annotation is Decimal
+    assert deposit["created_timestamp"].annotation is datetime
+    assert deposit["confirmed_timestamp"].annotation == (datetime | None)
+
+    withdrawal = inspect.signature(PerpsWithdrawal).parameters
+    assert "withdraw_id" in withdrawal
+    assert withdrawal["hash"].annotation == (str | None)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1.25", Decimal("1.25")),
+        (2, Decimal("2")),
+        (1.5, Decimal("1.5")),
+        (Decimal("3.75"), Decimal("3.75")),
+    ],
+)
+def test_decimal_fields_preserve_perps_number_or_string_grammar(
+    raw: object, expected: Decimal
+) -> None:
+    balance = PerpsBalance.parse_response({"asset": "USDC", "balance": raw, "value": raw})
+    assert balance.balance == expected
+    assert balance.value == expected
+
+
+def test_decimal_fields_reject_booleans() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsBalance.parse_response({"asset": "USDC", "balance": True, "value": "1"})
+
+
+def test_tuple_points_preprocess_before_field_validation() -> None:
+    equity = PerpsEquityPoint.parse_response([_EPOCH_MS, "10.5"])
+    pnl = PerpsPnlPoint.parse_response((_EPOCH_MS, -2.25))
+
+    assert equity.timestamp == _TIMESTAMP
+    assert equity.equity == Decimal("10.5")
+    assert pnl.timestamp == _TIMESTAMP
+    assert pnl.pnl == Decimal("-2.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        PerpsEquityPoint.parse_response([_EPOCH_MS, "10.5", "extra"])
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_required_timestamps_preserve_strict_integer_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsEquityPoint.parse_response([raw, "1"])
+
+
+def test_required_timestamps_pass_datetime_instances_through() -> None:
+    point = PerpsEquityPoint.parse_response([_TIMESTAMP, "1"])
+    assert point.timestamp is _TIMESTAMP
+
+
+def test_funding_payment_preserves_compact_aliases() -> None:
+    payment = PerpsFundingPayment.parse_response(
+        {"iid": 7, "sz": "2", "fr": "0.001", "fua": "USDC", "fund": "0.25", "ts": _EPOCH_MS}
+    )
+
+    assert payment.instrument_id == 7
+    assert payment.size == Decimal("2")
+    assert payment.funding_rate == Decimal("0.001")
+    assert payment.funding_asset == "USDC"
+    assert payment.funding == Decimal("0.25")
+    assert payment.timestamp == _TIMESTAMP
+
+
+def _deposit_payload(**overrides: object) -> dict[str, object]:
+    return {
+        "hash": "0xabc",
+        "asset": "USDC",
+        "amount": "100.5",
+        "status": "pending",
+        "from": "0xfrom",
+        "to": "0xto",
+        "confirmations": 0,
+        "required_confirmations": 3,
+        "created_timestamp": _EPOCH_MS,
+        **overrides,
+    }
+
+
+def test_funds_timestamps_preserve_optional_and_datetime_behavior() -> None:
+    omitted = PerpsDeposit.parse_response(_deposit_payload())
+    explicit_none = PerpsDeposit.parse_response(_deposit_payload(confirmed_timestamp=None))
+    datetimes = PerpsDeposit.parse_response(
+        _deposit_payload(created_timestamp=_TIMESTAMP, confirmed_timestamp=_TIMESTAMP)
+    )
+
+    assert omitted.created_at == _TIMESTAMP
+    assert omitted.confirmed_at is None
+    assert explicit_none.confirmed_at is None
+    assert datetimes.created_at is _TIMESTAMP
+    assert datetimes.confirmed_at is _TIMESTAMP
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_funds_created_timestamp_preserves_strict_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsDeposit.parse_response(_deposit_payload(created_timestamp=raw))
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_optional_transaction_hash_placeholders_normalize_to_none(placeholder: str) -> None:
+    deposit = PerpsDepositUpdate.parse_response(
+        {"hash": placeholder, "asset": "USDC", "amount": "1", "status": "pending"}
+    )
+    withdrawal = PerpsWithdrawalUpdate.parse_response(
+        {
+            "withdraw_id": 1,
+            "asset": "USDC",
+            "amount": "1",
+            "fee": "0.1",
+            "status": "pending",
+            "to": "0xto",
+            "hash": placeholder,
+        }
+    )
+
+    assert deposit.hash is None
+    assert withdrawal.hash is None
+
+
+def test_proxy_expiry_normalizes_nanoseconds_before_epoch_ms_parsing() -> None:
+    proxy = PerpsProxyKey.parse_response(
+        {"proxy": "0xproxy", "label": "bot", "expiry": _EPOCH_MS * 1_000_000}
+    )
+    assert proxy.expires_at == _TIMESTAMP
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_proxy_expiry_preserves_strict_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsProxyKey.parse_response({"proxy": "0xproxy", "expiry": raw})


### PR DESCRIPTION
## Summary
- expose Perps account and funds values with canonical decimal, timestamp, and hash types
- preserve strict integer epoch-millisecond parsing and proxy-expiry normalization order
- add focused model-contract coverage

## Stack
9 of 13 for DEV-537.

## Verification
- 48 focused tests and full unit suite
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deposit/withdrawal and portfolio margin field parsing; behavior is contract-tested but mistakes could mis-parse funds or timestamps for API consumers.
> 
> **Overview**
> Perps **account** and **funds** models now declare **`Decimal`**, **`datetime`**, and **`str | None`** on fields instead of internal annotated aliases (`_Decimal`, `PerpsTimestamp`, optional hash/timestamp types). Wire parsing is unchanged in spirit but moved to **`@field_validator`** hooks that call shared **`_coerce_decimalish`**, **`_require_epoch_ms`**, **`_parse_epoch_ms`**, and **`_parse_tx_hash`** helpers.
> 
> **`PerpsProxyKey.expires_at`** still normalizes nanosecond expiries before epoch-ms parsing, now via a field validator instead of **`BeforeValidator`** on the type. Tuple equity/PnL points and compact funding-payment aliases behave as before.
> 
> Adds **`test_perps_account_models.py`** to lock canonical type hints, alias signatures, decimal/timestamp/hash grammars, and proxy expiry normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576bcb5e4bf8f90637b8f4f808ec51307b2f82d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->