### PR TITLE
refactor(models): expose RTDS and sports value types

### DIFF
--- a/src/polymarket/models/rtds_events.py
+++ b/src/polymarket/models/rtds_events.py
@@ -7,8 +7,8 @@ from pydantic import Field, TypeAdapter, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsOrIsoTimestamp,
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.gamma.comment import (
     Comment,
@@ -41,7 +41,7 @@ _TWAP_WINDOW_BY_WIRE_TOPIC: dict[str, Literal[30, 60]] = {
 
 _CHAINLINK_PRICE_SCALE = 10**18
 _SIGNED_INTEGER_PATTERN = re.compile(r"-?[0-9]+")
-_DECIMALISH_ADAPTER = TypeAdapter(_DecimalFromNumberOrString)
+_DECIMALISH_ADAPTER = TypeAdapter(Decimal)
 
 
 def wire_topic_to_api(wire: str) -> str | None:
@@ -80,29 +80,49 @@ class CommentRemovedPayload(BaseModel):
 class CommentCreatedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["comment_created"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Comment
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class CommentRemovedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["comment_removed"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: CommentRemovedPayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class ReactionCreatedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["reaction_created"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Reaction
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class ReactionRemovedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["reaction_removed"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Reaction
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 CommentsEvent = (
@@ -113,21 +133,36 @@ CommentsEvent = (
 class PriceUpdatePayload(BaseModel):
     symbol: str
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class CryptoPricesBinanceEvent(BaseModel):
     topic: Literal["prices.crypto.binance"] = "prices.crypto.binance"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: PriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class CryptoPricesChainlinkEvent(BaseModel):
     topic: Literal["prices.crypto.chainlink"] = "prices.crypto.chainlink"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: PriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 def _chainlink_e18_to_decimal(value: object) -> Decimal:
@@ -149,7 +184,7 @@ def _chainlink_e18_to_decimal(value: object) -> Decimal:
 class CryptoPricesChainlinkTwapPayload(BaseModel):
     symbol: str
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
     window_seconds: Literal[30, 60] = Field(validation_alias="window_s")
 
     @model_validator(mode="before")
@@ -163,16 +198,26 @@ class CryptoPricesChainlinkTwapPayload(BaseModel):
                 return data
             msg = "full_accuracy_value is required"
             raise ValueError(msg)
-        _DECIMALISH_ADAPTER.validate_python(data.get("value"))
+        _DECIMALISH_ADAPTER.validate_python(_coerce_decimalish(data.get("value")))
         data["value"] = _chainlink_e18_to_decimal(data.pop("full_accuracy_value"))
         return data
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class CryptoPricesChainlinkTwapEvent(BaseModel):
     topic: Literal["prices.crypto.chainlink.twap"] = "prices.crypto.chainlink.twap"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: CryptoPricesChainlinkTwapPayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 CryptoPricesEvent = CryptoPricesBinanceEvent | CryptoPricesChainlinkEvent
@@ -180,7 +225,7 @@ CryptoPricesEvent = CryptoPricesBinanceEvent | CryptoPricesChainlinkEvent
 
 class EquityPriceUpdatePayload(BaseModel):
     symbol: str
-    value: _DecimalFromNumberOrString
+    value: Decimal
     timestamp: int
     received_at: int | None = None
     is_carried_forward: bool | None = None
@@ -196,10 +241,20 @@ class EquityPriceUpdatePayload(BaseModel):
             data["value"] = full
         return data
 
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
 
 class EquityPriceSnapshotEntry(BaseModel):
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class EquityPriceSubscribePayload(BaseModel):
@@ -210,15 +265,25 @@ class EquityPriceSubscribePayload(BaseModel):
 class EquityPricesUpdateEvent(BaseModel):
     topic: Literal["prices.equity.pyth"] = "prices.equity.pyth"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: EquityPriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class EquityPricesSubscribeEvent(BaseModel):
     topic: Literal["prices.equity.pyth"] = "prices.equity.pyth"
     type: Literal["subscribe"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: EquityPriceSubscribePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 EquityPricesEvent = EquityPricesUpdateEvent | EquityPricesSubscribeEvent

--- a/src/polymarket/models/sports_events.py
+++ b/src/polymarket/models/sports_events.py
@@ -1,9 +1,12 @@
+from datetime import datetime
 from typing import Any, Literal, cast
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import EpochMsOrIsoTimestamp
+from polymarket.models.clob._validators import (
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 class SportsGameResult(BaseModel):
@@ -19,7 +22,7 @@ class SportsGameResult(BaseModel):
     score: str
     period: str | None = None
     elapsed: str | None = None
-    finished_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="finishedTimestamp")
+    finished_at: datetime | None = Field(default=None, validation_alias="finishedTimestamp")
     turn: str | None = None
 
     @model_validator(mode="before")
@@ -37,6 +40,11 @@ class SportsGameResult(BaseModel):
         if camel in (None, "") and snake not in (None, ""):
             wire["finishedTimestamp"] = snake
         return wire
+
+    @field_validator("finished_at", mode="before")
+    @classmethod
+    def _parse_finished_at(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class SportsResultEvent(BaseModel):

--- a/tests/unit/test_streams_rtds_events.py
+++ b/tests/unit/test_streams_rtds_events.py
@@ -1,6 +1,7 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 
@@ -13,6 +14,7 @@ from polymarket.models.rtds_events import (
     CryptoPricesChainlinkTwapPayload,
     EquityPricesSubscribeEvent,
     EquityPricesUpdateEvent,
+    PriceUpdatePayload,
     ReactionCreatedEvent,
     api_topic_to_wire,
     parse_rtds_event,
@@ -186,6 +188,48 @@ def test_crypto_chainlink_wire_topic_remapped_to_api_topic() -> None:
     assert event.payload.symbol == "ETH/USD"
 
 
+def test_rtds_fields_expose_canonical_annotations() -> None:
+    price_hints = get_type_hints(PriceUpdatePayload, include_extras=True)
+    event_hints = get_type_hints(CommentCreatedEvent, include_extras=True)
+
+    assert price_hints["value"] is Decimal
+    assert event_hints["timestamp"] == (datetime | None)
+    assert inspect.signature(PriceUpdatePayload).parameters["value"].annotation is Decimal
+    assert inspect.signature(CommentCreatedEvent).parameters["timestamp"].annotation == (
+        datetime | None
+    )
+
+
+@pytest.mark.parametrize("value", [b"1.5", True, None, object()])
+def test_decimalish_fields_do_not_accept_broader_decimal_inputs(value: object) -> None:
+    with pytest.raises(ValueError):
+        PriceUpdatePayload.model_validate({"symbol": "BTC", "timestamp": 0, "value": value})
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected"),
+    [
+        (1710000000000, datetime.fromtimestamp(1710000000, tz=UTC)),
+        ("1710000000000", datetime.fromtimestamp(1710000000, tz=UTC)),
+        ("2024-03-09T12:00:00+00:00", datetime(2024, 3, 9, 12, tzinfo=UTC)),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_rtds_timestamp_preserves_accepted_inputs(
+    timestamp: object, expected: datetime | None
+) -> None:
+    event = parse_rtds_event({**_CRYPTO_BINANCE, "timestamp": timestamp})
+
+    assert event.timestamp == expected
+
+
+@pytest.mark.parametrize("timestamp", [True, 1710000000000.0, b"1710000000000", "+1", "-1"])
+def test_rtds_timestamp_preserves_rejected_inputs(timestamp: object) -> None:
+    with pytest.raises(ValueError):
+        parse_rtds_event({**_CRYPTO_BINANCE, "timestamp": timestamp})
+
+
 @pytest.mark.parametrize(
     ("wire_topic", "window_seconds"),
     [
@@ -323,6 +367,17 @@ def test_crypto_chainlink_twap_still_validates_display_value(display_value: obje
         payload["value"] = display_value
 
     with pytest.raises(ValueError):
+        parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
+
+
+def test_crypto_chainlink_twap_validates_display_value_before_full_accuracy_value() -> None:
+    payload = {
+        **_CRYPTO_CHAINLINK_TWAP["payload"],
+        "value": object(),
+        "full_accuracy_value": "invalid",
+    }
+
+    with pytest.raises(ValueError, match="expected decimal-ish value, got object"):
         parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
 
 

--- a/tests/unit/test_streams_sports_events.py
+++ b/tests/unit/test_streams_sports_events.py
@@ -1,5 +1,6 @@
+import inspect
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 from pydantic import ValidationError
@@ -41,6 +42,15 @@ def test_camelcase_wire_fields_map_to_snake_case() -> None:
     assert event.payload.league_abbreviation == "NBA"
     assert event.payload.home_team == "LAL"
     assert event.payload.away_team == "BOS"
+
+
+def test_finished_timestamp_exposes_canonical_annotation_and_alias_signature() -> None:
+    hints = get_type_hints(SportsGameResult, include_extras=True)
+    parameters = inspect.signature(SportsGameResult).parameters
+
+    assert hints["finished_at"] == (datetime | None)
+    assert parameters["finishedTimestamp"].annotation == (datetime | None)
+    assert "finished_at" not in parameters
 
 
 def test_required_fields_only() -> None:
@@ -94,6 +104,16 @@ def test_finished_timestamp_accepts_iso_string() -> None:
     event = parse_sports_event(payload)
     assert event.payload.finished_at is not None
     assert event.payload.finished_at.year == 2024
+
+
+@pytest.mark.parametrize(
+    "finished_timestamp", [True, 1710000000000.0, b"1710000000000", "+1", "-1"]
+)
+def test_finished_timestamp_preserves_rejected_inputs(finished_timestamp: object) -> None:
+    payload = dict(_WIRE) | {"finishedTimestamp": finished_timestamp}
+
+    with pytest.raises(ValidationError):
+        parse_sports_event(payload)
 
 
 def test_missing_required_field_raises_validation_error() -> None:


### PR DESCRIPTION
## Summary
- expose RTDS and sports prices and timestamps as canonical types
- preserve TWAP full-accuracy ordering and timestamp coalescing
- keep the intermediate decimal adapter strict

## Stack
8 of 13 for DEV-537.

## Verification
- 74 focused tests and 132 relevant contract tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time price and sports event parsing paths; behavior is intended to stay the same but stricter validation and annotation changes could affect downstream typing or edge-case inputs.
> 
> **Overview**
> RTDS and sports stream models now declare **canonical public types** (`Decimal`, `datetime | None`) on fields instead of `Annotated` aliases like `EpochMsOrIsoTimestamp` and `_DecimalFromNumberOrString`, with explicit `field_validator`s wired to `_parse_epoch_ms_or_iso_timestamp` and `_coerce_decimalish`.
> 
> The same pattern applies across comment/crypto/equity RTDS events and `SportsGameResult.finished_at`; Chainlink TWAP still runs display-`value` coercion before `full_accuracy_value` conversion. New unit tests lock in type hints/signatures, accepted vs rejected timestamp and decimal wire shapes, and TWAP validation ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a0d0d1fa9f3e8561be3f03e0673e1a9e95a3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->