### PR TITLE
refactor(models): expose Perps market value types

### DIFF
--- a/src/polymarket/models/perps/market.py
+++ b/src/polymarket/models/perps/market.py
@@ -1,16 +1,18 @@
 """Perps market data models."""
 
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal
 from typing import Literal, cast
 
 from pydantic import AliasChoices, Field, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentCategory,
@@ -20,11 +22,49 @@ from polymarket.models.perps.types import (
 )
 
 
+def _normalize_field(
+    data: dict[str, object],
+    aliases: tuple[str, ...],
+    parser: Callable[[object], object],
+) -> None:
+    for alias in aliases:
+        if alias in data:
+            data[alias] = parser(data[alias])
+            return
+
+
+def _normalize_market_data(
+    data: object,
+    *,
+    decimals: tuple[tuple[str, ...], ...] = (),
+    timestamps: tuple[tuple[str, ...], ...] = (),
+    optional_timestamps: tuple[tuple[str, ...], ...] = (),
+    optional_hashes: tuple[tuple[str, ...], ...] = (),
+) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    normalized = dict(cast("Mapping[str, object]", data))
+    for aliases in decimals:
+        _normalize_field(normalized, aliases, _coerce_decimalish)
+    for aliases in timestamps:
+        _normalize_field(normalized, aliases, _require_epoch_ms)
+    for aliases in optional_timestamps:
+        _normalize_field(normalized, aliases, _parse_epoch_ms)
+    for aliases in optional_hashes:
+        _normalize_field(normalized, aliases, _parse_tx_hash)
+    return normalized
+
+
 class PerpsRiskTier(BaseModel):
     """One leverage risk tier for a Perps instrument."""
 
-    lower_bound: _Decimal
+    lower_bound: Decimal
     max_leverage: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(data, decimals=(("lower_bound",),))
 
 
 class PerpsInstrument(BaseModel):
@@ -38,15 +78,29 @@ class PerpsInstrument(BaseModel):
     funding_interval: str
     quantity_decimals: int
     price_decimals: int
-    price_bounds: _Decimal
-    liquidation_fee: _Decimal
+    price_bounds: Decimal
+    liquidation_fee: Decimal
     max_order_count: int
-    min_notional: _Decimal
-    max_market_notional: _Decimal
-    max_limit_notional: _Decimal
+    min_notional: Decimal
+    max_market_notional: Decimal
+    max_limit_notional: Decimal
     max_leverage: int
     isolated_only: bool
     risk_tiers: tuple[PerpsRiskTier, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("price_bounds",),
+                ("liquidation_fee",),
+                ("min_notional",),
+                ("max_market_notional",),
+                ("max_limit_notional",),
+            ),
+        )
 
 
 class PerpsTicker(BaseModel):
@@ -54,29 +108,64 @@ class PerpsTicker(BaseModel):
 
     instrument_id: PerpsInstrumentId
     symbol: str
-    index_price: _Decimal
-    mark_price: _Decimal
-    last_price: _Decimal
-    mid_price: _Decimal
-    open_interest: _Decimal
-    funding_rate: _Decimal
-    next_funding: PerpsTimestamp
-    timestamp: OptionalPerpsTimestamp = None
-    open_price: _Decimal | None = None
-    volume_24h: _Decimal | None = None
+    index_price: Decimal
+    mark_price: Decimal
+    last_price: Decimal
+    mid_price: Decimal
+    open_interest: Decimal
+    funding_rate: Decimal
+    next_funding: datetime
+    timestamp: datetime | None = None
+    open_price: Decimal | None = None
+    volume_24h: Decimal | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("index_price",),
+                ("mark_price",),
+                ("last_price",),
+                ("mid_price",),
+                ("open_interest",),
+                ("funding_rate",),
+                ("open_price",),
+                ("volume_24h",),
+            ),
+            timestamps=(("next_funding",),),
+            optional_timestamps=(("timestamp",),),
+        )
 
 
 class PerpsTickerUpdate(BaseModel):
     """Streaming ticker update for a Perps instrument."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias="iid")
-    index_price: _Decimal = Field(validation_alias="idx")
-    mark_price: _Decimal = Field(validation_alias="mark")
-    last_price: _Decimal = Field(validation_alias="last")
-    mid_price: _Decimal = Field(validation_alias="mid")
-    open_interest: _Decimal = Field(validation_alias="oi")
-    funding_rate: _Decimal = Field(validation_alias="fr")
-    next_funding: PerpsTimestamp = Field(validation_alias="nxf")
+    index_price: Decimal = Field(validation_alias="idx")
+    mark_price: Decimal = Field(validation_alias="mark")
+    last_price: Decimal = Field(validation_alias="last")
+    mid_price: Decimal = Field(validation_alias="mid")
+    open_interest: Decimal = Field(validation_alias="oi")
+    funding_rate: Decimal = Field(validation_alias="fr")
+    next_funding: datetime = Field(validation_alias="nxf")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("idx", "index_price"),
+                ("mark", "mark_price"),
+                ("last", "last_price"),
+                ("mid", "mid_price"),
+                ("oi", "open_interest"),
+                ("fr", "funding_rate"),
+            ),
+            timestamps=(("nxf", "next_funding"),),
+        )
 
 
 def _candle_from_tuple(value: object) -> object:
@@ -99,18 +188,22 @@ def _candle_from_tuple(value: object) -> object:
 class PerpsCandle(BaseModel):
     """One OHLCV candle for a Perps instrument."""
 
-    timestamp: PerpsTimestamp
-    open: _Decimal
-    high: _Decimal
-    low: _Decimal
-    close: _Decimal
-    volume: _Decimal
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
     trades: int
 
     @model_validator(mode="before")
     @classmethod
-    def _from_tuple(cls, data: object) -> object:
-        return _candle_from_tuple(data)
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            _candle_from_tuple(data),
+            decimals=(("open",), ("high",), ("low",), ("close",), ("volume",)),
+            timestamps=(("timestamp",),),
+        )
 
 
 class PerpsStatistic(BaseModel):
@@ -118,9 +211,17 @@ class PerpsStatistic(BaseModel):
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     symbol: str | None = None
-    volume: _Decimal = Field(validation_alias=AliasChoices("volume", "vol"))
-    open_price: _Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
+    volume: Decimal = Field(validation_alias=AliasChoices("volume", "vol"))
+    open_price: Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
     klines: tuple[PerpsCandle, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("volume", "vol"), ("open_price", "open")),
+        )
 
 
 def _level_from_tuple(value: object) -> object:
@@ -135,13 +236,16 @@ def _level_from_tuple(value: object) -> object:
 class PerpsBookLevel(BaseModel):
     """One price level of a Perps order book."""
 
-    price: _Decimal
-    quantity: _Decimal
+    price: Decimal
+    quantity: Decimal
 
     @model_validator(mode="before")
     @classmethod
-    def _from_tuple(cls, data: object) -> object:
-        return _level_from_tuple(data)
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            _level_from_tuple(data),
+            decimals=(("price",), ("quantity",)),
+        )
 
 
 class PerpsBook(BaseModel):
@@ -150,8 +254,13 @@ class PerpsBook(BaseModel):
     instrument_id: PerpsInstrumentId
     bids: tuple[PerpsBookLevel, ...]
     asks: tuple[PerpsBookLevel, ...]
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(data, timestamps=(("timestamp",),))
 
 
 class PerpsBookUpdate(BaseModel):
@@ -166,11 +275,25 @@ class PerpsBbo(BaseModel):
     """Best bid and ask for a Perps instrument."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
-    bid_price: _Decimal = Field(validation_alias=AliasChoices("bid_price", "bp"))
-    bid_quantity: _Decimal = Field(validation_alias=AliasChoices("bid_quantity", "bq"))
-    ask_price: _Decimal = Field(validation_alias=AliasChoices("ask_price", "ap"))
-    ask_quantity: _Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
-    timestamp: OptionalPerpsTimestamp = None
+    bid_price: Decimal = Field(validation_alias=AliasChoices("bid_price", "bp"))
+    bid_quantity: Decimal = Field(validation_alias=AliasChoices("bid_quantity", "bq"))
+    ask_price: Decimal = Field(validation_alias=AliasChoices("ask_price", "ap"))
+    ask_quantity: Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
+    timestamp: datetime | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("bid_price", "bp"),
+                ("bid_quantity", "bq"),
+                ("ask_price", "ap"),
+                ("ask_quantity", "aq"),
+            ),
+            optional_timestamps=(("timestamp",),),
+        )
 
 
 class PerpsTrade(BaseModel):
@@ -179,34 +302,69 @@ class PerpsTrade(BaseModel):
     trade_id: PerpsTradeId = Field(validation_alias=AliasChoices("trade_id", "tid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: PerpsSide
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
-    hash: OptionalTxHash = None
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    hash: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("price", "p"), ("quantity", "qty")),
+            timestamps=(("timestamp", "ts"),),
+            optional_hashes=(("hash",),),
+        )
 
 
 class PerpsFundingRate(BaseModel):
     """One historical funding rate observation."""
 
-    funding_rate: _Decimal
-    timestamp: PerpsTimestamp
+    funding_rate: Decimal
+    timestamp: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("funding_rate",),),
+            timestamps=(("timestamp",),),
+        )
 
 
 class PerpsFeeTier(BaseModel):
     """One volume-based fee tier for a Perps instrument category."""
 
-    min_volume_30d: _Decimal
-    taker_fee_rate: _Decimal
-    maker_fee_rate: _Decimal
+    min_volume_30d: Decimal
+    taker_fee_rate: Decimal
+    maker_fee_rate: Decimal
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("min_volume_30d",), ("taker_fee_rate",), ("maker_fee_rate",)),
+        )
 
 
 class PerpsFeeScheduleEntry(BaseModel):
     """Maker and taker fee rates for a Perps instrument category."""
 
     category: PerpsInstrumentCategory
-    taker_fee_rate: _Decimal
-    maker_fee_rate: _Decimal
+    taker_fee_rate: Decimal
+    maker_fee_rate: Decimal
     tiers: tuple[PerpsFeeTier, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("taker_fee_rate",), ("maker_fee_rate",)),
+        )
 
 
 class PerpsCandleBatch(BaseModel):

--- a/tests/unit/test_perps_market_models.py
+++ b/tests/unit/test_perps_market_models.py
@@ -1,0 +1,247 @@
+"""Perps public market model validation contracts."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+from pydantic import ValidationError
+
+from polymarket.models.perps.market import (
+    PerpsBbo,
+    PerpsBook,
+    PerpsBookLevel,
+    PerpsCandle,
+    PerpsFeeScheduleEntry,
+    PerpsFeeTier,
+    PerpsFundingRate,
+    PerpsInstrument,
+    PerpsRiskTier,
+    PerpsStatistic,
+    PerpsTicker,
+    PerpsTickerUpdate,
+    PerpsTrade,
+)
+
+_EPOCH_MS = 1_751_500_000_000
+_TIMESTAMP = datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("model", "fields"),
+    [
+        (PerpsRiskTier, {"lower_bound": Decimal}),
+        (
+            PerpsInstrument,
+            {
+                "price_bounds": Decimal,
+                "liquidation_fee": Decimal,
+                "min_notional": Decimal,
+                "max_market_notional": Decimal,
+                "max_limit_notional": Decimal,
+            },
+        ),
+        (
+            PerpsTicker,
+            {
+                "index_price": Decimal,
+                "mark_price": Decimal,
+                "last_price": Decimal,
+                "mid_price": Decimal,
+                "open_interest": Decimal,
+                "funding_rate": Decimal,
+                "next_funding": datetime,
+                "timestamp": datetime | None,
+                "open_price": Decimal | None,
+                "volume_24h": Decimal | None,
+            },
+        ),
+        (
+            PerpsTickerUpdate,
+            {
+                "index_price": Decimal,
+                "mark_price": Decimal,
+                "last_price": Decimal,
+                "mid_price": Decimal,
+                "open_interest": Decimal,
+                "funding_rate": Decimal,
+                "next_funding": datetime,
+            },
+        ),
+        (
+            PerpsCandle,
+            {
+                "timestamp": datetime,
+                "open": Decimal,
+                "high": Decimal,
+                "low": Decimal,
+                "close": Decimal,
+                "volume": Decimal,
+            },
+        ),
+        (PerpsStatistic, {"volume": Decimal, "open_price": Decimal}),
+        (PerpsBookLevel, {"price": Decimal, "quantity": Decimal}),
+        (PerpsBook, {"timestamp": datetime}),
+        (
+            PerpsBbo,
+            {
+                "bid_price": Decimal,
+                "bid_quantity": Decimal,
+                "ask_price": Decimal,
+                "ask_quantity": Decimal,
+                "timestamp": datetime | None,
+            },
+        ),
+        (
+            PerpsTrade,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "timestamp": datetime,
+                "hash": str | None,
+            },
+        ),
+        (PerpsFundingRate, {"funding_rate": Decimal, "timestamp": datetime}),
+        (
+            PerpsFeeTier,
+            {
+                "min_volume_30d": Decimal,
+                "taker_fee_rate": Decimal,
+                "maker_fee_rate": Decimal,
+            },
+        ),
+        (
+            PerpsFeeScheduleEntry,
+            {"taker_fee_rate": Decimal, "maker_fee_rate": Decimal},
+        ),
+    ],
+)
+def test_public_annotations_are_canonical(model: type[object], fields: dict[str, object]) -> None:
+    hints = get_type_hints(model, include_extras=True)
+    for field, expected in fields.items():
+        assert hints[field] == expected
+
+
+def test_generated_signatures_use_canonical_types_and_compact_aliases() -> None:
+    ticker_parameters = inspect.signature(PerpsTickerUpdate).parameters
+    assert ticker_parameters["idx"].annotation is Decimal
+    assert ticker_parameters["nxf"].annotation is datetime
+
+    trade_parameters = inspect.signature(PerpsTrade).parameters
+    assert trade_parameters["price"].annotation is Decimal
+    assert trade_parameters["timestamp"].annotation is datetime
+    assert trade_parameters["hash"].annotation == (str | None)
+
+
+def test_compact_market_payload_preserves_decimal_and_timestamp_parsing() -> None:
+    ticker = PerpsTickerUpdate.model_validate(
+        {
+            "iid": 4,
+            "idx": 100,
+            "mark": 100.1,
+            "last": Decimal("100.2"),
+            "mid": "100.15",
+            "oi": "5000",
+            "fr": "0.0001",
+            "nxf": _EPOCH_MS,
+        }
+    )
+
+    assert ticker.index_price == Decimal("100")
+    assert ticker.mark_price == Decimal("100.1")
+    assert ticker.last_price == Decimal("100.2")
+    assert ticker.next_funding == _TIMESTAMP
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_decimal_fields_reject_bool(value: bool) -> None:
+    with pytest.raises(ValidationError, match="decimal-ish"):
+        PerpsBookLevel.model_validate([value, "1"])
+
+
+@pytest.mark.parametrize("value", [1.5, "1751500000000", True, None])
+def test_required_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms"):
+        PerpsFundingRate.model_validate({"funding_rate": "0.001", "timestamp": value})
+
+
+def test_tuple_preprocessing_and_optional_values_are_preserved() -> None:
+    candle = PerpsCandle.model_validate((_EPOCH_MS, 1, 2.5, "0.5", Decimal("1.5"), 10, 3))
+    bbo = PerpsBbo.model_validate(
+        {"iid": 7, "bp": "1", "bq": "2", "ap": "3", "aq": "4", "timestamp": None}
+    )
+
+    assert candle.timestamp == _TIMESTAMP
+    assert candle.open == Decimal("1")
+    assert candle.high == Decimal("2.5")
+    assert candle.volume == Decimal("10")
+    assert bbo.timestamp is None
+
+
+def test_optional_decimal_fields_accept_none_and_missing_values() -> None:
+    ticker = PerpsTicker.model_validate(
+        {
+            "instrument_id": 7,
+            "symbol": "XYZ-PERP",
+            "index_price": "100",
+            "mark_price": "101",
+            "last_price": "100.5",
+            "mid_price": "100.6",
+            "open_interest": "5000",
+            "funding_rate": "0.0001",
+            "next_funding": _EPOCH_MS,
+            "open_price": None,
+        }
+    )
+
+    assert ticker.open_price is None
+    assert ticker.volume_24h is None
+    assert ticker.timestamp is None
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_trade_normalizes_placeholder_transaction_hash(placeholder: str) -> None:
+    trade = PerpsTrade.model_validate(
+        {
+            "tid": 1,
+            "iid": 7,
+            "side": "long",
+            "p": "100",
+            "qty": "2",
+            "ts": _EPOCH_MS,
+            "hash": placeholder,
+        }
+    )
+
+    assert trade.hash is None
+
+
+def test_optional_timestamp_accepts_datetime_without_rewriting_it() -> None:
+    bbo = PerpsBbo.model_validate(
+        {
+            "instrument_id": 7,
+            "bid_price": "1",
+            "bid_quantity": "2",
+            "ask_price": "3",
+            "ask_quantity": "4",
+            "timestamp": _TIMESTAMP,
+        }
+    )
+
+    assert bbo.timestamp is _TIMESTAMP
+
+
+@pytest.mark.parametrize("value", [1.5, "1751500000000", True])
+def test_optional_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms"):
+        PerpsBbo.model_validate(
+            {
+                "iid": 7,
+                "bp": "1",
+                "bq": "2",
+                "ap": "3",
+                "aq": "4",
+                "timestamp": value,
+            }
+        )


### PR DESCRIPTION
## Summary
- expose Perps market responses with canonical decimal, timestamp, and hash types
- preserve compact aliases, tuple preprocessing, and strict Perps wire formats
- add focused annotation and behavior coverage

## Stack
10 of 13 for DEV-537.

## Verification
- full unit suite
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing for all public perps market payloads; behavior is heavily tested but any normalization bug could affect prices, timestamps, or trades downstream.
> 
> **Overview**
> Perps **public market models** now declare **`Decimal`**, **`datetime`**, and **`str | None`** on fields instead of internal `Annotated` aliases (`_Decimal`, `PerpsTimestamp`, etc.), so consumers and generated signatures see normal Python types.
> 
> Wire parsing is unchanged in spirit but **moved into shared `before` validators**: `_normalize_market_data` applies the same decimal, strict epoch-ms, optional timestamp, and tx-hash rules per model (including **compact stream aliases** like `idx` / `nxf` and **tuple** candle/book-level inputs).
> 
> Adds **`tests/unit/test_perps_market_models.py`** to lock annotations, alias behavior, strict validation (e.g. bools rejected for decimals), and edge cases like placeholder trade hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f0a3863fd16154c827b09ffb0b79b8efa7b360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->