### PR TITLE
refactor(models): expose CLOB builder value types

### DIFF
--- a/src/polymarket/models/clob/api_key.py
+++ b/src/polymarket/models/clob/api_key.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from pydantic import Field
+from datetime import datetime
+
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import EpochMsOrIsoTimestamp
+from polymarket.models.clob._validators import (
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 class ApiKeyCreds(BaseModel):
@@ -31,8 +35,13 @@ class BuilderApiKeyInfo(BaseModel):
     """
 
     key: str
-    created_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="createdAt")
-    revoked_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="revokedAt")
+    created_at: datetime | None = Field(default=None, validation_alias="createdAt")
+    revoked_at: datetime | None = Field(default=None, validation_alias="revokedAt")
+
+    @field_validator("created_at", "revoked_at", mode="before")
+    @classmethod
+    def _parse_timestamps(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 __all__ = ["ApiKeyCreds", "BuilderApiKeyInfo"]

--- a/src/polymarket/models/clob/builder.py
+++ b/src/polymarket/models/clob/builder.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal, DecimalException
 from typing import Any, cast
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochOrIsoTimestamp,
-    RequiredEpochOrIsoTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
@@ -53,22 +54,37 @@ class BuilderTrade(BaseModel):
     )
     token_id: TokenId = Field(validation_alias="assetId")
     side: OrderSide
-    size: _DecimalFromString
-    size_usdc: _DecimalFromString = Field(validation_alias="sizeUsdc")
-    price: _DecimalFromString
+    size: Decimal
+    size_usdc: Decimal = Field(validation_alias="sizeUsdc")
+    price: Decimal
     status: str
     outcome: str
     outcome_index: int = Field(validation_alias="outcomeIndex")
     owner: str
     maker: str
     transaction_hash: str = Field(validation_alias="transactionHash")
-    matched_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="matchTime")
+    matched_at: datetime = Field(validation_alias="matchTime")
     bucket_index: int = Field(validation_alias="bucketIndex")
-    fee: _DecimalFromString
-    fee_usdc: _DecimalFromString = Field(validation_alias="feeUsdc")
+    fee: Decimal
+    fee_usdc: Decimal = Field(validation_alias="feeUsdc")
     error_msg: str | None = Field(default=None, validation_alias="err_msg")
-    created_at: EpochOrIsoTimestamp = Field(default=None, validation_alias="createdAt")
-    updated_at: EpochOrIsoTimestamp = Field(default=None, validation_alias="updatedAt")
+    created_at: datetime | None = Field(default=None, validation_alias="createdAt")
+    updated_at: datetime | None = Field(default=None, validation_alias="updatedAt")
+
+    @field_validator("size", "size_usdc", "price", "fee", "fee_usdc", mode="before")
+    @classmethod
+    def _parse_decimal_fields(cls, value: object) -> object:
+        return parse_decimal_string(value)
+
+    @field_validator("matched_at", mode="before")
+    @classmethod
+    def _parse_matched_at(cls, value: object) -> object:
+        return _require_epoch_or_iso_timestamp(value)
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_optional_timestamps(cls, value: object) -> object:
+        return _parse_epoch_or_iso_timestamp(value)
 
 
 __all__ = ["BuilderFeeRates", "BuilderTrade"]

--- a/src/polymarket/models/clob/order_response.py
+++ b/src/polymarket/models/clob/order_response.py
@@ -5,10 +5,8 @@ from typing import Literal, TypeAlias
 
 from pydantic import Field, field_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderId
 from polymarket.types import TransactionHash
 
@@ -45,18 +43,18 @@ _ERROR_MSG_TO_CODE: dict[str, OrderResponseErrorCode] = {
 
 class RawOrderResponse(BaseModel):
     error_msg: str = Field(validation_alias="errorMsg")
-    making_amount: _DecimalFromString = Field(validation_alias="makingAmount")
+    making_amount: Decimal = Field(validation_alias="makingAmount")
     order_id: str = Field(validation_alias="orderID")
     status: str
     success: bool
-    taking_amount: _DecimalFromString = Field(validation_alias="takingAmount")
+    taking_amount: Decimal = Field(validation_alias="takingAmount")
     trade_ids: tuple[str, ...] = Field(default=(), validation_alias="tradeIDs")
     transactions_hashes: tuple[str, ...] = Field(default=(), validation_alias="transactionsHashes")
 
     @field_validator("making_amount", "taking_amount", mode="before")
     @classmethod
-    def _empty_string_to_zero(cls, value: object) -> object:
-        return "0" if value == "" else value
+    def _parse_amounts(cls, value: object) -> object:
+        return parse_decimal_string("0" if value == "" else value)
 
 
 class AcceptedOrder(BaseModel):

--- a/tests/unit/test_auth_actions.py
+++ b/tests/unit/test_auth_actions.py
@@ -1,3 +1,7 @@
+import inspect
+from datetime import UTC, datetime
+from typing import get_type_hints
+
 import pytest
 
 from polymarket._internal.actions.auth import (
@@ -10,6 +14,7 @@ from polymarket._internal.actions.auth import (
 from polymarket._internal.l1_auth import ApiKeyAuthSignature
 from polymarket.auth import BuilderApiKey
 from polymarket.errors import UnexpectedResponseError
+from polymarket.models.clob.api_key import BuilderApiKeyInfo
 
 
 def _sig() -> ApiKeyAuthSignature:
@@ -91,6 +96,31 @@ def test_parse_builder_api_keys_response_parses_records() -> None:
     assert keys[0].key == "k"
     assert keys[0].created_at is not None
     assert keys[0].revoked_at is None
+
+
+def test_builder_api_key_info_annotations_and_signature_expose_datetimes() -> None:
+    hints = get_type_hints(BuilderApiKeyInfo, include_extras=True)
+    assert hints["created_at"] == (datetime | None)
+    assert hints["revoked_at"] == (datetime | None)
+
+    parameters = inspect.signature(BuilderApiKeyInfo).parameters
+    assert parameters["createdAt"].annotation == (datetime | None)
+    assert parameters["revokedAt"].annotation == (datetime | None)
+
+
+def test_parse_builder_api_keys_response_preserves_timestamp_formats() -> None:
+    keys = parse_builder_api_keys_response(
+        [
+            {
+                "key": "k",
+                "createdAt": 1700000000000,
+                "revokedAt": "2023-11-14T22:13:25Z",
+            }
+        ]
+    )
+
+    assert keys[0].created_at == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+    assert keys[0].revoked_at == datetime(2023, 11, 14, 22, 13, 25, tzinfo=UTC)
 
 
 def test_parse_builder_api_keys_response_normalizes_bare_string_elements() -> None:

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -1,8 +1,9 @@
 # pyright: reportPrivateUsage=false
 import asyncio
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -49,6 +50,19 @@ _WIRE_TRADE: dict[str, Any] = {
 
 
 class TestBuilderTradeModel:
+    def test_annotations_and_signature_expose_canonical_types(self) -> None:
+        hints = get_type_hints(BuilderTrade, include_extras=True)
+        for field in ("size", "size_usdc", "price", "fee", "fee_usdc"):
+            assert hints[field] is Decimal
+        assert hints["matched_at"] is datetime
+        assert hints["created_at"] == (datetime | None)
+        assert hints["updated_at"] == (datetime | None)
+
+        parameters = inspect.signature(BuilderTrade).parameters
+        assert parameters["size"].annotation is Decimal
+        assert parameters["matchTime"].annotation is datetime
+        assert parameters["createdAt"].annotation == (datetime | None)
+
     def test_parses_required_fields_with_alias_mapping(self) -> None:
         trade = BuilderTrade.parse_response(_WIRE_TRADE)
         assert trade.id == "trade-1"
@@ -114,6 +128,12 @@ class TestBuilderTradeModel:
     def test_parses_match_time_from_epoch_seconds_int(self) -> None:
         trade = BuilderTrade.parse_response({**_WIRE_TRADE, "matchTime": 1777040544})
         assert trade.matched_at == datetime(2026, 4, 24, 14, 22, 24, tzinfo=UTC)
+
+    def test_parses_match_time_from_iso_string(self) -> None:
+        trade = BuilderTrade.parse_response(
+            {**_WIRE_TRADE, "matchTime": "2026-04-24T14:22:24.198666Z"}
+        )
+        assert trade.matched_at == datetime(2026, 4, 24, 14, 22, 24, 198666, tzinfo=UTC)
 
     def test_parses_created_and_updated_at_from_iso_strings(self) -> None:
         trade = BuilderTrade.parse_response(

--- a/tests/unit/test_order_post.py
+++ b/tests/unit/test_order_post.py
@@ -1,3 +1,7 @@
+import inspect
+from decimal import Decimal
+from typing import get_type_hints
+
 import pytest
 
 from polymarket._internal.actions.orders.post import (
@@ -8,7 +12,7 @@ from polymarket._internal.actions.orders.post import (
 )
 from polymarket._internal.actions.orders.types import BYTES32_ZERO
 from polymarket.errors import UnexpectedResponseError, UserInputError
-from polymarket.models.clob.order_response import AcceptedOrder, RejectedOrder
+from polymarket.models.clob.order_response import AcceptedOrder, RawOrderResponse, RejectedOrder
 from polymarket.models.clob.orders import SignedOrder
 from polymarket.models.types import TokenId
 from polymarket.types import EvmAddress, HexString
@@ -126,6 +130,31 @@ def test_parse_order_response_normalizes_empty_making_taking_for_live_orders() -
     assert isinstance(parsed, AcceptedOrder)
     assert parsed.making_amount == 0
     assert parsed.taking_amount == 0
+
+
+def test_raw_order_response_annotations_and_signature_expose_decimals() -> None:
+    hints = get_type_hints(RawOrderResponse, include_extras=True)
+    assert hints["making_amount"] is Decimal
+    assert hints["taking_amount"] is Decimal
+
+    parameters = inspect.signature(RawOrderResponse).parameters
+    assert parameters["makingAmount"].annotation is Decimal
+    assert parameters["takingAmount"].annotation is Decimal
+
+
+@pytest.mark.parametrize("amount", [1, 1.0])
+def test_parse_order_response_rejects_non_string_amounts(amount: object) -> None:
+    raw: dict[str, object] = {
+        "errorMsg": "",
+        "makingAmount": amount,
+        "orderID": "ord-1",
+        "status": "live",
+        "success": True,
+        "takingAmount": "1",
+    }
+
+    with pytest.raises(UnexpectedResponseError):
+        parse_order_response(raw)
 
 
 def test_parse_order_response_recognizes_accepted_payload() -> None:


### PR DESCRIPTION
## Summary
- expose builder, API-key, and raw-order values with canonical field types
- move strict decimal and timestamp wire handling to model validators
- preserve empty raw-order amounts and timestamp aliases

## Stack
4 of 13 for DEV-537.

## Verification
- 87 focused and compatibility tests
- Ruff, formatting, and Pyright
- complete stack: `make check`, `uv build`, and `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order-post and builder-trade parsing with stricter wire typing for amounts; behavior is heavily tested but affects API response models consumers rely on.
> 
> **Overview**
> CLOB **builder**, **API key**, and **raw order** models now declare **`Decimal`** and **`datetime`** on their public fields instead of `Annotated` wire helpers (`_DecimalFromString`, `EpochMsOrIsoTimestamp`, etc.). Parsing stays the same but moves into explicit `@field_validator` hooks that call shared helpers (`parse_decimal_string`, `_parse_epoch_ms_or_iso_timestamp`, etc.).
> 
> **`RawOrderResponse`** still maps empty `makingAmount`/`takingAmount` strings to zero via the updated amount validator. Tests lock in reflected types (`get_type_hints` / `inspect.signature`), mixed epoch vs ISO timestamps for builder keys and trades, ISO `matchTime`, and rejection of numeric (non-string) order amounts on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a56aef618b5eda68668df476061d8fefc8e3eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->