### PR TITLE
refactor(models): preserve validation diagnostics

### DIFF
--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,8 +1,8 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import cast
+from typing import Annotated, cast
 
-from pydantic import TypeAdapter, ValidationError, field_validator
+from pydantic import BeforeValidator, TypeAdapter, ValidationError, field_validator
 
 from polymarket._internal.request import QueryParamValue
 from polymarket._internal.validation import require_nonempty
@@ -50,36 +50,14 @@ class _SpreadResponse(BaseModel):
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[TokenId, Decimal])
-_SpreadsAdapter = TypeAdapter(dict[TokenId, Decimal])
-_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, Decimal]])
+_StrictDecimalValue = Annotated[Decimal, BeforeValidator(parse_decimal_string)]
+
+_MidpointsAdapter = TypeAdapter(dict[TokenId, _StrictDecimalValue])
+_SpreadsAdapter = TypeAdapter(dict[TokenId, _StrictDecimalValue])
+_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, _StrictDecimalValue]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])
-
-
-def _parse_decimal_mapping(data: object) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    return {
-        key: parse_decimal_string(value)
-        for key, value in cast(Mapping[object, object], data).items()
-    }
-
-
-def _parse_prices_mapping(data: object) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    parsed: dict[object, object] = {}
-    for token_id, prices in cast(Mapping[object, object], data).items():
-        if not isinstance(prices, Mapping):
-            parsed[token_id] = prices
-            continue
-        parsed[token_id] = {
-            side: parse_decimal_string(value)
-            for side, value in cast(Mapping[object, object], prices).items()
-        }
-    return parsed
 
 
 def _require_string_token_id(token_id: object) -> str:
@@ -149,8 +127,8 @@ def build_midpoints_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict
 
 def parse_midpoints(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _MidpointsAdapter.validate_python(_parse_decimal_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _MidpointsAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("midpoints response did not match expected shape") from error
 
 
@@ -171,8 +149,8 @@ def build_prices_request(*, requests: Sequence[PriceRequest]) -> tuple[str, list
 
 def parse_prices(data: object) -> dict[TokenId, dict[OrderSide, Decimal]]:
     try:
-        return _PricesAdapter.validate_python(_parse_prices_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _PricesAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("prices response did not match expected shape") from error
 
 
@@ -213,8 +191,8 @@ def build_spreads_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict[s
 
 def parse_spreads(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _SpreadsAdapter.validate_python(_parse_decimal_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _SpreadsAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("spreads response did not match expected shape") from error
 
 

--- a/src/polymarket/models/perps/market.py
+++ b/src/polymarket/models/perps/market.py
@@ -1,11 +1,11 @@
 """Perps market data models."""
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import Literal, cast
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
@@ -22,49 +22,16 @@ from polymarket.models.perps.types import (
 )
 
 
-def _normalize_field(
-    data: dict[str, object],
-    aliases: tuple[str, ...],
-    parser: Callable[[object], object],
-) -> None:
-    for alias in aliases:
-        if alias in data:
-            data[alias] = parser(data[alias])
-            return
-
-
-def _normalize_market_data(
-    data: object,
-    *,
-    decimals: tuple[tuple[str, ...], ...] = (),
-    timestamps: tuple[tuple[str, ...], ...] = (),
-    optional_timestamps: tuple[tuple[str, ...], ...] = (),
-    optional_hashes: tuple[tuple[str, ...], ...] = (),
-) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    normalized = dict(cast("Mapping[str, object]", data))
-    for aliases in decimals:
-        _normalize_field(normalized, aliases, _coerce_decimalish)
-    for aliases in timestamps:
-        _normalize_field(normalized, aliases, _require_epoch_ms)
-    for aliases in optional_timestamps:
-        _normalize_field(normalized, aliases, _parse_epoch_ms)
-    for aliases in optional_hashes:
-        _normalize_field(normalized, aliases, _parse_tx_hash)
-    return normalized
-
-
 class PerpsRiskTier(BaseModel):
     """One leverage risk tier for a Perps instrument."""
 
     lower_bound: Decimal
     max_leverage: int
 
-    @model_validator(mode="before")
+    @field_validator("lower_bound", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(data, decimals=(("lower_bound",),))
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsInstrument(BaseModel):
@@ -88,19 +55,17 @@ class PerpsInstrument(BaseModel):
     isolated_only: bool
     risk_tiers: tuple[PerpsRiskTier, ...]
 
-    @model_validator(mode="before")
+    @field_validator(
+        "price_bounds",
+        "liquidation_fee",
+        "min_notional",
+        "max_market_notional",
+        "max_limit_notional",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("price_bounds",),
-                ("liquidation_fee",),
-                ("min_notional",),
-                ("max_market_notional",),
-                ("max_limit_notional",),
-            ),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsTicker(BaseModel):
@@ -119,24 +84,30 @@ class PerpsTicker(BaseModel):
     open_price: Decimal | None = None
     volume_24h: Decimal | None = None
 
-    @model_validator(mode="before")
+    @field_validator(
+        "index_price",
+        "mark_price",
+        "last_price",
+        "mid_price",
+        "open_interest",
+        "funding_rate",
+        "open_price",
+        "volume_24h",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("index_price",),
-                ("mark_price",),
-                ("last_price",),
-                ("mid_price",),
-                ("open_interest",),
-                ("funding_rate",),
-                ("open_price",),
-                ("volume_24h",),
-            ),
-            timestamps=(("next_funding",),),
-            optional_timestamps=(("timestamp",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("next_funding", mode="before")
+    @classmethod
+    def _parse_next_funding(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsTickerUpdate(BaseModel):
@@ -151,21 +122,23 @@ class PerpsTickerUpdate(BaseModel):
     funding_rate: Decimal = Field(validation_alias="fr")
     next_funding: datetime = Field(validation_alias="nxf")
 
-    @model_validator(mode="before")
+    @field_validator(
+        "index_price",
+        "mark_price",
+        "last_price",
+        "mid_price",
+        "open_interest",
+        "funding_rate",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("idx", "index_price"),
-                ("mark", "mark_price"),
-                ("last", "last_price"),
-                ("mid", "mid_price"),
-                ("oi", "open_interest"),
-                ("fr", "funding_rate"),
-            ),
-            timestamps=(("nxf", "next_funding"),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("next_funding", mode="before")
+    @classmethod
+    def _parse_next_funding(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 def _candle_from_tuple(value: object) -> object:
@@ -199,11 +172,17 @@ class PerpsCandle(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            _candle_from_tuple(data),
-            decimals=(("open",), ("high",), ("low",), ("close",), ("volume",)),
-            timestamps=(("timestamp",),),
-        )
+        return _candle_from_tuple(data)
+
+    @field_validator("open", "high", "low", "close", "volume", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsStatistic(BaseModel):
@@ -215,13 +194,10 @@ class PerpsStatistic(BaseModel):
     open_price: Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
     klines: tuple[PerpsCandle, ...]
 
-    @model_validator(mode="before")
+    @field_validator("volume", "open_price", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("volume", "vol"), ("open_price", "open")),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 def _level_from_tuple(value: object) -> object:
@@ -242,10 +218,12 @@ class PerpsBookLevel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            _level_from_tuple(data),
-            decimals=(("price",), ("quantity",)),
-        )
+        return _level_from_tuple(data)
+
+    @field_validator("price", "quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsBook(BaseModel):
@@ -257,10 +235,10 @@ class PerpsBook(BaseModel):
     timestamp: datetime
     sequence: int
 
-    @model_validator(mode="before")
+    @field_validator("timestamp", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(data, timestamps=(("timestamp",),))
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsBookUpdate(BaseModel):
@@ -281,19 +259,15 @@ class PerpsBbo(BaseModel):
     ask_quantity: Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
     timestamp: datetime | None = None
 
-    @model_validator(mode="before")
+    @field_validator("bid_price", "bid_quantity", "ask_price", "ask_quantity", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("bid_price", "bp"),
-                ("bid_quantity", "bq"),
-                ("ask_price", "ap"),
-                ("ask_quantity", "aq"),
-            ),
-            optional_timestamps=(("timestamp",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsTrade(BaseModel):
@@ -307,15 +281,20 @@ class PerpsTrade(BaseModel):
     timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
     hash: str | None = None
 
-    @model_validator(mode="before")
+    @field_validator("price", "quantity", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("price", "p"), ("quantity", "qty")),
-            timestamps=(("timestamp", "ts"),),
-            optional_hashes=(("hash",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 class PerpsFundingRate(BaseModel):
@@ -324,14 +303,15 @@ class PerpsFundingRate(BaseModel):
     funding_rate: Decimal
     timestamp: datetime
 
-    @model_validator(mode="before")
+    @field_validator("funding_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("funding_rate",),),
-            timestamps=(("timestamp",),),
-        )
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsFeeTier(BaseModel):
@@ -341,13 +321,10 @@ class PerpsFeeTier(BaseModel):
     taker_fee_rate: Decimal
     maker_fee_rate: Decimal
 
-    @model_validator(mode="before")
+    @field_validator("min_volume_30d", "taker_fee_rate", "maker_fee_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("min_volume_30d",), ("taker_fee_rate",), ("maker_fee_rate",)),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsFeeScheduleEntry(BaseModel):
@@ -358,13 +335,10 @@ class PerpsFeeScheduleEntry(BaseModel):
     maker_fee_rate: Decimal
     tiers: tuple[PerpsFeeTier, ...]
 
-    @model_validator(mode="before")
+    @field_validator("taker_fee_rate", "maker_fee_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("taker_fee_rate",), ("maker_fee_rate",)),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsCandleBatch(BaseModel):

--- a/src/polymarket/models/rtds_events.py
+++ b/src/polymarket/models/rtds_events.py
@@ -1,9 +1,9 @@
 import re
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
-from pydantic import Field, TypeAdapter, field_validator, model_validator
+from pydantic import BeforeValidator, Field, TypeAdapter, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
@@ -41,7 +41,9 @@ _TWAP_WINDOW_BY_WIRE_TOPIC: dict[str, Literal[30, 60]] = {
 
 _CHAINLINK_PRICE_SCALE = 10**18
 _SIGNED_INTEGER_PATTERN = re.compile(r"-?[0-9]+")
-_DECIMALISH_ADAPTER = TypeAdapter(Decimal)
+_DECIMALISH_ADAPTER: TypeAdapter[Decimal] = TypeAdapter(
+    Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
+)
 
 
 def wire_topic_to_api(wire: str) -> str | None:
@@ -198,7 +200,7 @@ class CryptoPricesChainlinkTwapPayload(BaseModel):
                 return data
             msg = "full_accuracy_value is required"
             raise ValueError(msg)
-        _DECIMALISH_ADAPTER.validate_python(_coerce_decimalish(data.get("value")))
+        _DECIMALISH_ADAPTER.validate_python(data.get("value"))
         data["value"] = _chainlink_e18_to_decimal(data.pop("full_accuracy_value"))
         return data
 

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -3,6 +3,7 @@ from types import MappingProxyType
 from typing import assert_type
 
 import pytest
+from pydantic import ValidationError
 
 from polymarket._internal.actions.clob import (
     build_last_trade_price_request,
@@ -149,6 +150,19 @@ def test_parse_midpoints_rejects_numeric_value_in_generic_mapping() -> None:
         parse_midpoints(MappingProxyType({"1": 0.5}))
 
 
+def test_parse_midpoints_accepts_string_value_in_generic_mapping() -> None:
+    assert parse_midpoints(MappingProxyType({"1": "0.5"})) == {TokenId("1"): Decimal("0.5")}
+
+
+def test_parse_midpoints_preserves_element_validation_errors() -> None:
+    with pytest.raises(UnexpectedResponseError) as captured:
+        parse_midpoints({"1": 0.5, "2": True})
+
+    cause = captured.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert [error["loc"] for error in cause.errors()] == [("1",), ("2",)]
+
+
 def test_parse_midpoints_accepts_existing_decimal_value() -> None:
     assert parse_midpoints({"1": Decimal("0.5")}) == {TokenId("1"): Decimal("0.5")}
 
@@ -252,6 +266,18 @@ def test_parse_prices_rejects_numeric_value_in_nested_generic_mapping() -> None:
     prices = MappingProxyType({"BUY": 0.52})
     with pytest.raises(UnexpectedResponseError):
         parse_prices(MappingProxyType({"1": prices}))
+
+
+def test_parse_prices_preserves_nested_element_validation_errors() -> None:
+    with pytest.raises(UnexpectedResponseError) as captured:
+        parse_prices({"1": {"BUY": 0.52, "SELL": True}})
+
+    cause = captured.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert [error["loc"] for error in cause.errors()] == [
+        ("1", "BUY"),
+        ("1", "SELL"),
+    ]
 
 
 def test_parse_prices_accepts_existing_decimal_value() -> None:

--- a/tests/unit/test_perps_market_models.py
+++ b/tests/unit/test_perps_market_models.py
@@ -160,6 +160,46 @@ def test_decimal_fields_reject_bool(value: bool) -> None:
         PerpsBookLevel.model_validate([value, "1"])
 
 
+def test_market_fields_preserve_multiple_validation_errors() -> None:
+    with pytest.raises(ValidationError) as captured:
+        PerpsTickerUpdate.model_validate(
+            {
+                "iid": 4,
+                "idx": True,
+                "mark": [],
+                "last": "100.2",
+                "mid": "100.15",
+                "oi": "5000",
+                "fr": "0.0001",
+                "nxf": "1751500000000",
+            }
+        )
+
+    assert [error["loc"] for error in captured.value.errors()] == [
+        ("idx",),
+        ("mark",),
+        ("nxf",),
+    ]
+
+
+def test_tuple_models_preserve_nested_field_error_locations() -> None:
+    with pytest.raises(ValidationError) as captured:
+        PerpsBook.model_validate(
+            {
+                "instrument_id": 4,
+                "bids": [[True, []]],
+                "asks": [],
+                "timestamp": _EPOCH_MS,
+                "sequence": 1,
+            }
+        )
+
+    assert [error["loc"] for error in captured.value.errors()] == [
+        ("bids", 0, "price"),
+        ("bids", 0, "quantity"),
+    ]
+
+
 @pytest.mark.parametrize("value", [1.5, "1751500000000", True, None])
 def test_required_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
     with pytest.raises(ValidationError, match="epoch-ms"):

--- a/tests/unit/test_streams_rtds_events.py
+++ b/tests/unit/test_streams_rtds_events.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Any, get_type_hints
 
 import pytest
+from pydantic import ValidationError
 
 from polymarket.models.rtds_events import (
     CommentCreatedEvent,
@@ -379,6 +380,20 @@ def test_crypto_chainlink_twap_validates_display_value_before_full_accuracy_valu
 
     with pytest.raises(ValueError, match="expected decimal-ish value, got object"):
         parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
+
+
+def test_crypto_chainlink_twap_preserves_invalid_display_value_error_input() -> None:
+    display_value = object()
+    payload = {
+        **_CRYPTO_CHAINLINK_TWAP["payload"],
+        "value": display_value,
+        "full_accuracy_value": "invalid",
+    }
+
+    with pytest.raises(ValidationError) as captured:
+        CryptoPricesChainlinkTwapPayload.model_validate(payload)
+
+    assert captured.value.errors()[0]["input"] is display_value
 
 
 def test_crypto_chainlink_twap_payload_round_trips_public_shape() -> None:


### PR DESCRIPTION
## Summary

- keep strict CLOB collection parsing inside private element adapters so Pydantic retains per-entry errors and aggregation
- keep TWAP display-value coercion inside its private adapter so invalid input context remains unchanged
- move Perps market value coercion from model-level normalization to field validators while retaining tuple/list shape normalization
- preserve canonical public annotations, constructor signatures, aliases, accepted inputs, parsed values, serialization, and schemas

## Why

The annotation refactor should not require duplicating Pydantic alias resolution or changing validation diagnostics. Model validators now only normalize structural wire shapes; field and element validation remains owned by Pydantic.

This is the final PR in [Stack #250](https://github.com/Polymarket/py-sdk/pull/250) and follows #245.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration" -q` (2,202 passed, 184 deselected)
- `uv build`
- `make api-reference`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing for CLOB bulk responses, all major Perps market models, and RTDS price payloads; behavior should match but error shapes and edge cases around non-dict mappings changed.
> 
> **Overview**
> Refactors API response parsing so **decimal and timestamp coercion runs inside Pydantic** instead of manual dict walks before `TypeAdapter` / model validation. That keeps **richer `ValidationError` output** (per-key paths, multiple failures, original bad inputs).
> 
> **CLOB actions** (`clob.py`): drops `_parse_decimal_mapping` / `_parse_prices_mapping`; midpoints, spreads, and prices adapters use `Annotated[Decimal, BeforeValidator(parse_decimal_string)]` and validate raw payloads directly. `UnexpectedResponseError` now chains only `ValidationError`, not `ValueError` from pre-parsing.
> 
> **Perps market models** (`market.py`): removes shared `_normalize_market_data`; each model uses targeted `field_validator(..., mode="before")` for decimals, epoch-ms timestamps, and tx hashes. Tuple-shaped candles/levels still preprocess via `model_validator`, with field validators handling coercion afterward.
> 
> **RTDS** (`rtds_events.py`): `_DECIMALISH_ADAPTER` wraps `BeforeValidator(_coerce_decimalish)` so Chainlink TWAP display-value checks go through the same validation path.
> 
> **Tests** assert preserved error locations for bulk CLOB parses, multi-field Perps payloads, nested book levels, and RTDS TWAP invalid `value` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92a7c6ddfa92d78b9ba3308f5ad63948d132f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->