### PR TITLE
refactor(models): expose canonical public value types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@
 - Do not rename existing variables, functions, or classes unless the operator explicitly asks for it in the prompt. Keep PRs lean; if a name looks wrong, propose the rename as a separate change instead of bundling it.
 - Avoid reuse that does not carry semantic or domain-specific value. Do not add boolean mode flags or generic helpers that hide distinct behavior behind one function; prefer separate explicit helpers whose names describe the behavior they implement.
 
+## Public Model Types
+
+- Public model fields and generated constructor signatures must expose canonical Python value types such as `Decimal`, `datetime`, and domain enums, not wire-format names or validation-only `Annotated` aliases.
+- Do not use `TYPE_CHECKING` branches to give static tooling a different type definition from the one available at runtime. Keep static annotations, runtime introspection, and generated documentation consistent.
+- Normalize incoming wire values at the response boundary with field validators or explicit response parsing. Keep format-specific behavior, such as decimal strings, E6 integer strings, and distinct timestamp encodings, in clearly named parsers rather than broad shared aliases.
+- Construct outgoing request payloads explicitly at the request boundary, including unit scaling and string conversion. Do not rely on response-model serializers to satisfy request protocols, and only add a model serializer when JSON serialization is itself part of the model's documented public contract.
+- Preserve `Annotated` metadata that expresses real type semantics, such as discriminators or constraints. The restriction is on validation-only metadata leaking into the public type surface, not on `Annotated` itself.
+
 ## Platform Invariants
 
 - A market's minimum tick size may become finer, such as `0.01` to `0.001`, but it cannot become coarser, such as `0.001` to `0.01`. SDK caching and recovery logic may rely on this monotonic behavior and should not add defensive handling for tick-size coarsening.

--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,8 +1,8 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import cast
+from typing import Annotated, cast
 
-from pydantic import TypeAdapter, ValidationError, field_validator
+from pydantic import BeforeValidator, TypeAdapter, ValidationError, field_validator
 
 from polymarket._internal.request import QueryParamValue
 from polymarket._internal.validation import require_nonempty
@@ -50,36 +50,14 @@ class _SpreadResponse(BaseModel):
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[TokenId, Decimal])
-_SpreadsAdapter = TypeAdapter(dict[TokenId, Decimal])
-_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, Decimal]])
+_StrictDecimalValue = Annotated[Decimal, BeforeValidator(parse_decimal_string)]
+
+_MidpointsAdapter = TypeAdapter(dict[TokenId, _StrictDecimalValue])
+_SpreadsAdapter = TypeAdapter(dict[TokenId, _StrictDecimalValue])
+_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, _StrictDecimalValue]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])
-
-
-def _parse_decimal_mapping(data: object) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    return {
-        key: parse_decimal_string(value)
-        for key, value in cast(Mapping[object, object], data).items()
-    }
-
-
-def _parse_prices_mapping(data: object) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    parsed: dict[object, object] = {}
-    for token_id, prices in cast(Mapping[object, object], data).items():
-        if not isinstance(prices, Mapping):
-            parsed[token_id] = prices
-            continue
-        parsed[token_id] = {
-            side: parse_decimal_string(value)
-            for side, value in cast(Mapping[object, object], prices).items()
-        }
-    return parsed
 
 
 def _require_string_token_id(token_id: object) -> str:
@@ -149,8 +127,8 @@ def build_midpoints_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict
 
 def parse_midpoints(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _MidpointsAdapter.validate_python(_parse_decimal_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _MidpointsAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("midpoints response did not match expected shape") from error
 
 
@@ -171,8 +149,8 @@ def build_prices_request(*, requests: Sequence[PriceRequest]) -> tuple[str, list
 
 def parse_prices(data: object) -> dict[TokenId, dict[OrderSide, Decimal]]:
     try:
-        return _PricesAdapter.validate_python(_parse_prices_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _PricesAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("prices response did not match expected shape") from error
 
 
@@ -213,8 +191,8 @@ def build_spreads_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict[s
 
 def parse_spreads(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _SpreadsAdapter.validate_python(_parse_decimal_mapping(data))
-    except (ValidationError, ValueError) as error:
+        return _SpreadsAdapter.validate_python(data)
+    except ValidationError as error:
         raise UnexpectedResponseError("spreads response did not match expected shape") from error
 
 

--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,12 +1,13 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from typing import cast
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError, field_validator
 
 from polymarket._internal.request import QueryParamValue
 from polymarket._internal.validation import require_nonempty
 from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob import (
     LastTradePrice,
@@ -16,33 +17,69 @@ from polymarket.models.clob import (
     PriceHistoryPoint,
     PriceRequest,
 )
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderSide, TokenId
 
 
 class _MidpointResponse(BaseModel):
-    mid: _DecimalFromString
+    mid: Decimal
+
+    @field_validator("mid", mode="before")
+    @classmethod
+    def _parse_mid(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class _PriceResponse(BaseModel):
-    price: _DecimalFromString
+    price: Decimal
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class _SpreadResponse(BaseModel):
-    spread: _DecimalFromString
+    spread: Decimal
+
+    @field_validator("spread", mode="before")
+    @classmethod
+    def _parse_spread(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 _PRICE_HISTORY_INTERVALS: frozenset[str] = frozenset({"max", "1w", "1d", "6h", "1h"})
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
 
-_MidpointsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
-_SpreadsAdapter = TypeAdapter(dict[TokenId, _DecimalFromString])
-_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, _DecimalFromString]])
+_MidpointsAdapter = TypeAdapter(dict[TokenId, Decimal])
+_SpreadsAdapter = TypeAdapter(dict[TokenId, Decimal])
+_PricesAdapter = TypeAdapter(dict[TokenId, dict[OrderSide, Decimal]])
 _OrderBookListAdapter = TypeAdapter(tuple[OrderBook, ...])
 _LastTradePriceListAdapter = TypeAdapter(tuple[LastTradePriceForToken, ...])
 _PriceHistoryListAdapter = TypeAdapter(tuple[PriceHistoryPoint, ...])
+
+
+def _parse_decimal_mapping(data: object) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    return {
+        key: parse_decimal_string(value)
+        for key, value in cast(Mapping[object, object], data).items()
+    }
+
+
+def _parse_prices_mapping(data: object) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    parsed: dict[object, object] = {}
+    for token_id, prices in cast(Mapping[object, object], data).items():
+        if not isinstance(prices, Mapping):
+            parsed[token_id] = prices
+            continue
+        parsed[token_id] = {
+            side: parse_decimal_string(value)
+            for side, value in cast(Mapping[object, object], prices).items()
+        }
+    return parsed
 
 
 def _require_string_token_id(token_id: object) -> str:
@@ -112,8 +149,8 @@ def build_midpoints_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict
 
 def parse_midpoints(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _MidpointsAdapter.validate_python(data)
-    except ValidationError as error:
+        return _MidpointsAdapter.validate_python(_parse_decimal_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("midpoints response did not match expected shape") from error
 
 
@@ -134,8 +171,8 @@ def build_prices_request(*, requests: Sequence[PriceRequest]) -> tuple[str, list
 
 def parse_prices(data: object) -> dict[TokenId, dict[OrderSide, Decimal]]:
     try:
-        return _PricesAdapter.validate_python(data)
-    except ValidationError as error:
+        return _PricesAdapter.validate_python(_parse_prices_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("prices response did not match expected shape") from error
 
 
@@ -176,8 +213,8 @@ def build_spreads_request(*, token_ids: Sequence[str]) -> tuple[str, list[dict[s
 
 def parse_spreads(data: object) -> dict[TokenId, Decimal]:
     try:
-        return _SpreadsAdapter.validate_python(data)
-    except ValidationError as error:
+        return _SpreadsAdapter.validate_python(_parse_decimal_mapping(data))
+    except (ValidationError, ValueError) as error:
         raise UnexpectedResponseError("spreads response did not match expected shape") from error
 
 

--- a/src/polymarket/models/_validators.py
+++ b/src/polymarket/models/_validators.py
@@ -32,8 +32,3 @@ def parse_e6_decimal_string(value: object) -> object:
         msg = f"invalid base-unit integer string: {value!r}"
         raise ValueError(msg)
     return Decimal(value).scaleb(-6)
-
-
-def serialize_e6_decimal_string(value: Decimal) -> str:
-    """Serialize a scaled amount back to the base-unit integer string the wire carries."""
-    return str(int(value.scaleb(6)))

--- a/src/polymarket/models/_validators.py
+++ b/src/polymarket/models/_validators.py
@@ -1,9 +1,6 @@
 """Field validators shared across SDK model packages."""
 
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator, PlainSerializer
 
 
 def parse_decimal_string(value: object) -> object:
@@ -40,23 +37,3 @@ def parse_e6_decimal_string(value: object) -> object:
 def serialize_e6_decimal_string(value: Decimal) -> str:
     """Serialize a scaled amount back to the base-unit integer string the wire carries."""
     return str(int(value.scaleb(6)))
-
-
-if TYPE_CHECKING:
-    DecimalFromString = Decimal
-    DecimalFromE6String = Decimal
-else:
-    DecimalFromString = Annotated[Decimal, BeforeValidator(parse_decimal_string)]
-    # JSON dumps write the wire's base-unit integer string so a dumped model
-    # re-validates to the same amount instead of being rescaled a second time.
-    DecimalFromE6String = Annotated[
-        Decimal,
-        BeforeValidator(parse_e6_decimal_string),
-        PlainSerializer(serialize_e6_decimal_string, return_type=str, when_used="json"),
-    ]
-
-
-__all__ = [
-    "DecimalFromE6String",
-    "DecimalFromString",
-]

--- a/src/polymarket/models/clob/_validators.py
+++ b/src/polymarket/models/clob/_validators.py
@@ -1,13 +1,5 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator
-
-# Re-exported under the historical private name for the CLOB model modules.
-from polymarket.models._validators import (  # noqa: F401
-    DecimalFromString as _DecimalFromString,  # pyright: ignore[reportUnusedImport]
-)
 
 
 def _coerce_decimalish(value: object) -> object:
@@ -195,37 +187,14 @@ def _parse_expiration_timestamp(value: object) -> object:
     return _parse_epoch_seconds_timestamp(value)
 
 
-if TYPE_CHECKING:
-    _DecimalFromNumberOrString = Decimal
-    _OptionalDecimalFromNumberOrString = Decimal | None
-else:
-    _DecimalFromNumberOrString = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
-    # The validator must wrap the whole optional annotation: on a
-    # ``Decimal | None`` union, a BeforeValidator attached only to the Decimal
-    # member cannot map "" to None (the None branch still sees the original "").
-    _OptionalDecimalFromNumberOrString = Annotated[
-        Decimal | None, BeforeValidator(_coerce_optional_decimalish)
-    ]
-
-EpochMsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms_timestamp)]
-EpochMsOrIsoTimestamp = Annotated[
-    datetime | None, BeforeValidator(_parse_epoch_ms_or_iso_timestamp)
-]
-EpochOrIsoTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_or_iso_timestamp)]
-RequiredEpochOrIsoTimestamp = Annotated[datetime, BeforeValidator(_require_epoch_or_iso_timestamp)]
-EpochSecondsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_seconds_timestamp)]
-EpochSecondsOrMsTimestamp = Annotated[
-    datetime | None, BeforeValidator(_parse_epoch_seconds_or_ms_timestamp)
-]
-ExpirationTimestamp = Annotated[datetime | None, BeforeValidator(_parse_expiration_timestamp)]
-
-
 __all__ = [
-    "EpochMsOrIsoTimestamp",
-    "EpochMsTimestamp",
-    "EpochOrIsoTimestamp",
-    "EpochSecondsOrMsTimestamp",
-    "EpochSecondsTimestamp",
-    "ExpirationTimestamp",
-    "RequiredEpochOrIsoTimestamp",
+    "_coerce_decimalish",
+    "_coerce_optional_decimalish",
+    "_parse_epoch_ms_or_iso_timestamp",
+    "_parse_epoch_ms_timestamp",
+    "_parse_epoch_or_iso_timestamp",
+    "_parse_epoch_seconds_or_ms_timestamp",
+    "_parse_epoch_seconds_timestamp",
+    "_parse_expiration_timestamp",
+    "_require_epoch_or_iso_timestamp",
 ]

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Annotated, Any, Literal, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast
 
-from pydantic import BeforeValidator, Field, field_validator
+from pydantic import Field, field_validator
 
 from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
@@ -39,9 +39,6 @@ def _normalize_trade_status(value: object) -> object:
     if isinstance(value, str) and value.startswith("TRADE_STATUS_"):
         return value[len("TRADE_STATUS_") :]
     return value
-
-
-TradeStatusField = Annotated[TradeStatus, BeforeValidator(_normalize_trade_status)]
 
 
 class OpenOrder(BaseModel):

--- a/src/polymarket/models/clob/account.py
+++ b/src/polymarket/models/clob/account.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
 from pydantic import BeforeValidator, Field, field_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    ExpirationTimestamp,
-    RequiredEpochOrIsoTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_expiration_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
@@ -57,15 +59,23 @@ class OpenOrder(BaseModel):
     owner: str
     maker_address: str = Field(validation_alias="maker_address")
     side: OrderSide
-    price: _DecimalFromString
-    original_size: _DecimalFromString = Field(validation_alias="original_size")
-    size_matched: _DecimalFromString = Field(validation_alias="size_matched")
+    price: Decimal
+    original_size: Decimal = Field(validation_alias="original_size")
+    size_matched: Decimal = Field(validation_alias="size_matched")
     outcome: str
     order_type: str = Field(validation_alias="order_type")
     status: str
     associate_trades: tuple[str, ...] = Field(default=(), validation_alias="associate_trades")
-    created_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="created_at")
-    expires_at: ExpirationTimestamp = Field(default=None, validation_alias="expiration")
+    created_at: datetime = Field(validation_alias="created_at")
+    expires_at: datetime | None = Field(default=None, validation_alias="expiration")
+
+    _validate_decimals = field_validator("price", "original_size", "size_matched", mode="before")(
+        parse_decimal_string
+    )
+    _validate_created_at = field_validator("created_at", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
+    _validate_expires_at = field_validator("expires_at", mode="before")(_parse_expiration_timestamp)
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid
@@ -93,10 +103,14 @@ class MakerOrder(BaseModel):
     maker_address: str = Field(validation_alias="maker_address")
     owner: str
     side: OrderSide
-    price: _DecimalFromString
-    matched_amount: _DecimalFromString = Field(validation_alias="matched_amount")
+    price: Decimal
+    matched_amount: Decimal = Field(validation_alias="matched_amount")
     outcome: str
-    fee_rate_bps: _DecimalFromString | None = Field(default=None, validation_alias="fee_rate_bps")
+    fee_rate_bps: Decimal | None = Field(default=None, validation_alias="fee_rate_bps")
+
+    _validate_decimals = field_validator("price", "matched_amount", "fee_rate_bps", mode="before")(
+        parse_decimal_string
+    )
 
     @field_validator("fee_rate_bps", mode="before")
     @classmethod
@@ -121,16 +135,24 @@ class ClobTrade(BaseModel):
     taker_order_id: str = Field(validation_alias="taker_order_id")
     side: OrderSide
     trader_side: Literal["TAKER", "MAKER"] = Field(validation_alias="trader_side")
-    price: _DecimalFromString
-    size: _DecimalFromString
+    price: Decimal
+    size: Decimal
     outcome: str
-    status: TradeStatusField
-    fee_rate_bps: _DecimalFromString = Field(validation_alias="fee_rate_bps")
+    status: TradeStatus
+    fee_rate_bps: Decimal = Field(validation_alias="fee_rate_bps")
     bucket_index: int = Field(validation_alias="bucket_index")
     transaction_hash: str = Field(validation_alias="transaction_hash")
     maker_orders: tuple[MakerOrder, ...] = Field(validation_alias="maker_orders")
-    matched_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="match_time")
-    updated_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="last_update")
+    matched_at: datetime = Field(validation_alias="match_time")
+    updated_at: datetime = Field(validation_alias="last_update")
+
+    _validate_decimals = field_validator("price", "size", "fee_rate_bps", mode="before")(
+        parse_decimal_string
+    )
+    _validate_status = field_validator("status", mode="before")(_normalize_trade_status)
+    _validate_timestamps = field_validator("matched_at", "updated_at", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid
@@ -156,7 +178,11 @@ class Notification(BaseModel):
     owner: str
     type: int
     payload: Any = None
-    timestamp: RequiredEpochOrIsoTimestamp
+    timestamp: datetime
+
+    _validate_timestamp = field_validator("timestamp", mode="before")(
+        _require_epoch_or_iso_timestamp
+    )
 
     @field_validator("id", mode="before")
     @classmethod

--- a/src/polymarket/models/clob/api_key.py
+++ b/src/polymarket/models/clob/api_key.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from pydantic import Field
+from datetime import datetime
+
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import EpochMsOrIsoTimestamp
+from polymarket.models.clob._validators import (
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 class ApiKeyCreds(BaseModel):
@@ -31,8 +35,13 @@ class BuilderApiKeyInfo(BaseModel):
     """
 
     key: str
-    created_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="createdAt")
-    revoked_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="revokedAt")
+    created_at: datetime | None = Field(default=None, validation_alias="createdAt")
+    revoked_at: datetime | None = Field(default=None, validation_alias="revokedAt")
+
+    @field_validator("created_at", "revoked_at", mode="before")
+    @classmethod
+    def _parse_timestamps(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 __all__ = ["ApiKeyCreds", "BuilderApiKeyInfo"]

--- a/src/polymarket/models/clob/builder.py
+++ b/src/polymarket/models/clob/builder.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal, DecimalException
 from typing import Any, cast
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochOrIsoTimestamp,
-    RequiredEpochOrIsoTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, OrderSide, TokenId
 
@@ -53,22 +54,37 @@ class BuilderTrade(BaseModel):
     )
     token_id: TokenId = Field(validation_alias="assetId")
     side: OrderSide
-    size: _DecimalFromString
-    size_usdc: _DecimalFromString = Field(validation_alias="sizeUsdc")
-    price: _DecimalFromString
+    size: Decimal
+    size_usdc: Decimal = Field(validation_alias="sizeUsdc")
+    price: Decimal
     status: str
     outcome: str
     outcome_index: int = Field(validation_alias="outcomeIndex")
     owner: str
     maker: str
     transaction_hash: str = Field(validation_alias="transactionHash")
-    matched_at: RequiredEpochOrIsoTimestamp = Field(validation_alias="matchTime")
+    matched_at: datetime = Field(validation_alias="matchTime")
     bucket_index: int = Field(validation_alias="bucketIndex")
-    fee: _DecimalFromString
-    fee_usdc: _DecimalFromString = Field(validation_alias="feeUsdc")
+    fee: Decimal
+    fee_usdc: Decimal = Field(validation_alias="feeUsdc")
     error_msg: str | None = Field(default=None, validation_alias="err_msg")
-    created_at: EpochOrIsoTimestamp = Field(default=None, validation_alias="createdAt")
-    updated_at: EpochOrIsoTimestamp = Field(default=None, validation_alias="updatedAt")
+    created_at: datetime | None = Field(default=None, validation_alias="createdAt")
+    updated_at: datetime | None = Field(default=None, validation_alias="updatedAt")
+
+    @field_validator("size", "size_usdc", "price", "fee", "fee_usdc", mode="before")
+    @classmethod
+    def _parse_decimal_fields(cls, value: object) -> object:
+        return parse_decimal_string(value)
+
+    @field_validator("matched_at", mode="before")
+    @classmethod
+    def _parse_matched_at(cls, value: object) -> object:
+        return _require_epoch_or_iso_timestamp(value)
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_optional_timestamps(cls, value: object) -> object:
+        return _parse_epoch_or_iso_timestamp(value)
 
 
 __all__ = ["BuilderFeeRates", "BuilderTrade"]

--- a/src/polymarket/models/clob/last_trade.py
+++ b/src/polymarket/models/clob/last_trade.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
+from pydantic import field_validator
+
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderSide, TokenId
 
 
 class LastTradePrice(BaseModel):
-    price: _DecimalFromString
+    price: Decimal
     side: OrderSide
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class LastTradePriceForToken(BaseModel):
     token_id: TokenId
-    price: _DecimalFromString
+    price: Decimal
     side: OrderSide
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 __all__ = ["LastTradePrice", "LastTradePriceForToken"]

--- a/src/polymarket/models/clob/market_events.py
+++ b/src/polymarket/models/clob/market_events.py
@@ -1,12 +1,14 @@
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
 
-from pydantic import BeforeValidator, Field, TypeAdapter, field_validator
+from pydantic import Field, TypeAdapter, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsTimestamp,
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
-    _OptionalDecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _coerce_optional_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.clob.order_book import OrderBookLevel
 from polymarket.models.types import CtfConditionId, TokenId, validate_optional_ctf_condition_id
@@ -14,9 +16,6 @@ from polymarket.models.types import CtfConditionId, TokenId, validate_optional_c
 
 def _uppercase_order_side(value: object) -> object:
     return value.upper() if isinstance(value, str) else value
-
-
-_OrderSide = Annotated[Literal["BUY", "SELL"], BeforeValidator(_uppercase_order_side)]
 
 
 class MarketEventMessage(BaseModel):
@@ -29,12 +28,27 @@ class MarketEventMessage(BaseModel):
 
 class PriceChange(BaseModel):
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: _DecimalFromNumberOrString
-    size: _DecimalFromNumberOrString
-    side: _OrderSide
+    price: Decimal
+    size: Decimal
+    side: Literal["BUY", "SELL"]
     hash: str | None = None
-    best_bid: _OptionalDecimalFromNumberOrString = None
-    best_ask: _OptionalDecimalFromNumberOrString = None
+    best_bid: Decimal | None = None
+    best_ask: Decimal | None = None
+
+    @field_validator("price", "size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("best_bid", "best_ask", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_order_side(value)
 
 
 # --- Payloads (the variant-specific data; lifted out of the wire's top level) ---
@@ -46,45 +60,105 @@ class MarketBookPayload(BaseModel):
     bids: tuple[OrderBookLevel, ...]
     asks: tuple[OrderBookLevel, ...]
     hash: str | None = None
-    timestamp: EpochMsTimestamp = None
-    min_order_size: _OptionalDecimalFromNumberOrString = None
-    tick_size: _OptionalDecimalFromNumberOrString = None
+    timestamp: datetime | None = None
+    min_order_size: Decimal | None = None
+    tick_size: Decimal | None = None
     neg_risk: bool | None = None
-    last_trade_price: _OptionalDecimalFromNumberOrString = None
+    last_trade_price: Decimal | None = None
+
+    @field_validator("min_order_size", "tick_size", "last_trade_price", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketPriceChangePayload(BaseModel):
     market: str
     price_changes: tuple[PriceChange, ...]
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketLastTradePricePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    price: _DecimalFromNumberOrString
-    size: _OptionalDecimalFromNumberOrString = None
-    side: _OrderSide
-    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
+    price: Decimal
+    size: Decimal | None = None
+    side: Literal["BUY", "SELL"]
+    fee_rate_bps: Decimal | None = None
     transaction_hash: str | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("size", "fee_rate_bps", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_order_side(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketTickSizeChangePayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    old_tick_size: _OptionalDecimalFromNumberOrString = None
-    new_tick_size: _DecimalFromNumberOrString
-    timestamp: EpochMsTimestamp = None
+    old_tick_size: Decimal | None = None
+    new_tick_size: Decimal
+    timestamp: datetime | None = None
+
+    @field_validator("new_tick_size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("old_tick_size", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketBestBidAskPayload(BaseModel):
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    best_bid: _OptionalDecimalFromNumberOrString = None
-    best_ask: _OptionalDecimalFromNumberOrString = None
-    spread: _OptionalDecimalFromNumberOrString = None
-    timestamp: EpochMsTimestamp = None
+    best_bid: Decimal | None = None
+    best_ask: Decimal | None = None
+    spread: Decimal | None = None
+    timestamp: datetime | None = None
+
+    @field_validator("best_bid", "best_ask", "spread", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class NewMarketPayload(BaseModel):
@@ -96,17 +170,17 @@ class NewMarketPayload(BaseModel):
     token_ids: tuple[TokenId, ...] | None = Field(default=None, validation_alias="assets_ids")
     outcomes: tuple[str, ...] | None = None
     event_message: MarketEventMessage | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     tags: tuple[str, ...] | None = None
     condition_id: CtfConditionId | None = None
     active: bool | None = None
     clob_token_ids: tuple[str, ...] | None = None
     sports_market_type: str | None = None
-    line: _OptionalDecimalFromNumberOrString = None
-    game_start_time: EpochMsTimestamp = None
-    order_price_min_tick_size: _OptionalDecimalFromNumberOrString = None
+    line: Decimal | None = None
+    game_start_time: datetime | None = None
+    order_price_min_tick_size: Decimal | None = None
     group_item_title: str | None = None
-    taker_base_fee: _OptionalDecimalFromNumberOrString = None
+    taker_base_fee: Decimal | None = None
     fees_enabled: bool | None = None
     fee_schedule: object | None = None
 
@@ -114,6 +188,16 @@ class NewMarketPayload(BaseModel):
     @classmethod
     def _validate_condition_id(cls, value: object) -> CtfConditionId | None:
         return validate_optional_ctf_condition_id(value)
+
+    @field_validator("line", "order_price_min_tick_size", "taker_base_fee", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("timestamp", "game_start_time", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 class MarketResolvedPayload(BaseModel):
@@ -123,8 +207,13 @@ class MarketResolvedPayload(BaseModel):
     winning_token_id: TokenId | None = Field(default=None, validation_alias="winning_asset_id")
     winning_outcome: str | None = None
     event_message: MarketEventMessage | None = None
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     tags: tuple[str, ...] | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
 
 
 # --- Envelope: every event is {topic, type, payload} ---

--- a/src/polymarket/models/clob/order_book.py
+++ b/src/polymarket/models/clob/order_book.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import Field, field_validator
 
 from polymarket._frames_bridge import frames_func as _frames_func
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsTimestamp,
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, TokenId
 
@@ -17,8 +19,13 @@ _DecimalMode = Literal["decimal", "float"]
 
 
 class OrderBookLevel(BaseModel):
-    price: _DecimalFromString
-    size: _DecimalFromString
+    price: Decimal
+    size: Decimal
+
+    @field_validator("price", "size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
 
 class OrderBook(BaseModel):
@@ -30,21 +37,31 @@ class OrderBook(BaseModel):
         description="CTF condition id for the market represented by this order book.",
     )
     token_id: TokenId = Field(validation_alias="asset_id")
-    timestamp: EpochMsTimestamp = None
+    timestamp: datetime | None = None
     bids: tuple[OrderBookLevel, ...]
     """Ascending price order, lowest bid first."""
     asks: tuple[OrderBookLevel, ...]
     """Descending price order, highest ask first."""
-    min_order_size: _DecimalFromString
-    tick_size: _DecimalFromString
+    min_order_size: Decimal
+    tick_size: Decimal
     neg_risk: bool
-    last_trade_price: _DecimalFromString | None = None
+    last_trade_price: Decimal | None = None
     hash: str
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_timestamp(value)
+
+    @field_validator("min_order_size", "tick_size", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return parse_decimal_string(value)
 
     @field_validator("last_trade_price", mode="before")
     @classmethod
     def _parse_last_trade_price(cls, value: object) -> object:
-        return None if value in (None, "") else value
+        return parse_decimal_string(None if value == "" else value)
 
     def _repr_html_(self) -> str:
         from polymarket._jupyter import card, safe_html_repr, truncate_mid

--- a/src/polymarket/models/clob/order_response.py
+++ b/src/polymarket/models/clob/order_response.py
@@ -5,10 +5,8 @@ from typing import Literal, TypeAlias
 
 from pydantic import Field, field_validator
 
+from polymarket.models._validators import parse_decimal_string
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import (
-    _DecimalFromString,  # pyright: ignore[reportPrivateUsage]
-)
 from polymarket.models.types import OrderId
 from polymarket.types import TransactionHash
 
@@ -45,18 +43,18 @@ _ERROR_MSG_TO_CODE: dict[str, OrderResponseErrorCode] = {
 
 class RawOrderResponse(BaseModel):
     error_msg: str = Field(validation_alias="errorMsg")
-    making_amount: _DecimalFromString = Field(validation_alias="makingAmount")
+    making_amount: Decimal = Field(validation_alias="makingAmount")
     order_id: str = Field(validation_alias="orderID")
     status: str
     success: bool
-    taking_amount: _DecimalFromString = Field(validation_alias="takingAmount")
+    taking_amount: Decimal = Field(validation_alias="takingAmount")
     trade_ids: tuple[str, ...] = Field(default=(), validation_alias="tradeIDs")
     transactions_hashes: tuple[str, ...] = Field(default=(), validation_alias="transactionsHashes")
 
     @field_validator("making_amount", "taking_amount", mode="before")
     @classmethod
-    def _empty_string_to_zero(cls, value: object) -> object:
-        return "0" if value == "" else value
+    def _parse_amounts(cls, value: object) -> object:
+        return parse_decimal_string("0" if value == "" else value)
 
 
 class AcceptedOrder(BaseModel):

--- a/src/polymarket/models/clob/rewards.py
+++ b/src/polymarket/models/clob/rewards.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import TypeAlias
 
 from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.types import CtfConditionId, TokenId, validate_ctf_condition_id
 
@@ -53,10 +54,13 @@ class CurrentRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
-    total_rewards: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_rewards"
-    )
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
+    total_rewards: Decimal | None = Field(default=None, validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -72,22 +76,27 @@ class CurrentRewardConfig(BaseModel):
 class CurrentReward(BaseModel):
     condition_id: CtfConditionId = Field(validation_alias="condition_id")
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="rewards_min_size"
-    )
+    rewards_min_size: Decimal | None = Field(default=None, validation_alias="rewards_min_size")
     rewards_config: tuple[CurrentRewardConfig, ...] = Field(
         default=(), validation_alias="rewards_config"
     )
-    sponsored_daily_rate: _DecimalFromNumberOrString | None = Field(
+    sponsored_daily_rate: Decimal | None = Field(
         default=None, validation_alias="sponsored_daily_rate"
     )
     sponsors_count: int | None = Field(default=None, validation_alias="sponsors_count")
-    native_daily_rate: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="native_daily_rate"
+    native_daily_rate: Decimal | None = Field(default=None, validation_alias="native_daily_rate")
+    total_daily_rate: Decimal | None = Field(default=None, validation_alias="total_daily_rate")
+
+    @field_validator(
+        "rewards_min_size",
+        "sponsored_daily_rate",
+        "native_daily_rate",
+        "total_daily_rate",
+        mode="before",
     )
-    total_daily_rate: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_daily_rate"
-    )
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod
@@ -99,10 +108,13 @@ class MarketRewardConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     start_date: datetime = Field(validation_alias="start_date")
     end_date: datetime | None = Field(default=None, validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
-    total_rewards: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="total_rewards"
-    )
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
+    total_rewards: Decimal | None = Field(default=None, validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", mode="before")
     @classmethod
@@ -118,7 +130,12 @@ class MarketRewardConfig(BaseModel):
 class MarketRewardToken(BaseModel):
     token_id: TokenId = Field(validation_alias="token_id")
     outcome: str
-    price: _DecimalFromNumberOrString
+    price: Decimal
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class MarketReward(BaseModel):
@@ -128,9 +145,7 @@ class MarketReward(BaseModel):
     event_slug: str | None = Field(default=None, validation_alias="event_slug")
     image: str | None = None
     rewards_max_spread: float | None = Field(default=None, validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString | None = Field(
-        default=None, validation_alias="rewards_min_size"
-    )
+    rewards_min_size: Decimal | None = Field(default=None, validation_alias="rewards_min_size")
     market_competitiveness: float | None = Field(
         default=None, validation_alias="market_competitiveness"
     )
@@ -138,6 +153,11 @@ class MarketReward(BaseModel):
     rewards_config: tuple[MarketRewardConfig, ...] = Field(
         default=(), validation_alias="rewards_config"
     )
+
+    @field_validator("rewards_min_size", mode="before")
+    @classmethod
+    def _parse_rewards_min_size(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod
@@ -147,11 +167,16 @@ class MarketReward(BaseModel):
 
 class UserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
     condition_id: CtfConditionId = Field(validation_alias="condition_id")
     date: datetime
-    earnings: _DecimalFromNumberOrString
+    earnings: Decimal
     maker_address: str = Field(validation_alias="maker_address")
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("date", mode="before")
     @classmethod
@@ -166,10 +191,15 @@ class UserEarning(BaseModel):
 
 class TotalUserEarning(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
     date: datetime
-    earnings: _DecimalFromNumberOrString
+    earnings: Decimal
     maker_address: str = Field(validation_alias="maker_address")
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("date", mode="before")
     @classmethod
@@ -180,9 +210,14 @@ class TotalUserEarning(BaseModel):
 class UserRewardsConfig(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
     end_date: datetime = Field(validation_alias="end_date")
-    rate_per_day: _DecimalFromNumberOrString = Field(validation_alias="rate_per_day")
+    rate_per_day: Decimal = Field(validation_alias="rate_per_day")
     start_date: datetime = Field(validation_alias="start_date")
-    total_rewards: _DecimalFromNumberOrString = Field(validation_alias="total_rewards")
+    total_rewards: Decimal = Field(validation_alias="total_rewards")
+
+    @field_validator("rate_per_day", "total_rewards", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("start_date", "end_date", mode="before")
     @classmethod
@@ -192,8 +227,13 @@ class UserRewardsConfig(BaseModel):
 
 class EarningBreakdown(BaseModel):
     asset_address: str = Field(validation_alias="asset_address")
-    asset_rate: _DecimalFromNumberOrString = Field(validation_alias="asset_rate")
-    earnings: _DecimalFromNumberOrString
+    asset_rate: Decimal = Field(validation_alias="asset_rate")
+    earnings: Decimal
+
+    @field_validator("asset_rate", "earnings", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class UserRewardsEarning(BaseModel):
@@ -208,8 +248,13 @@ class UserRewardsEarning(BaseModel):
     question: str
     rewards_config: tuple[UserRewardsConfig, ...] = Field(validation_alias="rewards_config")
     rewards_max_spread: float = Field(validation_alias="rewards_max_spread")
-    rewards_min_size: _DecimalFromNumberOrString = Field(validation_alias="rewards_min_size")
+    rewards_min_size: Decimal = Field(validation_alias="rewards_min_size")
     tokens: tuple[MarketRewardToken, ...]
+
+    @field_validator("rewards_min_size", mode="before")
+    @classmethod
+    def _parse_rewards_min_size(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
     @field_validator("condition_id", mode="before")
     @classmethod

--- a/src/polymarket/models/clob/user_events.py
+++ b/src/polymarket/models/clob/user_events.py
@@ -1,24 +1,26 @@
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
 
-from pydantic import AliasChoices, BeforeValidator, Field, TypeAdapter, ValidationError
+from pydantic import AliasChoices, Field, TypeAdapter, ValidationError, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochSecondsOrMsTimestamp,
-    EpochSecondsTimestamp,
-    ExpirationTimestamp,
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
-    _OptionalDecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _coerce_optional_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_seconds_or_ms_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_seconds_timestamp,  # pyright: ignore[reportPrivateUsage]
+    _parse_expiration_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
-from polymarket.models.clob.account import TradeStatusField
-from polymarket.models.types import TokenId
+from polymarket.models.clob.account import (
+    TradeStatus,
+    _normalize_trade_status,  # pyright: ignore[reportPrivateUsage]
+)
+from polymarket.models.types import OrderSide, TokenId
 
 
 def _uppercase_string(value: object) -> object:
     return value.upper() if isinstance(value, str) else value
-
-
-_OrderSide = Annotated[Literal["BUY", "SELL"], BeforeValidator(_uppercase_string)]
 
 
 _OrderEventType = Literal["PLACEMENT", "UPDATE", "CANCELLATION"]
@@ -30,22 +32,19 @@ _OrderStatus = Literal["LIVE", "MATCHED", "DELAYED", "UNMATCHED", "CANCELED"]
 _OrderType = Literal["GTC", "FOK", "IOC", "GTD", "FAK"]
 
 
-_TraderSide = Annotated[Literal["TAKER", "MAKER"], BeforeValidator(_uppercase_string)]
-
-
 class UserOrderPayload(BaseModel):
     id: str
     owner: str
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    side: _OrderSide
-    original_size: _DecimalFromNumberOrString
-    size_matched: _DecimalFromNumberOrString
-    price: _DecimalFromNumberOrString
+    side: OrderSide
+    original_size: Decimal
+    size_matched: Decimal
+    price: Decimal
     order_event_type: _OrderEventType = Field(validation_alias="type")
-    timestamp: EpochSecondsOrMsTimestamp = None
-    created_at: EpochSecondsTimestamp = None
-    expires_at: ExpirationTimestamp = Field(default=None, validation_alias="expiration")
+    timestamp: datetime | None = None
+    created_at: datetime | None = None
+    expires_at: datetime | None = Field(default=None, validation_alias="expiration")
     order_type: _OrderType | None = None
     status: _OrderStatus | None = None
     maker_address: str | None = None
@@ -53,18 +52,58 @@ class UserOrderPayload(BaseModel):
     associate_trades: tuple[str, ...] | None = None
     outcome: str | None = None
 
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_string(value)
+
+    @field_validator("original_size", "size_matched", "price", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_seconds_or_ms_timestamp(value)
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_created_at(cls, value: object) -> object:
+        return _parse_epoch_seconds_timestamp(value)
+
+    @field_validator("expires_at", mode="before")
+    @classmethod
+    def _parse_expires_at(cls, value: object) -> object:
+        return _parse_expiration_timestamp(value)
+
 
 class UserTradeMakerOrder(BaseModel):
     order_id: str
     owner: str
     maker_address: str | None = None
-    matched_amount: _DecimalFromNumberOrString
-    price: _DecimalFromNumberOrString
-    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
+    matched_amount: Decimal
+    price: Decimal
+    fee_rate_bps: Decimal | None = None
     token_id: TokenId = Field(validation_alias="asset_id")
-    side: _OrderSide
+    side: OrderSide
     outcome: str | None = None
     outcome_index: int | None = None
+
+    @field_validator("matched_amount", "price", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("fee_rate_bps", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: object) -> object:
+        return _uppercase_string(value)
 
 
 class UserTradePayload(BaseModel):
@@ -72,24 +111,54 @@ class UserTradePayload(BaseModel):
     taker_order_id: str
     market: str
     token_id: TokenId = Field(validation_alias="asset_id")
-    side: _OrderSide
-    size: _DecimalFromNumberOrString
-    price: _DecimalFromNumberOrString
-    status: TradeStatusField
+    side: OrderSide
+    size: Decimal
+    price: Decimal
+    status: TradeStatus
     owner: str
-    timestamp: EpochSecondsOrMsTimestamp = None
-    fee_rate_bps: _OptionalDecimalFromNumberOrString = None
-    matched_at: EpochSecondsTimestamp = Field(
+    timestamp: datetime | None = None
+    fee_rate_bps: Decimal | None = None
+    matched_at: datetime | None = Field(
         default=None, validation_alias=AliasChoices("match_time", "matchtime")
     )
-    updated_at: EpochSecondsTimestamp = Field(default=None, validation_alias="last_update")
+    updated_at: datetime | None = Field(default=None, validation_alias="last_update")
     trade_owner: str | None = None
     maker_address: str | None = None
     transaction_hash: str | None = None
     bucket_index: int | None = None
     maker_orders: tuple[UserTradeMakerOrder, ...] | None = None
-    trader_side: _TraderSide | None = None
+    trader_side: Literal["TAKER", "MAKER"] | None = None
     outcome: str | None = None
+
+    @field_validator("side", "trader_side", mode="before")
+    @classmethod
+    def _normalize_sides(cls, value: object) -> object:
+        return _uppercase_string(value)
+
+    @field_validator("size", "price", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("fee_rate_bps", mode="before")
+    @classmethod
+    def _parse_optional_decimal(cls, value: object) -> object:
+        return _coerce_optional_decimalish(value)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _parse_status(cls, value: object) -> object:
+        return _normalize_trade_status(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_seconds_or_ms_timestamp(value)
+
+    @field_validator("matched_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_seconds_timestamp(cls, value: object) -> object:
+        return _parse_epoch_seconds_timestamp(value)
 
 
 class UserOrderEvent(BaseModel):

--- a/src/polymarket/models/collateral_return.py
+++ b/src/polymarket/models/collateral_return.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import Field, field_serializer, field_validator
+from pydantic import Field, field_validator
 
 from polymarket.models._validators import (
     parse_decimal_string,
     parse_e6_decimal_string,
-    serialize_e6_decimal_string,
 )
 from polymarket.models.base import BaseModel
 from polymarket.models.types import (
@@ -55,7 +54,6 @@ class CollateralReturnOperation(BaseModel):
     amount: Decimal
 
     _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
-    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
     @field_validator("kind", mode="before")
     @classmethod
@@ -80,7 +78,6 @@ class CollateralReturnPositionAmount(BaseModel):
     amount: Decimal
 
     _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
-    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
 
 class CollateralReturnPositionSummary(BaseModel):

--- a/src/polymarket/models/collateral_return.py
+++ b/src/polymarket/models/collateral_return.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_serializer, field_validator
 
-from polymarket.models._validators import DecimalFromE6String, DecimalFromString
+from polymarket.models._validators import (
+    parse_decimal_string,
+    parse_e6_decimal_string,
+    serialize_e6_decimal_string,
+)
 from polymarket.models.base import BaseModel
 from polymarket.models.types import (
     ComboConditionId,
@@ -47,7 +52,10 @@ class CollateralReturnOperation(BaseModel):
     event_id: EventId | None = None
     position_id: PositionId | None = None
     condition_index: int = 0
-    amount: DecimalFromE6String
+    amount: Decimal
+
+    _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
+    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
     @field_validator("kind", mode="before")
     @classmethod
@@ -69,7 +77,10 @@ class CollateralReturnPositionAmount(BaseModel):
     """A position and the amount of it a plan touches."""
 
     position_id: PositionId
-    amount: DecimalFromE6String
+    amount: Decimal
+
+    _parse_amount = field_validator("amount", mode="before")(parse_e6_decimal_string)
+    _serialize_amount = field_serializer("amount", when_used="json")(serialize_e6_decimal_string)
 
 
 class CollateralReturnPositionSummary(BaseModel):
@@ -103,14 +114,14 @@ class CollateralReturnPlanResponse(BaseModel):
     chain_id: int
     wallet: EvmAddress
     block_number: int
-    starting_pusd: DecimalFromString
-    net_pusd_out: DecimalFromString
-    final_pusd: DecimalFromString
+    starting_pusd: Decimal
+    net_pusd_out: Decimal
+    final_pusd: Decimal
     operations: tuple[CollateralReturnOperation, ...]
     operation_count: int
     truncated: bool
     estimated_cost: float
-    required_pusd_input: DecimalFromString
+    required_pusd_input: Decimal
     required_positions: tuple[CollateralReturnPositionAmount, ...]
     # Tolerate older service builds that predate the summary field.
     position_summary: CollateralReturnPositionSummary = Field(
@@ -118,6 +129,14 @@ class CollateralReturnPlanResponse(BaseModel):
     )
     candidate_position_ids: tuple[PositionId, ...]
     router_call: CollateralReturnRouterCall
+
+    _parse_decimal_fields = field_validator(
+        "starting_pusd",
+        "net_pusd_out",
+        "final_pusd",
+        "required_pusd_input",
+        mode="before",
+    )(parse_decimal_string)
 
 
 __all__ = [

--- a/src/polymarket/models/perps/_validators.py
+++ b/src/polymarket/models/perps/_validators.py
@@ -1,8 +1,5 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Annotated
-
-from pydantic import BeforeValidator
 
 
 def _coerce_decimalish(value: object) -> object:
@@ -46,19 +43,9 @@ def _parse_tx_hash(value: object) -> object:
     return value
 
 
-if TYPE_CHECKING:
-    _Decimal = Decimal
-else:
-    _Decimal = Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
-
-PerpsTimestamp = Annotated[datetime, BeforeValidator(_require_epoch_ms)]
-OptionalPerpsTimestamp = Annotated[datetime | None, BeforeValidator(_parse_epoch_ms)]
-OptionalTxHash = Annotated[str | None, BeforeValidator(_parse_tx_hash)]
-
-
 __all__ = [
-    "OptionalPerpsTimestamp",
-    "OptionalTxHash",
-    "PerpsTimestamp",
-    "_Decimal",
+    "_coerce_decimalish",
+    "_parse_epoch_ms",
+    "_parse_tx_hash",
+    "_require_epoch_ms",
 ]

--- a/src/polymarket/models/perps/account.py
+++ b/src/polymarket/models/perps/account.py
@@ -1,12 +1,17 @@
 """Perps account models."""
 
 from collections.abc import Sequence
-from typing import Annotated, cast
+from datetime import datetime
+from decimal import Decimal
+from typing import cast
 
-from pydantic import AliasChoices, BeforeValidator, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.perps._validators import PerpsTimestamp, _Decimal
+from polymarket.models.perps._validators import (
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.perps.types import PerpsEntityId, PerpsInstrumentId
 
 # Proxy key expiries above this magnitude are nanoseconds; convert to ms.
@@ -17,20 +22,37 @@ class PerpsBalance(BaseModel):
     """One asset balance in the Perps account."""
 
     asset: str
-    balance: _Decimal
-    value: _Decimal
+    balance: Decimal
+    value: Decimal
+
+    @field_validator("balance", "value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsAccountStats(BaseModel):
     """Rolling 7-day trading statistics for the Perps account."""
 
-    volume_7d: _Decimal
-    taker_volume_7d: _Decimal
-    maker_volume_7d: _Decimal
-    account_maker_share_7d: _Decimal
-    entity_maker_share_7d: _Decimal | None = None
+    volume_7d: Decimal
+    taker_volume_7d: Decimal
+    maker_volume_7d: Decimal
+    account_maker_share_7d: Decimal
+    entity_maker_share_7d: Decimal | None = None
     entity_id: PerpsEntityId | None = None
     entity_name: str | None = None
+
+    @field_validator(
+        "volume_7d",
+        "taker_volume_7d",
+        "maker_volume_7d",
+        "account_maker_share_7d",
+        "entity_maker_share_7d",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPosition(BaseModel):
@@ -38,26 +60,53 @@ class PerpsPosition(BaseModel):
 
     instrument_id: PerpsInstrumentId
     symbol: str
-    size: _Decimal
-    entry_price: _Decimal
+    size: Decimal
+    entry_price: Decimal
     leverage: int
     cross: bool
-    initial_margin: _Decimal
-    maintenance_margin: _Decimal
-    position_value: _Decimal
-    liquidation_price: _Decimal
-    unrealized_pnl: _Decimal
-    return_on_equity: _Decimal
-    cumulative_funding: _Decimal
+    initial_margin: Decimal
+    maintenance_margin: Decimal
+    position_value: Decimal
+    liquidation_price: Decimal
+    unrealized_pnl: Decimal
+    return_on_equity: Decimal
+    cumulative_funding: Decimal
+
+    @field_validator(
+        "size",
+        "entry_price",
+        "initial_margin",
+        "maintenance_margin",
+        "position_value",
+        "liquidation_price",
+        "unrealized_pnl",
+        "return_on_equity",
+        "cumulative_funding",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsMarginSummary(BaseModel):
     """Account-wide margin totals."""
 
-    total_account_value: _Decimal
-    total_initial_margin: _Decimal
-    total_maintenance_margin: _Decimal
-    total_position_value: _Decimal
+    total_account_value: Decimal
+    total_initial_margin: Decimal
+    total_maintenance_margin: Decimal
+    total_position_value: Decimal
+
+    @field_validator(
+        "total_account_value",
+        "total_initial_margin",
+        "total_maintenance_margin",
+        "total_position_value",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPortfolio(BaseModel):
@@ -65,20 +114,40 @@ class PerpsPortfolio(BaseModel):
 
     positions: tuple[PerpsPosition, ...]
     margin: PerpsMarginSummary
-    withdrawable: _Decimal
+    withdrawable: Decimal
     in_liquidation: bool
-    timestamp: PerpsTimestamp
+    timestamp: datetime
+
+    @field_validator("withdrawable", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsFundingPayment(BaseModel):
     """One funding payment applied to a position."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
-    size: _Decimal = Field(validation_alias=AliasChoices("size", "sz"))
-    funding_rate: _Decimal = Field(validation_alias=AliasChoices("funding_rate", "fr"))
+    size: Decimal = Field(validation_alias=AliasChoices("size", "sz"))
+    funding_rate: Decimal = Field(validation_alias=AliasChoices("funding_rate", "fr"))
     funding_asset: str = Field(validation_alias=AliasChoices("funding_asset", "fua"))
-    funding: _Decimal = Field(validation_alias=AliasChoices("funding", "fund"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    funding: Decimal = Field(validation_alias=AliasChoices("funding", "fund"))
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+
+    @field_validator("size", "funding_rate", "funding", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsAccountConfig(BaseModel):
@@ -92,8 +161,8 @@ class PerpsAccountConfig(BaseModel):
 class PerpsEquityPoint(BaseModel):
     """One account equity observation."""
 
-    timestamp: PerpsTimestamp
-    equity: _Decimal
+    timestamp: datetime
+    equity: Decimal
 
     @model_validator(mode="before")
     @classmethod
@@ -105,12 +174,22 @@ class PerpsEquityPoint(BaseModel):
             return list(entries)
         return {"timestamp": entries[0], "equity": entries[1]}
 
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("equity", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
 
 class PerpsPnlPoint(BaseModel):
     """One account profit-and-loss observation."""
 
-    timestamp: PerpsTimestamp
-    pnl: _Decimal
+    timestamp: datetime
+    pnl: Decimal
 
     @model_validator(mode="before")
     @classmethod
@@ -121,6 +200,16 @@ class PerpsPnlPoint(BaseModel):
         if len(entries) != 2:
             return list(entries)
         return {"timestamp": entries[0], "pnl": entries[1]}
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("pnl", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 def _normalize_proxy_expiry(value: object) -> object:
@@ -136,9 +225,12 @@ class PerpsProxyKey(BaseModel):
 
     proxy: str
     label: str | None = None
-    expires_at: Annotated[PerpsTimestamp, BeforeValidator(_normalize_proxy_expiry)] = Field(
-        validation_alias="expiry"
-    )
+    expires_at: datetime = Field(validation_alias="expiry")
+
+    @field_validator("expires_at", mode="before")
+    @classmethod
+    def _parse_expiry(cls, value: object) -> object:
+        return _require_epoch_ms(_normalize_proxy_expiry(value))
 
 
 class PerpsCredentialsInfo(BaseModel):

--- a/src/polymarket/models/perps/events.py
+++ b/src/polymarket/models/perps/events.py
@@ -1,12 +1,16 @@
 """Perps realtime event models."""
 
 import re
+from datetime import datetime
 from typing import Annotated, Any, Literal, cast
 
-from pydantic import Field, TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError, field_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.perps._validators import OptionalPerpsTimestamp, PerpsTimestamp
+from polymarket.models.perps._validators import (
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.perps.account import PerpsBalance, PerpsFundingPayment, PerpsPortfolio
 from polymarket.models.perps.funds import PerpsDepositUpdate, PerpsWithdrawalUpdate
 from polymarket.models.perps.market import (
@@ -43,68 +47,75 @@ _SESSION_CHANNEL_TYPES: dict[str, str] = {
 _NOTIFICATIONS_CHANNEL = "notifications"
 
 
-class PerpsTradeEvent(BaseModel):
+class _PerpsEventEnvelope(BaseModel):
+    @field_validator("timestamp", mode="before", check_fields=False)
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+
+class PerpsTradeEvent(_PerpsEventEnvelope):
     """Public trades printed in one update for a subscribed instrument."""
 
     topic: Literal["perps.trades"] = "perps.trades"
     type: Literal["trade"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: list[PerpsTrade]
 
 
-class PerpsBboEvent(BaseModel):
+class PerpsBboEvent(_PerpsEventEnvelope):
     """A best bid/ask update for a subscribed instrument."""
 
     topic: Literal["perps.bbo"] = "perps.bbo"
     type: Literal["bbo"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBbo
 
 
-class PerpsBookEvent(BaseModel):
+class PerpsBookEvent(_PerpsEventEnvelope):
     """An order book delta for a subscribed instrument."""
 
     topic: Literal["perps.book"] = "perps.book"
     type: Literal["book"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBookUpdate
 
 
-class PerpsTickerEvent(BaseModel):
+class PerpsTickerEvent(_PerpsEventEnvelope):
     """A ticker update for a subscribed instrument."""
 
     topic: Literal["perps.tickers"] = "perps.tickers"
     type: Literal["ticker"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsTickerUpdate
 
 
-class PerpsStatisticEvent(BaseModel):
+class PerpsStatisticEvent(_PerpsEventEnvelope):
     """A trading statistics update for a subscribed instrument."""
 
     topic: Literal["perps.statistics"] = "perps.statistics"
     type: Literal["statistic"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsStatistic
 
 
-class PerpsCandleEvent(BaseModel):
+class PerpsCandleEvent(_PerpsEventEnvelope):
     """A candle batch for a subscribed instrument and interval."""
 
     topic: Literal["perps.candles"] = "perps.candles"
     type: Literal["candle"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsCandleBatch
 
@@ -122,72 +133,72 @@ PerpsMarketEvent = Annotated[
 _MARKET_EVENT_ADAPTER: TypeAdapter[PerpsMarketEvent] = TypeAdapter(PerpsMarketEvent)
 
 
-class PerpsBalanceEvent(BaseModel):
+class PerpsBalanceEvent(_PerpsEventEnvelope):
     """A balance update for the session account."""
 
     type: Literal["balance"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsBalance
 
 
-class PerpsPortfolioEvent(BaseModel):
+class PerpsPortfolioEvent(_PerpsEventEnvelope):
     """A portfolio snapshot update for the session account."""
 
     type: Literal["portfolio"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsPortfolio
 
 
-class PerpsOrderEvent(BaseModel):
+class PerpsOrderEvent(_PerpsEventEnvelope):
     """An order lifecycle update for the session account."""
 
     type: Literal["order"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsOrder
 
 
-class PerpsFillEvent(BaseModel):
+class PerpsFillEvent(_PerpsEventEnvelope):
     """Fill updates in one frame for the session account."""
 
     type: Literal["fill"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: list[PerpsFill]
 
 
-class PerpsFundingEvent(BaseModel):
+class PerpsFundingEvent(_PerpsEventEnvelope):
     """A funding payment update for the session account."""
 
     type: Literal["funding"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsFundingPayment
 
 
-class PerpsDepositEvent(BaseModel):
+class PerpsDepositEvent(_PerpsEventEnvelope):
     """A deposit status update for the session account."""
 
     type: Literal["deposit"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsDepositUpdate
 
 
-class PerpsWithdrawalEvent(BaseModel):
+class PerpsWithdrawalEvent(_PerpsEventEnvelope):
     """A withdrawal status update for the session account."""
 
     type: Literal["withdrawal"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsWithdrawalUpdate
 
@@ -200,22 +211,22 @@ class PerpsTpSlUpdate(BaseModel):
     reason: str | None = None
 
 
-class PerpsTpSlEvent(BaseModel):
+class PerpsTpSlEvent(_PerpsEventEnvelope):
     """A take-profit/stop-loss lifecycle update for the session account."""
 
     type: Literal["tpsl"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsTpSlUpdate
 
 
-class PerpsNotificationEvent(BaseModel):
+class PerpsNotificationEvent(_PerpsEventEnvelope):
     """An account notification for the session account."""
 
     type: Literal["notification"]
     channel: str
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
     payload: PerpsNotification
 
@@ -234,7 +245,12 @@ class PerpsResyncEvent(BaseModel):
     channel: str | None = None
     previous_sequence: int | None = None
     sequence: int | None = None
-    timestamp: OptionalPerpsTimestamp = None
+    timestamp: datetime | None = None
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 PerpsSessionEvent = (

--- a/src/polymarket/models/perps/funds.py
+++ b/src/polymarket/models/perps/funds.py
@@ -1,13 +1,16 @@
 """Perps deposit and withdrawal models."""
 
-from pydantic import Field
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsDepositStatus,
@@ -21,25 +24,48 @@ class PerpsDeposit(BaseModel):
 
     hash: str
     asset: str
-    amount: _Decimal
+    amount: Decimal
     status: PerpsDepositStatus
     from_address: str = Field(validation_alias="from")
     to: str
     confirmations: int
     required_confirmations: int
-    created_at: PerpsTimestamp = Field(validation_alias="created_timestamp")
-    confirmed_at: OptionalPerpsTimestamp = Field(
-        default=None, validation_alias="confirmed_timestamp"
-    )
+    created_at: datetime = Field(validation_alias="created_timestamp")
+    confirmed_at: datetime | None = Field(default=None, validation_alias="confirmed_timestamp")
+
+    @field_validator("amount", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_created_at(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("confirmed_at", mode="before")
+    @classmethod
+    def _parse_confirmed_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsDepositUpdate(BaseModel):
     """Streaming status update for one Perps deposit."""
 
-    hash: OptionalTxHash = None
+    hash: str | None = None
     asset: str
-    amount: _Decimal
+    amount: Decimal
     status: PerpsDepositStatus
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
+
+    @field_validator("amount", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsWithdrawal(BaseModel):
@@ -47,17 +73,35 @@ class PerpsWithdrawal(BaseModel):
 
     withdrawal_id: PerpsWithdrawalId = Field(validation_alias="withdraw_id")
     asset: str
-    amount: _Decimal
-    fee: _Decimal
+    amount: Decimal
+    fee: Decimal
     status: PerpsWithdrawalStatus
     to: str
-    hash: OptionalTxHash = None
+    hash: str | None = None
     confirmations: int
     required_confirmations: int
-    created_at: PerpsTimestamp = Field(validation_alias="created_timestamp")
-    confirmed_at: OptionalPerpsTimestamp = Field(
-        default=None, validation_alias="confirmed_timestamp"
-    )
+    created_at: datetime = Field(validation_alias="created_timestamp")
+    confirmed_at: datetime | None = Field(default=None, validation_alias="confirmed_timestamp")
+
+    @field_validator("amount", "fee", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_created_at(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("confirmed_at", mode="before")
+    @classmethod
+    def _parse_confirmed_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsWithdrawalUpdate(BaseModel):
@@ -65,11 +109,21 @@ class PerpsWithdrawalUpdate(BaseModel):
 
     withdrawal_id: PerpsWithdrawalId = Field(validation_alias="withdraw_id")
     asset: str
-    amount: _Decimal
-    fee: _Decimal
+    amount: Decimal
+    fee: Decimal
     status: PerpsWithdrawalStatus
     to: str
-    hash: OptionalTxHash = None
+    hash: str | None = None
+
+    @field_validator("amount", "fee", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 __all__ = [

--- a/src/polymarket/models/perps/market.py
+++ b/src/polymarket/models/perps/market.py
@@ -1,16 +1,18 @@
 """Perps market data models."""
 
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal
 from typing import Literal, cast
 
 from pydantic import AliasChoices, Field, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentCategory,
@@ -20,11 +22,49 @@ from polymarket.models.perps.types import (
 )
 
 
+def _normalize_field(
+    data: dict[str, object],
+    aliases: tuple[str, ...],
+    parser: Callable[[object], object],
+) -> None:
+    for alias in aliases:
+        if alias in data:
+            data[alias] = parser(data[alias])
+            return
+
+
+def _normalize_market_data(
+    data: object,
+    *,
+    decimals: tuple[tuple[str, ...], ...] = (),
+    timestamps: tuple[tuple[str, ...], ...] = (),
+    optional_timestamps: tuple[tuple[str, ...], ...] = (),
+    optional_hashes: tuple[tuple[str, ...], ...] = (),
+) -> object:
+    if not isinstance(data, Mapping):
+        return data
+    normalized = dict(cast("Mapping[str, object]", data))
+    for aliases in decimals:
+        _normalize_field(normalized, aliases, _coerce_decimalish)
+    for aliases in timestamps:
+        _normalize_field(normalized, aliases, _require_epoch_ms)
+    for aliases in optional_timestamps:
+        _normalize_field(normalized, aliases, _parse_epoch_ms)
+    for aliases in optional_hashes:
+        _normalize_field(normalized, aliases, _parse_tx_hash)
+    return normalized
+
+
 class PerpsRiskTier(BaseModel):
     """One leverage risk tier for a Perps instrument."""
 
-    lower_bound: _Decimal
+    lower_bound: Decimal
     max_leverage: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(data, decimals=(("lower_bound",),))
 
 
 class PerpsInstrument(BaseModel):
@@ -38,15 +78,29 @@ class PerpsInstrument(BaseModel):
     funding_interval: str
     quantity_decimals: int
     price_decimals: int
-    price_bounds: _Decimal
-    liquidation_fee: _Decimal
+    price_bounds: Decimal
+    liquidation_fee: Decimal
     max_order_count: int
-    min_notional: _Decimal
-    max_market_notional: _Decimal
-    max_limit_notional: _Decimal
+    min_notional: Decimal
+    max_market_notional: Decimal
+    max_limit_notional: Decimal
     max_leverage: int
     isolated_only: bool
     risk_tiers: tuple[PerpsRiskTier, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("price_bounds",),
+                ("liquidation_fee",),
+                ("min_notional",),
+                ("max_market_notional",),
+                ("max_limit_notional",),
+            ),
+        )
 
 
 class PerpsTicker(BaseModel):
@@ -54,29 +108,64 @@ class PerpsTicker(BaseModel):
 
     instrument_id: PerpsInstrumentId
     symbol: str
-    index_price: _Decimal
-    mark_price: _Decimal
-    last_price: _Decimal
-    mid_price: _Decimal
-    open_interest: _Decimal
-    funding_rate: _Decimal
-    next_funding: PerpsTimestamp
-    timestamp: OptionalPerpsTimestamp = None
-    open_price: _Decimal | None = None
-    volume_24h: _Decimal | None = None
+    index_price: Decimal
+    mark_price: Decimal
+    last_price: Decimal
+    mid_price: Decimal
+    open_interest: Decimal
+    funding_rate: Decimal
+    next_funding: datetime
+    timestamp: datetime | None = None
+    open_price: Decimal | None = None
+    volume_24h: Decimal | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("index_price",),
+                ("mark_price",),
+                ("last_price",),
+                ("mid_price",),
+                ("open_interest",),
+                ("funding_rate",),
+                ("open_price",),
+                ("volume_24h",),
+            ),
+            timestamps=(("next_funding",),),
+            optional_timestamps=(("timestamp",),),
+        )
 
 
 class PerpsTickerUpdate(BaseModel):
     """Streaming ticker update for a Perps instrument."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias="iid")
-    index_price: _Decimal = Field(validation_alias="idx")
-    mark_price: _Decimal = Field(validation_alias="mark")
-    last_price: _Decimal = Field(validation_alias="last")
-    mid_price: _Decimal = Field(validation_alias="mid")
-    open_interest: _Decimal = Field(validation_alias="oi")
-    funding_rate: _Decimal = Field(validation_alias="fr")
-    next_funding: PerpsTimestamp = Field(validation_alias="nxf")
+    index_price: Decimal = Field(validation_alias="idx")
+    mark_price: Decimal = Field(validation_alias="mark")
+    last_price: Decimal = Field(validation_alias="last")
+    mid_price: Decimal = Field(validation_alias="mid")
+    open_interest: Decimal = Field(validation_alias="oi")
+    funding_rate: Decimal = Field(validation_alias="fr")
+    next_funding: datetime = Field(validation_alias="nxf")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("idx", "index_price"),
+                ("mark", "mark_price"),
+                ("last", "last_price"),
+                ("mid", "mid_price"),
+                ("oi", "open_interest"),
+                ("fr", "funding_rate"),
+            ),
+            timestamps=(("nxf", "next_funding"),),
+        )
 
 
 def _candle_from_tuple(value: object) -> object:
@@ -99,18 +188,22 @@ def _candle_from_tuple(value: object) -> object:
 class PerpsCandle(BaseModel):
     """One OHLCV candle for a Perps instrument."""
 
-    timestamp: PerpsTimestamp
-    open: _Decimal
-    high: _Decimal
-    low: _Decimal
-    close: _Decimal
-    volume: _Decimal
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
     trades: int
 
     @model_validator(mode="before")
     @classmethod
-    def _from_tuple(cls, data: object) -> object:
-        return _candle_from_tuple(data)
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            _candle_from_tuple(data),
+            decimals=(("open",), ("high",), ("low",), ("close",), ("volume",)),
+            timestamps=(("timestamp",),),
+        )
 
 
 class PerpsStatistic(BaseModel):
@@ -118,9 +211,17 @@ class PerpsStatistic(BaseModel):
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     symbol: str | None = None
-    volume: _Decimal = Field(validation_alias=AliasChoices("volume", "vol"))
-    open_price: _Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
+    volume: Decimal = Field(validation_alias=AliasChoices("volume", "vol"))
+    open_price: Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
     klines: tuple[PerpsCandle, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("volume", "vol"), ("open_price", "open")),
+        )
 
 
 def _level_from_tuple(value: object) -> object:
@@ -135,13 +236,16 @@ def _level_from_tuple(value: object) -> object:
 class PerpsBookLevel(BaseModel):
     """One price level of a Perps order book."""
 
-    price: _Decimal
-    quantity: _Decimal
+    price: Decimal
+    quantity: Decimal
 
     @model_validator(mode="before")
     @classmethod
-    def _from_tuple(cls, data: object) -> object:
-        return _level_from_tuple(data)
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            _level_from_tuple(data),
+            decimals=(("price",), ("quantity",)),
+        )
 
 
 class PerpsBook(BaseModel):
@@ -150,8 +254,13 @@ class PerpsBook(BaseModel):
     instrument_id: PerpsInstrumentId
     bids: tuple[PerpsBookLevel, ...]
     asks: tuple[PerpsBookLevel, ...]
-    timestamp: PerpsTimestamp
+    timestamp: datetime
     sequence: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(data, timestamps=(("timestamp",),))
 
 
 class PerpsBookUpdate(BaseModel):
@@ -166,11 +275,25 @@ class PerpsBbo(BaseModel):
     """Best bid and ask for a Perps instrument."""
 
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
-    bid_price: _Decimal = Field(validation_alias=AliasChoices("bid_price", "bp"))
-    bid_quantity: _Decimal = Field(validation_alias=AliasChoices("bid_quantity", "bq"))
-    ask_price: _Decimal = Field(validation_alias=AliasChoices("ask_price", "ap"))
-    ask_quantity: _Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
-    timestamp: OptionalPerpsTimestamp = None
+    bid_price: Decimal = Field(validation_alias=AliasChoices("bid_price", "bp"))
+    bid_quantity: Decimal = Field(validation_alias=AliasChoices("bid_quantity", "bq"))
+    ask_price: Decimal = Field(validation_alias=AliasChoices("ask_price", "ap"))
+    ask_quantity: Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
+    timestamp: datetime | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(
+                ("bid_price", "bp"),
+                ("bid_quantity", "bq"),
+                ("ask_price", "ap"),
+                ("ask_quantity", "aq"),
+            ),
+            optional_timestamps=(("timestamp",),),
+        )
 
 
 class PerpsTrade(BaseModel):
@@ -179,34 +302,69 @@ class PerpsTrade(BaseModel):
     trade_id: PerpsTradeId = Field(validation_alias=AliasChoices("trade_id", "tid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: PerpsSide
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
-    hash: OptionalTxHash = None
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    hash: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("price", "p"), ("quantity", "qty")),
+            timestamps=(("timestamp", "ts"),),
+            optional_hashes=(("hash",),),
+        )
 
 
 class PerpsFundingRate(BaseModel):
     """One historical funding rate observation."""
 
-    funding_rate: _Decimal
-    timestamp: PerpsTimestamp
+    funding_rate: Decimal
+    timestamp: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("funding_rate",),),
+            timestamps=(("timestamp",),),
+        )
 
 
 class PerpsFeeTier(BaseModel):
     """One volume-based fee tier for a Perps instrument category."""
 
-    min_volume_30d: _Decimal
-    taker_fee_rate: _Decimal
-    maker_fee_rate: _Decimal
+    min_volume_30d: Decimal
+    taker_fee_rate: Decimal
+    maker_fee_rate: Decimal
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("min_volume_30d",), ("taker_fee_rate",), ("maker_fee_rate",)),
+        )
 
 
 class PerpsFeeScheduleEntry(BaseModel):
     """Maker and taker fee rates for a Perps instrument category."""
 
     category: PerpsInstrumentCategory
-    taker_fee_rate: _Decimal
-    maker_fee_rate: _Decimal
+    taker_fee_rate: Decimal
+    maker_fee_rate: Decimal
     tiers: tuple[PerpsFeeTier, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: object) -> object:
+        return _normalize_market_data(
+            data,
+            decimals=(("taker_fee_rate",), ("maker_fee_rate",)),
+        )
 
 
 class PerpsCandleBatch(BaseModel):

--- a/src/polymarket/models/perps/market.py
+++ b/src/polymarket/models/perps/market.py
@@ -1,11 +1,11 @@
 """Perps market data models."""
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import Literal, cast
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
@@ -22,49 +22,16 @@ from polymarket.models.perps.types import (
 )
 
 
-def _normalize_field(
-    data: dict[str, object],
-    aliases: tuple[str, ...],
-    parser: Callable[[object], object],
-) -> None:
-    for alias in aliases:
-        if alias in data:
-            data[alias] = parser(data[alias])
-            return
-
-
-def _normalize_market_data(
-    data: object,
-    *,
-    decimals: tuple[tuple[str, ...], ...] = (),
-    timestamps: tuple[tuple[str, ...], ...] = (),
-    optional_timestamps: tuple[tuple[str, ...], ...] = (),
-    optional_hashes: tuple[tuple[str, ...], ...] = (),
-) -> object:
-    if not isinstance(data, Mapping):
-        return data
-    normalized = dict(cast("Mapping[str, object]", data))
-    for aliases in decimals:
-        _normalize_field(normalized, aliases, _coerce_decimalish)
-    for aliases in timestamps:
-        _normalize_field(normalized, aliases, _require_epoch_ms)
-    for aliases in optional_timestamps:
-        _normalize_field(normalized, aliases, _parse_epoch_ms)
-    for aliases in optional_hashes:
-        _normalize_field(normalized, aliases, _parse_tx_hash)
-    return normalized
-
-
 class PerpsRiskTier(BaseModel):
     """One leverage risk tier for a Perps instrument."""
 
     lower_bound: Decimal
     max_leverage: int
 
-    @model_validator(mode="before")
+    @field_validator("lower_bound", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(data, decimals=(("lower_bound",),))
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsInstrument(BaseModel):
@@ -88,19 +55,17 @@ class PerpsInstrument(BaseModel):
     isolated_only: bool
     risk_tiers: tuple[PerpsRiskTier, ...]
 
-    @model_validator(mode="before")
+    @field_validator(
+        "price_bounds",
+        "liquidation_fee",
+        "min_notional",
+        "max_market_notional",
+        "max_limit_notional",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("price_bounds",),
-                ("liquidation_fee",),
-                ("min_notional",),
-                ("max_market_notional",),
-                ("max_limit_notional",),
-            ),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsTicker(BaseModel):
@@ -119,24 +84,30 @@ class PerpsTicker(BaseModel):
     open_price: Decimal | None = None
     volume_24h: Decimal | None = None
 
-    @model_validator(mode="before")
+    @field_validator(
+        "index_price",
+        "mark_price",
+        "last_price",
+        "mid_price",
+        "open_interest",
+        "funding_rate",
+        "open_price",
+        "volume_24h",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("index_price",),
-                ("mark_price",),
-                ("last_price",),
-                ("mid_price",),
-                ("open_interest",),
-                ("funding_rate",),
-                ("open_price",),
-                ("volume_24h",),
-            ),
-            timestamps=(("next_funding",),),
-            optional_timestamps=(("timestamp",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("next_funding", mode="before")
+    @classmethod
+    def _parse_next_funding(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsTickerUpdate(BaseModel):
@@ -151,21 +122,23 @@ class PerpsTickerUpdate(BaseModel):
     funding_rate: Decimal = Field(validation_alias="fr")
     next_funding: datetime = Field(validation_alias="nxf")
 
-    @model_validator(mode="before")
+    @field_validator(
+        "index_price",
+        "mark_price",
+        "last_price",
+        "mid_price",
+        "open_interest",
+        "funding_rate",
+        mode="before",
+    )
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("idx", "index_price"),
-                ("mark", "mark_price"),
-                ("last", "last_price"),
-                ("mid", "mid_price"),
-                ("oi", "open_interest"),
-                ("fr", "funding_rate"),
-            ),
-            timestamps=(("nxf", "next_funding"),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("next_funding", mode="before")
+    @classmethod
+    def _parse_next_funding(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 def _candle_from_tuple(value: object) -> object:
@@ -199,11 +172,17 @@ class PerpsCandle(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            _candle_from_tuple(data),
-            decimals=(("open",), ("high",), ("low",), ("close",), ("volume",)),
-            timestamps=(("timestamp",),),
-        )
+        return _candle_from_tuple(data)
+
+    @field_validator("open", "high", "low", "close", "volume", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsStatistic(BaseModel):
@@ -215,13 +194,10 @@ class PerpsStatistic(BaseModel):
     open_price: Decimal = Field(validation_alias=AliasChoices("open_price", "open"))
     klines: tuple[PerpsCandle, ...]
 
-    @model_validator(mode="before")
+    @field_validator("volume", "open_price", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("volume", "vol"), ("open_price", "open")),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 def _level_from_tuple(value: object) -> object:
@@ -242,10 +218,12 @@ class PerpsBookLevel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            _level_from_tuple(data),
-            decimals=(("price",), ("quantity",)),
-        )
+        return _level_from_tuple(data)
+
+    @field_validator("price", "quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsBook(BaseModel):
@@ -257,10 +235,10 @@ class PerpsBook(BaseModel):
     timestamp: datetime
     sequence: int
 
-    @model_validator(mode="before")
+    @field_validator("timestamp", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(data, timestamps=(("timestamp",),))
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsBookUpdate(BaseModel):
@@ -281,19 +259,15 @@ class PerpsBbo(BaseModel):
     ask_quantity: Decimal = Field(validation_alias=AliasChoices("ask_quantity", "aq"))
     timestamp: datetime | None = None
 
-    @model_validator(mode="before")
+    @field_validator("bid_price", "bid_quantity", "ask_price", "ask_quantity", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(
-                ("bid_price", "bp"),
-                ("bid_quantity", "bq"),
-                ("ask_price", "ap"),
-                ("ask_quantity", "aq"),
-            ),
-            optional_timestamps=(("timestamp",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
 
 
 class PerpsTrade(BaseModel):
@@ -307,15 +281,20 @@ class PerpsTrade(BaseModel):
     timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
     hash: str | None = None
 
-    @model_validator(mode="before")
+    @field_validator("price", "quantity", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("price", "p"), ("quantity", "qty")),
-            timestamps=(("timestamp", "ts"),),
-            optional_hashes=(("hash",),),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _parse_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 class PerpsFundingRate(BaseModel):
@@ -324,14 +303,15 @@ class PerpsFundingRate(BaseModel):
     funding_rate: Decimal
     timestamp: datetime
 
-    @model_validator(mode="before")
+    @field_validator("funding_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("funding_rate",),),
-            timestamps=(("timestamp",),),
-        )
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 class PerpsFeeTier(BaseModel):
@@ -341,13 +321,10 @@ class PerpsFeeTier(BaseModel):
     taker_fee_rate: Decimal
     maker_fee_rate: Decimal
 
-    @model_validator(mode="before")
+    @field_validator("min_volume_30d", "taker_fee_rate", "maker_fee_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("min_volume_30d",), ("taker_fee_rate",), ("maker_fee_rate",)),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsFeeScheduleEntry(BaseModel):
@@ -358,13 +335,10 @@ class PerpsFeeScheduleEntry(BaseModel):
     maker_fee_rate: Decimal
     tiers: tuple[PerpsFeeTier, ...]
 
-    @model_validator(mode="before")
+    @field_validator("taker_fee_rate", "maker_fee_rate", mode="before")
     @classmethod
-    def _normalize(cls, data: object) -> object:
-        return _normalize_market_data(
-            data,
-            decimals=(("taker_fee_rate",), ("maker_fee_rate",)),
-        )
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsCandleBatch(BaseModel):

--- a/src/polymarket/models/perps/notifications.py
+++ b/src/polymarket/models/perps/notifications.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalPerpsTimestamp,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentId,
@@ -37,10 +39,15 @@ class PerpsPositionChangeNotification(BaseModel):
     type: Literal["position_opened", "position_increased", "position_reduced"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    avg_price: _Decimal
+    size: Decimal
+    avg_price: Decimal
     leverage: int
     order_type: PerpsNotificationOrderType | None = None
+
+    @field_validator("size", "avg_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsPositionClosedNotification(BaseModel):
@@ -50,10 +57,15 @@ class PerpsPositionClosedNotification(BaseModel):
     type: Literal["position_closed"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    avg_price: _Decimal
-    pnl: _Decimal
+    size: Decimal
+    avg_price: Decimal
+    pnl: Decimal
     order_type: PerpsNotificationOrderType | None = None
+
+    @field_validator("size", "avg_price", "pnl", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsLimitOrderCanceledNotification(BaseModel):
@@ -63,8 +75,13 @@ class PerpsLimitOrderCanceledNotification(BaseModel):
     type: Literal["limit_order_canceled"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size: _Decimal
-    price: _Decimal
+    size: Decimal
+    price: Decimal
+
+    @field_validator("size", "price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsIsolatedLiquidationWarningNotification(BaseModel):
@@ -74,8 +91,13 @@ class PerpsIsolatedLiquidationWarningNotification(BaseModel):
     type: Literal["liquidation_warning"]
     margin_type: Literal["isolated"]
     instrument_id: PerpsInstrumentId
-    mark_price: _Decimal
-    liquidation_price: _Decimal = Field(validation_alias="liq_price")
+    mark_price: Decimal
+    liquidation_price: Decimal = Field(validation_alias="liq_price")
+
+    @field_validator("mark_price", "liquidation_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsCrossLiquidationWarningNotification(BaseModel):
@@ -84,8 +106,13 @@ class PerpsCrossLiquidationWarningNotification(BaseModel):
     id: PerpsNotificationId
     type: Literal["liquidation_warning"]
     margin_type: Literal["cross"]
-    mark_price: _Decimal
+    mark_price: Decimal
     affected_instruments: tuple[PerpsInstrumentId, ...]
+
+    @field_validator("mark_price", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 PerpsLiquidationWarningNotification = Annotated[
@@ -101,10 +128,15 @@ class PerpsPositionLiquidatedNotification(BaseModel):
     type: Literal["position_liquidated"]
     instrument_id: PerpsInstrumentId
     side: PerpsSide
-    size_closed: _Decimal
-    pnl: _Decimal | None
+    size_closed: Decimal
+    pnl: Decimal | None
     margin_type: PerpsMarginType
     via_backstop: bool
+
+    @field_validator("size_closed", "pnl", mode="before")
+    @classmethod
+    def _validate_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 PerpsNotification = Annotated[
@@ -121,8 +153,18 @@ class PerpsNotificationEntry(BaseModel):
     """One notification with its account-scoped read state."""
 
     notification: PerpsNotification
-    read_at: OptionalPerpsTimestamp = None
-    timestamp: PerpsTimestamp = Field(validation_alias="ts")
+    read_at: datetime | None = None
+    timestamp: datetime = Field(validation_alias="ts")
+
+    @field_validator("read_at", mode="before")
+    @classmethod
+    def _validate_read_at(cls, value: object) -> object:
+        return _parse_epoch_ms(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _validate_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/polymarket/models/perps/orders.py
+++ b/src/polymarket/models/perps/orders.py
@@ -1,14 +1,16 @@
 """Perps order and fill models."""
 
+from datetime import datetime
+from decimal import Decimal
 from typing import Any, Literal, cast
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.perps._validators import (
-    OptionalTxHash,
-    PerpsTimestamp,
-    _Decimal,
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_tx_hash,  # pyright: ignore[reportPrivateUsage]
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.perps.types import (
     PerpsInstrumentId,
@@ -39,10 +41,15 @@ class PerpsTpSlOrderFields(BaseModel):
 
     kind: PerpsTpSlKind
     scope: PerpsTpSlScope
-    trigger_price: _Decimal = Field(validation_alias="trp")
+    trigger_price: Decimal = Field(validation_alias="trp")
     parent_order_id: PerpsOrderId | None = Field(default=None, validation_alias="parent_oid")
-    armed_quantity: _Decimal | None = Field(default=None, validation_alias="armed_qty")
+    armed_quantity: Decimal | None = Field(default=None, validation_alias="armed_qty")
     slippage_bps: int | None = Field(default=None, validation_alias="slip_bps")
+
+    @field_validator("trigger_price", "armed_quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class PerpsOrder(BaseModel):
@@ -51,16 +58,16 @@ class PerpsOrder(BaseModel):
     id: PerpsOrderId = Field(validation_alias=AliasChoices("order_id", "oid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: OrderSide = Field(validation_alias="buy")
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
     time_in_force: PerpsTimeInForce = Field(validation_alias="tif")
     post_only: bool = Field(validation_alias=AliasChoices("post_only", "po"))
     reduce_only: bool = Field(validation_alias="ro")
     status: PerpsOrderStatus
-    resting_quantity: _Decimal = Field(validation_alias=AliasChoices("resting_quantity", "rest"))
-    filled_quantity: _Decimal = Field(validation_alias=AliasChoices("filled_quantity", "fill"))
-    created_at: PerpsTimestamp = Field(validation_alias=AliasChoices("created_timestamp", "cts"))
-    updated_at: PerpsTimestamp = Field(validation_alias=AliasChoices("updated_timestamp", "uts"))
+    resting_quantity: Decimal = Field(validation_alias=AliasChoices("resting_quantity", "rest"))
+    filled_quantity: Decimal = Field(validation_alias=AliasChoices("filled_quantity", "fill"))
+    created_at: datetime = Field(validation_alias=AliasChoices("created_timestamp", "cts"))
+    updated_at: datetime = Field(validation_alias=AliasChoices("updated_timestamp", "uts"))
     client_order_id: str | None = Field(
         default=None, validation_alias=AliasChoices("client_order_id", "coid")
     )
@@ -78,6 +85,16 @@ class PerpsOrder(BaseModel):
         normalized["buy"] = _side_from_buy(normalized["buy"])
         return normalized
 
+    @field_validator("price", "quantity", "resting_quantity", "filled_quantity", mode="before")
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _parse_timestamps(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
 
 class PerpsFill(BaseModel):
     """One fill on a Perps order for the account."""
@@ -86,20 +103,43 @@ class PerpsFill(BaseModel):
     order_id: PerpsOrderId = Field(validation_alias=AliasChoices("order_id", "oid"))
     instrument_id: PerpsInstrumentId = Field(validation_alias=AliasChoices("instrument_id", "iid"))
     side: PerpsSide
-    price: _Decimal = Field(validation_alias=AliasChoices("price", "p"))
-    quantity: _Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
+    price: Decimal = Field(validation_alias=AliasChoices("price", "p"))
+    quantity: Decimal = Field(validation_alias=AliasChoices("quantity", "qty"))
     taker: bool
-    fee: _Decimal
+    fee: Decimal
     fee_asset: str = Field(validation_alias=AliasChoices("fee_asset", "fea"))
-    previous_size: _Decimal = Field(validation_alias=AliasChoices("previous_size", "psz"))
-    previous_entry_price: _Decimal = Field(
+    previous_size: Decimal = Field(validation_alias=AliasChoices("previous_size", "psz"))
+    previous_entry_price: Decimal = Field(
         validation_alias=AliasChoices("previous_entry_price", "pep")
     )
-    pnl: _Decimal
+    pnl: Decimal
     liquidation: bool = Field(validation_alias=AliasChoices("liquidation", "liq"))
-    timestamp: PerpsTimestamp = Field(validation_alias=AliasChoices("timestamp", "ts"))
-    hash: OptionalTxHash = None
+    timestamp: datetime = Field(validation_alias=AliasChoices("timestamp", "ts"))
+    hash: str | None = None
     client_order_id: str | None = Field(default=None, validation_alias="coid")
+
+    @field_validator(
+        "price",
+        "quantity",
+        "fee",
+        "previous_size",
+        "previous_entry_price",
+        "pnl",
+        mode="before",
+    )
+    @classmethod
+    def _parse_decimals(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+    @field_validator("hash", mode="before")
+    @classmethod
+    def _normalize_hash(cls, value: object) -> object:
+        return _parse_tx_hash(value)
 
 
 def _default_ack_error(data: object) -> object:

--- a/src/polymarket/models/rtds_events.py
+++ b/src/polymarket/models/rtds_events.py
@@ -7,8 +7,8 @@ from pydantic import Field, TypeAdapter, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
-    EpochMsOrIsoTimestamp,
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
+    _coerce_decimalish,  # pyright: ignore[reportPrivateUsage]
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
 )
 from polymarket.models.gamma.comment import (
     Comment,
@@ -41,7 +41,7 @@ _TWAP_WINDOW_BY_WIRE_TOPIC: dict[str, Literal[30, 60]] = {
 
 _CHAINLINK_PRICE_SCALE = 10**18
 _SIGNED_INTEGER_PATTERN = re.compile(r"-?[0-9]+")
-_DECIMALISH_ADAPTER = TypeAdapter(_DecimalFromNumberOrString)
+_DECIMALISH_ADAPTER = TypeAdapter(Decimal)
 
 
 def wire_topic_to_api(wire: str) -> str | None:
@@ -80,29 +80,49 @@ class CommentRemovedPayload(BaseModel):
 class CommentCreatedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["comment_created"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Comment
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class CommentRemovedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["comment_removed"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: CommentRemovedPayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class ReactionCreatedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["reaction_created"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Reaction
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class ReactionRemovedEvent(BaseModel):
     topic: Literal["comments"] = "comments"
     type: Literal["reaction_removed"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: Reaction
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 CommentsEvent = (
@@ -113,21 +133,36 @@ CommentsEvent = (
 class PriceUpdatePayload(BaseModel):
     symbol: str
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class CryptoPricesBinanceEvent(BaseModel):
     topic: Literal["prices.crypto.binance"] = "prices.crypto.binance"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: PriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class CryptoPricesChainlinkEvent(BaseModel):
     topic: Literal["prices.crypto.chainlink"] = "prices.crypto.chainlink"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: PriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 def _chainlink_e18_to_decimal(value: object) -> Decimal:
@@ -149,7 +184,7 @@ def _chainlink_e18_to_decimal(value: object) -> Decimal:
 class CryptoPricesChainlinkTwapPayload(BaseModel):
     symbol: str
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
     window_seconds: Literal[30, 60] = Field(validation_alias="window_s")
 
     @model_validator(mode="before")
@@ -163,16 +198,26 @@ class CryptoPricesChainlinkTwapPayload(BaseModel):
                 return data
             msg = "full_accuracy_value is required"
             raise ValueError(msg)
-        _DECIMALISH_ADAPTER.validate_python(data.get("value"))
+        _DECIMALISH_ADAPTER.validate_python(_coerce_decimalish(data.get("value")))
         data["value"] = _chainlink_e18_to_decimal(data.pop("full_accuracy_value"))
         return data
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class CryptoPricesChainlinkTwapEvent(BaseModel):
     topic: Literal["prices.crypto.chainlink.twap"] = "prices.crypto.chainlink.twap"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: CryptoPricesChainlinkTwapPayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 CryptoPricesEvent = CryptoPricesBinanceEvent | CryptoPricesChainlinkEvent
@@ -180,7 +225,7 @@ CryptoPricesEvent = CryptoPricesBinanceEvent | CryptoPricesChainlinkEvent
 
 class EquityPriceUpdatePayload(BaseModel):
     symbol: str
-    value: _DecimalFromNumberOrString
+    value: Decimal
     timestamp: int
     received_at: int | None = None
     is_carried_forward: bool | None = None
@@ -196,10 +241,20 @@ class EquityPriceUpdatePayload(BaseModel):
             data["value"] = full
         return data
 
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
+
 
 class EquityPriceSnapshotEntry(BaseModel):
     timestamp: int
-    value: _DecimalFromNumberOrString
+    value: Decimal
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_decimal(cls, value: object) -> object:
+        return _coerce_decimalish(value)
 
 
 class EquityPriceSubscribePayload(BaseModel):
@@ -210,15 +265,25 @@ class EquityPriceSubscribePayload(BaseModel):
 class EquityPricesUpdateEvent(BaseModel):
     topic: Literal["prices.equity.pyth"] = "prices.equity.pyth"
     type: Literal["update"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: EquityPriceUpdatePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class EquityPricesSubscribeEvent(BaseModel):
     topic: Literal["prices.equity.pyth"] = "prices.equity.pyth"
     type: Literal["subscribe"]
-    timestamp: EpochMsOrIsoTimestamp
+    timestamp: datetime | None
     payload: EquityPriceSubscribePayload
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _parse_timestamp(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 EquityPricesEvent = EquityPricesUpdateEvent | EquityPricesSubscribeEvent

--- a/src/polymarket/models/rtds_events.py
+++ b/src/polymarket/models/rtds_events.py
@@ -1,9 +1,9 @@
 import re
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
-from pydantic import Field, TypeAdapter, field_validator, model_validator
+from pydantic import BeforeValidator, Field, TypeAdapter, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
 from polymarket.models.clob._validators import (
@@ -41,7 +41,9 @@ _TWAP_WINDOW_BY_WIRE_TOPIC: dict[str, Literal[30, 60]] = {
 
 _CHAINLINK_PRICE_SCALE = 10**18
 _SIGNED_INTEGER_PATTERN = re.compile(r"-?[0-9]+")
-_DECIMALISH_ADAPTER = TypeAdapter(Decimal)
+_DECIMALISH_ADAPTER: TypeAdapter[Decimal] = TypeAdapter(
+    Annotated[Decimal, BeforeValidator(_coerce_decimalish)]
+)
 
 
 def wire_topic_to_api(wire: str) -> str | None:
@@ -198,7 +200,7 @@ class CryptoPricesChainlinkTwapPayload(BaseModel):
                 return data
             msg = "full_accuracy_value is required"
             raise ValueError(msg)
-        _DECIMALISH_ADAPTER.validate_python(_coerce_decimalish(data.get("value")))
+        _DECIMALISH_ADAPTER.validate_python(data.get("value"))
         data["value"] = _chainlink_e18_to_decimal(data.pop("full_accuracy_value"))
         return data
 

--- a/src/polymarket/models/sports_events.py
+++ b/src/polymarket/models/sports_events.py
@@ -1,9 +1,12 @@
+from datetime import datetime
 from typing import Any, Literal, cast
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from polymarket.models.base import BaseModel
-from polymarket.models.clob._validators import EpochMsOrIsoTimestamp
+from polymarket.models.clob._validators import (
+    _parse_epoch_ms_or_iso_timestamp,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 class SportsGameResult(BaseModel):
@@ -19,7 +22,7 @@ class SportsGameResult(BaseModel):
     score: str
     period: str | None = None
     elapsed: str | None = None
-    finished_at: EpochMsOrIsoTimestamp = Field(default=None, validation_alias="finishedTimestamp")
+    finished_at: datetime | None = Field(default=None, validation_alias="finishedTimestamp")
     turn: str | None = None
 
     @model_validator(mode="before")
@@ -37,6 +40,11 @@ class SportsGameResult(BaseModel):
         if camel in (None, "") and snake not in (None, ""):
             wire["finishedTimestamp"] = snake
         return wire
+
+    @field_validator("finished_at", mode="before")
+    @classmethod
+    def _parse_finished_at(cls, value: object) -> object:
+        return _parse_epoch_ms_or_iso_timestamp(value)
 
 
 class SportsResultEvent(BaseModel):

--- a/tests/unit/test_account_models.py
+++ b/tests/unit/test_account_models.py
@@ -1,5 +1,7 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_type_hints
 
 import pytest
 
@@ -10,6 +12,7 @@ from polymarket.models.clob.account import (
     MakerOrder,
     Notification,
     OpenOrder,
+    TradeStatus,
 )
 
 
@@ -74,6 +77,131 @@ def _clob_trade_payload(**overrides: object) -> dict[str, object]:
     }
     base.update(overrides)
     return base
+
+
+def test_account_model_annotations_are_canonical() -> None:
+    expected = {
+        OpenOrder: {
+            "price": Decimal,
+            "original_size": Decimal,
+            "size_matched": Decimal,
+            "created_at": datetime,
+            "expires_at": datetime | None,
+        },
+        MakerOrder: {
+            "price": Decimal,
+            "matched_amount": Decimal,
+            "fee_rate_bps": Decimal | None,
+        },
+        ClobTrade: {
+            "price": Decimal,
+            "size": Decimal,
+            "status": TradeStatus,
+            "fee_rate_bps": Decimal,
+            "matched_at": datetime,
+            "updated_at": datetime,
+        },
+        Notification: {"timestamp": datetime},
+    }
+
+    for model, fields in expected.items():
+        hints = get_type_hints(model, include_extras=True)
+        for field, annotation in fields.items():
+            assert hints[field] == annotation
+            assert model.model_fields[field].annotation == annotation
+
+
+def test_account_model_signatures_use_canonical_annotations() -> None:
+    expected = {
+        OpenOrder: {
+            "price": Decimal,
+            "original_size": Decimal,
+            "size_matched": Decimal,
+            "created_at": datetime,
+            "expiration": datetime | None,
+        },
+        MakerOrder: {
+            "price": Decimal,
+            "matched_amount": Decimal,
+            "fee_rate_bps": Decimal | None,
+        },
+        ClobTrade: {
+            "price": Decimal,
+            "size": Decimal,
+            "status": TradeStatus,
+            "fee_rate_bps": Decimal,
+            "match_time": datetime,
+            "last_update": datetime,
+        },
+        Notification: {"timestamp": datetime},
+    }
+
+    for model, fields in expected.items():
+        parameters = inspect.signature(model).parameters
+        for field, annotation in fields.items():
+            assert parameters[field].annotation == annotation
+
+
+@pytest.mark.parametrize("field", ["price", "original_size", "size_matched"])
+def test_open_order_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    order = OpenOrder.parse_response(_open_order_payload(**{field: Decimal("1.25")}))
+    assert getattr(order, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        OpenOrder.parse_response(_open_order_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize("field", ["price", "matched_amount", "fee_rate_bps"])
+def test_maker_order_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    maker = MakerOrder.parse_response(_maker_order_payload(**{field: Decimal("1.25")}))
+    assert getattr(maker, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        MakerOrder.parse_response(_maker_order_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize("field", ["price", "size", "fee_rate_bps"])
+def test_clob_trade_decimal_fields_require_strings_or_decimals(field: str) -> None:
+    trade = ClobTrade.parse_response(_clob_trade_payload(**{field: Decimal("1.25")}))
+    assert getattr(trade, field) == Decimal("1.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(**{field: 1}))
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["MATCHED", "MATCHED_NOT_BROADCASTED", "MINED", "CONFIRMED", "RETRYING", "FAILED"],
+)
+def test_clob_trade_normalizes_prefixed_statuses(status: TradeStatus) -> None:
+    trade = ClobTrade.parse_response(_clob_trade_payload(status=f"TRADE_STATUS_{status}"))
+    assert trade.status == status
+
+
+def test_clob_trade_rejects_unknown_status() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(status="TRADE_STATUS_UNKNOWN"))
+
+
+@pytest.mark.parametrize("created_at", [None, ""])
+def test_open_order_requires_created_at(created_at: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        OpenOrder.parse_response(_open_order_payload(created_at=created_at))
+
+
+@pytest.mark.parametrize("field", ["match_time", "last_update"])
+@pytest.mark.parametrize("value", [None, ""])
+def test_clob_trade_requires_timestamps(field: str, value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        ClobTrade.parse_response(_clob_trade_payload(**{field: value}))
+
+
+@pytest.mark.parametrize("timestamp", [None, ""])
+def test_notification_requires_timestamp(timestamp: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        Notification.parse_response(
+            {"id": 1, "owner": "0xOWNER", "type": 0, "payload": None, "timestamp": timestamp}
+        )
 
 
 def test_open_order_parses_epoch_ms_timestamps() -> None:

--- a/tests/unit/test_auth_actions.py
+++ b/tests/unit/test_auth_actions.py
@@ -1,3 +1,7 @@
+import inspect
+from datetime import UTC, datetime
+from typing import get_type_hints
+
 import pytest
 
 from polymarket._internal.actions.auth import (
@@ -10,6 +14,7 @@ from polymarket._internal.actions.auth import (
 from polymarket._internal.l1_auth import ApiKeyAuthSignature
 from polymarket.auth import BuilderApiKey
 from polymarket.errors import UnexpectedResponseError
+from polymarket.models.clob.api_key import BuilderApiKeyInfo
 
 
 def _sig() -> ApiKeyAuthSignature:
@@ -91,6 +96,31 @@ def test_parse_builder_api_keys_response_parses_records() -> None:
     assert keys[0].key == "k"
     assert keys[0].created_at is not None
     assert keys[0].revoked_at is None
+
+
+def test_builder_api_key_info_annotations_and_signature_expose_datetimes() -> None:
+    hints = get_type_hints(BuilderApiKeyInfo, include_extras=True)
+    assert hints["created_at"] == (datetime | None)
+    assert hints["revoked_at"] == (datetime | None)
+
+    parameters = inspect.signature(BuilderApiKeyInfo).parameters
+    assert parameters["createdAt"].annotation == (datetime | None)
+    assert parameters["revokedAt"].annotation == (datetime | None)
+
+
+def test_parse_builder_api_keys_response_preserves_timestamp_formats() -> None:
+    keys = parse_builder_api_keys_response(
+        [
+            {
+                "key": "k",
+                "createdAt": 1700000000000,
+                "revokedAt": "2023-11-14T22:13:25Z",
+            }
+        ]
+    )
+
+    assert keys[0].created_at == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+    assert keys[0].revoked_at == datetime(2023, 11, 14, 22, 13, 25, tzinfo=UTC)
 
 
 def test_parse_builder_api_keys_response_normalizes_bare_string_elements() -> None:

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -1,8 +1,9 @@
 # pyright: reportPrivateUsage=false
 import asyncio
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -49,6 +50,19 @@ _WIRE_TRADE: dict[str, Any] = {
 
 
 class TestBuilderTradeModel:
+    def test_annotations_and_signature_expose_canonical_types(self) -> None:
+        hints = get_type_hints(BuilderTrade, include_extras=True)
+        for field in ("size", "size_usdc", "price", "fee", "fee_usdc"):
+            assert hints[field] is Decimal
+        assert hints["matched_at"] is datetime
+        assert hints["created_at"] == (datetime | None)
+        assert hints["updated_at"] == (datetime | None)
+
+        parameters = inspect.signature(BuilderTrade).parameters
+        assert parameters["size"].annotation is Decimal
+        assert parameters["matchTime"].annotation is datetime
+        assert parameters["createdAt"].annotation == (datetime | None)
+
     def test_parses_required_fields_with_alias_mapping(self) -> None:
         trade = BuilderTrade.parse_response(_WIRE_TRADE)
         assert trade.id == "trade-1"
@@ -114,6 +128,12 @@ class TestBuilderTradeModel:
     def test_parses_match_time_from_epoch_seconds_int(self) -> None:
         trade = BuilderTrade.parse_response({**_WIRE_TRADE, "matchTime": 1777040544})
         assert trade.matched_at == datetime(2026, 4, 24, 14, 22, 24, tzinfo=UTC)
+
+    def test_parses_match_time_from_iso_string(self) -> None:
+        trade = BuilderTrade.parse_response(
+            {**_WIRE_TRADE, "matchTime": "2026-04-24T14:22:24.198666Z"}
+        )
+        assert trade.matched_at == datetime(2026, 4, 24, 14, 22, 24, 198666, tzinfo=UTC)
 
     def test_parses_created_and_updated_at_from_iso_strings(self) -> None:
         trade = BuilderTrade.parse_response(

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import MappingProxyType
 from typing import assert_type
 
 import pytest
@@ -143,6 +144,15 @@ def test_parse_midpoints_rejects_numeric_value() -> None:
         parse_midpoints({"1": 0.5})  # type: ignore[dict-item]
 
 
+def test_parse_midpoints_rejects_numeric_value_in_generic_mapping() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_midpoints(MappingProxyType({"1": 0.5}))
+
+
+def test_parse_midpoints_accepts_existing_decimal_value() -> None:
+    assert parse_midpoints({"1": Decimal("0.5")}) == {TokenId("1"): Decimal("0.5")}
+
+
 def test_parse_midpoint_rejects_numeric_mid_value() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_midpoint({"mid": 0.5})
@@ -233,6 +243,21 @@ def test_parse_prices_returns_nested_decimal_dict() -> None:
     assert result == {TokenId("1"): {"BUY": Decimal("0.52"), "SELL": Decimal("0.53")}}
 
 
+def test_parse_prices_rejects_numeric_value() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_prices({"1": {"BUY": 0.52}})  # type: ignore[dict-item]
+
+
+def test_parse_prices_rejects_numeric_value_in_nested_generic_mapping() -> None:
+    prices = MappingProxyType({"BUY": 0.52})
+    with pytest.raises(UnexpectedResponseError):
+        parse_prices(MappingProxyType({"1": prices}))
+
+
+def test_parse_prices_accepts_existing_decimal_value() -> None:
+    assert parse_prices({"1": {"BUY": Decimal("0.52")}}) == {TokenId("1"): {"BUY": Decimal("0.52")}}
+
+
 def test_parse_prices_rejects_invalid_side_key() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_prices({"1": {"HOLD": "0.5"}})
@@ -285,6 +310,12 @@ def test_parse_order_book_accepts_null_timestamp_and_null_last_trade_price() -> 
     assert book.last_trade_price is None
 
 
+def test_parse_order_book_accepts_empty_last_trade_price() -> None:
+    book = parse_order_book({**_ORDER_BOOK_PAYLOAD, "last_trade_price": ""})
+
+    assert book.last_trade_price is None
+
+
 def test_parse_order_book_accepts_missing_timestamp_and_last_trade_price() -> None:
     payload = {
         k: v for k, v in _ORDER_BOOK_PAYLOAD.items() if k not in ("timestamp", "last_trade_price")
@@ -305,6 +336,14 @@ def test_parse_order_book_rejects_malformed_timestamp() -> None:
 
 @pytest.mark.parametrize("bad_value", [" 1716000000000", "1716000000000 ", "+1", "-1"])
 def test_parse_order_book_rejects_loose_numeric_timestamp_strings(bad_value: str) -> None:
+    payload = {**_ORDER_BOOK_PAYLOAD, "timestamp": bad_value}
+
+    with pytest.raises(UnexpectedResponseError):
+        parse_order_book(payload)
+
+
+@pytest.mark.parametrize("bad_value", [1716000000000, 1716000000000.0, True])
+def test_parse_order_book_rejects_non_string_timestamp_values(bad_value: object) -> None:
     payload = {**_ORDER_BOOK_PAYLOAD, "timestamp": bad_value}
 
     with pytest.raises(UnexpectedResponseError):
@@ -412,6 +451,15 @@ def test_parse_spreads_returns_decimal_keyed_by_token_id() -> None:
     assert result == {TokenId("1"): Decimal("0.02")}
 
 
+def test_parse_spreads_rejects_numeric_value() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_spreads({"1": 0.02})  # type: ignore[dict-item]
+
+
+def test_parse_spreads_accepts_existing_decimal_value() -> None:
+    assert parse_spreads({"1": Decimal("0.02")}) == {TokenId("1"): Decimal("0.02")}
+
+
 def test_build_last_trade_price_request_targets_last_trade_price_path() -> None:
     path, params = build_last_trade_price_request(token_id="123")
 
@@ -424,6 +472,11 @@ def test_parse_last_trade_price_returns_model() -> None:
 
     assert result.price == Decimal("0.53")
     assert result.side == "BUY"
+
+
+def test_parse_last_trade_price_rejects_numeric_price() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        parse_last_trade_price({"price": 0.53, "side": "BUY"})
 
 
 def test_parse_last_trade_price_rejects_invalid_side() -> None:

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -3,6 +3,7 @@ from types import MappingProxyType
 from typing import assert_type
 
 import pytest
+from pydantic import ValidationError
 
 from polymarket._internal.actions.clob import (
     build_last_trade_price_request,
@@ -149,6 +150,19 @@ def test_parse_midpoints_rejects_numeric_value_in_generic_mapping() -> None:
         parse_midpoints(MappingProxyType({"1": 0.5}))
 
 
+def test_parse_midpoints_accepts_string_value_in_generic_mapping() -> None:
+    assert parse_midpoints(MappingProxyType({"1": "0.5"})) == {TokenId("1"): Decimal("0.5")}
+
+
+def test_parse_midpoints_preserves_element_validation_errors() -> None:
+    with pytest.raises(UnexpectedResponseError) as captured:
+        parse_midpoints({"1": 0.5, "2": True})
+
+    cause = captured.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert [error["loc"] for error in cause.errors()] == [("1",), ("2",)]
+
+
 def test_parse_midpoints_accepts_existing_decimal_value() -> None:
     assert parse_midpoints({"1": Decimal("0.5")}) == {TokenId("1"): Decimal("0.5")}
 
@@ -252,6 +266,18 @@ def test_parse_prices_rejects_numeric_value_in_nested_generic_mapping() -> None:
     prices = MappingProxyType({"BUY": 0.52})
     with pytest.raises(UnexpectedResponseError):
         parse_prices(MappingProxyType({"1": prices}))
+
+
+def test_parse_prices_preserves_nested_element_validation_errors() -> None:
+    with pytest.raises(UnexpectedResponseError) as captured:
+        parse_prices({"1": {"BUY": 0.52, "SELL": True}})
+
+    cause = captured.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert [error["loc"] for error in cause.errors()] == [
+        ("1", "BUY"),
+        ("1", "SELL"),
+    ]
 
 
 def test_parse_prices_accepts_existing_decimal_value() -> None:

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -199,20 +199,6 @@ def test_plan_tolerates_missing_position_summary() -> None:
     assert plan.position_summary.created == ()
 
 
-def test_plan_json_round_trips_scaled_amounts() -> None:
-    plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=_OTHER_WALLET))
-
-    python_dump = plan.model_dump()
-    json_dump = plan.model_dump(mode="json")
-    restored = CollateralReturnPlanResponse.model_validate_json(plan.model_dump_json())
-
-    assert python_dump["operations"][0]["amount"] == Decimal("1")
-    assert python_dump["required_positions"][0]["amount"] == Decimal("1")
-    assert json_dump["operations"][0]["amount"] == "1000000"
-    assert json_dump["required_positions"][0]["amount"] == "1000000"
-    assert restored == plan
-
-
 def test_execute_submits_router_call_for_deposit_wallet() -> None:
     submit_captured: list[httpx.Request] = []
 

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -1,9 +1,10 @@
 # pyright: reportPrivateUsage=false
 import asyncio
 import dataclasses
+import inspect
 import json
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 from urllib.parse import urlparse
 
 import httpx
@@ -26,6 +27,10 @@ from polymarket.errors import (
     RequestRejectedError,
     UnexpectedResponseError,
     UserInputError,
+)
+from polymarket.models.collateral_return import (
+    CollateralReturnOperation,
+    CollateralReturnPositionAmount,
 )
 
 _PLAN_HASH = "0x" + "ab" * 32
@@ -90,6 +95,24 @@ def test_plan_parses_wire_shape() -> None:
     assert merge.amount == Decimal("1")  # e6 base units scaled to collateral units
 
 
+def test_decimal_fields_expose_canonical_annotations() -> None:
+    affected_fields = (
+        (CollateralReturnOperation, ("amount",)),
+        (CollateralReturnPositionAmount, ("amount",)),
+        (
+            CollateralReturnPlanResponse,
+            ("starting_pusd", "net_pusd_out", "final_pusd", "required_pusd_input"),
+        ),
+    )
+
+    for model, fields in affected_fields:
+        hints = get_type_hints(model, include_extras=True)
+        parameters = inspect.signature(model).parameters
+        for field in fields:
+            assert hints[field] is Decimal
+            assert parameters[field].annotation is Decimal
+
+
 def test_plan_parses_unknown_kinds_as_plain_strings() -> None:
     plan = CollateralReturnPlanResponse.parse_response(
         _plan_payload(
@@ -107,14 +130,49 @@ def test_plan_parses_unknown_kinds_as_plain_strings() -> None:
     assert on_event.kind is CollateralReturnOperationKind.MERGE_ON_EVENT
 
 
-def test_plan_rejects_malformed_base_unit_amounts() -> None:
-    for amount in ("1.5", "-1000000"):
-        with pytest.raises(UnexpectedResponseError):
-            CollateralReturnPlanResponse.parse_response(
-                _plan_payload(
-                    wallet=_OTHER_WALLET, operations=[{"kind": "merge", "amount": amount}]
-                )
+@pytest.mark.parametrize(
+    ("wire_amount", "expected"),
+    [
+        ("0", Decimal("0.000000")),
+        ("1", Decimal("0.000001")),
+        ("1000001", Decimal("1.000001")),
+    ],
+)
+def test_plan_parses_base_unit_amount_edges(wire_amount: str, expected: Decimal) -> None:
+    plan = CollateralReturnPlanResponse.parse_response(
+        _plan_payload(
+            wallet=_OTHER_WALLET,
+            operations=[{"kind": "merge", "amount": wire_amount}],
+            required_positions=[{"position_id": "42", "amount": wire_amount}],
+        )
+    )
+
+    assert plan.operations[0].amount == expected
+    assert plan.required_positions[0].amount == expected
+
+
+@pytest.mark.parametrize("amount", ["1.5", "-1000000", "+1000000", "1e6", 1000000, True])
+def test_plan_rejects_malformed_base_unit_amounts(amount: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        CollateralReturnPlanResponse.parse_response(
+            _plan_payload(wallet=_OTHER_WALLET, operations=[{"kind": "merge", "amount": amount}])
+        )
+
+
+def test_plan_keeps_strict_decimal_strings_distinct_from_base_units() -> None:
+    plan = CollateralReturnPlanResponse.parse_response(
+        _plan_payload(wallet=_OTHER_WALLET, starting_pusd="-1.5")
+    )
+
+    assert plan.starting_pusd == Decimal("-1.5")
+
+    with pytest.raises(UnexpectedResponseError):
+        CollateralReturnPlanResponse.parse_response(
+            _plan_payload(
+                wallet=_OTHER_WALLET,
+                operations=[{"kind": "merge", "amount": "-1.5"}],
             )
+        )
 
 
 def test_plan_requires_service_fields() -> None:
@@ -144,8 +202,14 @@ def test_plan_tolerates_missing_position_summary() -> None:
 def test_plan_json_round_trips_scaled_amounts() -> None:
     plan = CollateralReturnPlanResponse.parse_response(_plan_payload(wallet=_OTHER_WALLET))
 
+    python_dump = plan.model_dump()
+    json_dump = plan.model_dump(mode="json")
     restored = CollateralReturnPlanResponse.model_validate_json(plan.model_dump_json())
 
+    assert python_dump["operations"][0]["amount"] == Decimal("1")
+    assert python_dump["required_positions"][0]["amount"] == Decimal("1")
+    assert json_dump["operations"][0]["amount"] == "1000000"
+    assert json_dump["required_positions"][0]["amount"] == "1000000"
     assert restored == plan
 
 

--- a/tests/unit/test_decimal_field_contract.py
+++ b/tests/unit/test_decimal_field_contract.py
@@ -1,10 +1,13 @@
+import inspect
+from datetime import datetime
 from decimal import Decimal
 from typing import get_type_hints
 
 import pytest
 
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.clob.order_book import OrderBookLevel
+from polymarket.models.clob.last_trade import LastTradePrice, LastTradePriceForToken
+from polymarket.models.clob.order_book import OrderBook, OrderBookLevel
 from polymarket.models.rtds_events import CryptoPricesChainlinkTwapPayload, PriceUpdatePayload
 
 
@@ -14,9 +17,28 @@ class TestStrictStringFieldsExposeBareDecimal:
         assert OrderBookLevel.model_fields["size"].annotation is Decimal
 
     def test_get_type_hints_resolves_to_bare_decimal(self) -> None:
-        hints = get_type_hints(OrderBookLevel)
+        hints = get_type_hints(OrderBookLevel, include_extras=True)
         assert hints["price"] is Decimal
         assert hints["size"] is Decimal
+
+    @pytest.mark.parametrize(
+        ("model", "field", "annotation"),
+        [
+            (OrderBookLevel, "price", Decimal),
+            (OrderBookLevel, "size", Decimal),
+            (OrderBook, "min_order_size", Decimal),
+            (OrderBook, "tick_size", Decimal),
+            (OrderBook, "last_trade_price", Decimal | None),
+            (OrderBook, "timestamp", datetime | None),
+            (LastTradePrice, "price", Decimal),
+            (LastTradePriceForToken, "price", Decimal),
+        ],
+    )
+    def test_market_read_annotations_are_canonical(
+        self, model: type[object], field: str, annotation: object
+    ) -> None:
+        assert get_type_hints(model, include_extras=True)[field] == annotation
+        assert inspect.signature(model).parameters[field].annotation == annotation
 
 
 class TestStrictStringValidatorAcceptsAndRejects:

--- a/tests/unit/test_order_post.py
+++ b/tests/unit/test_order_post.py
@@ -1,3 +1,7 @@
+import inspect
+from decimal import Decimal
+from typing import get_type_hints
+
 import pytest
 
 from polymarket._internal.actions.orders.post import (
@@ -8,7 +12,7 @@ from polymarket._internal.actions.orders.post import (
 )
 from polymarket._internal.actions.orders.types import BYTES32_ZERO
 from polymarket.errors import UnexpectedResponseError, UserInputError
-from polymarket.models.clob.order_response import AcceptedOrder, RejectedOrder
+from polymarket.models.clob.order_response import AcceptedOrder, RawOrderResponse, RejectedOrder
 from polymarket.models.clob.orders import SignedOrder
 from polymarket.models.types import TokenId
 from polymarket.types import EvmAddress, HexString
@@ -126,6 +130,31 @@ def test_parse_order_response_normalizes_empty_making_taking_for_live_orders() -
     assert isinstance(parsed, AcceptedOrder)
     assert parsed.making_amount == 0
     assert parsed.taking_amount == 0
+
+
+def test_raw_order_response_annotations_and_signature_expose_decimals() -> None:
+    hints = get_type_hints(RawOrderResponse, include_extras=True)
+    assert hints["making_amount"] is Decimal
+    assert hints["taking_amount"] is Decimal
+
+    parameters = inspect.signature(RawOrderResponse).parameters
+    assert parameters["makingAmount"].annotation is Decimal
+    assert parameters["takingAmount"].annotation is Decimal
+
+
+@pytest.mark.parametrize("amount", [1, 1.0])
+def test_parse_order_response_rejects_non_string_amounts(amount: object) -> None:
+    raw: dict[str, object] = {
+        "errorMsg": "",
+        "makingAmount": amount,
+        "orderID": "ord-1",
+        "status": "live",
+        "success": True,
+        "takingAmount": "1",
+    }
+
+    with pytest.raises(UnexpectedResponseError):
+        parse_order_response(raw)
 
 
 def test_parse_order_response_recognizes_accepted_payload() -> None:

--- a/tests/unit/test_perps_account_models.py
+++ b/tests/unit/test_perps_account_models.py
@@ -1,0 +1,242 @@
+"""Perps account and funds model validation contracts."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+
+from polymarket.errors import UnexpectedResponseError
+from polymarket.models.perps.account import (
+    PerpsAccountStats,
+    PerpsBalance,
+    PerpsEquityPoint,
+    PerpsFundingPayment,
+    PerpsMarginSummary,
+    PerpsPnlPoint,
+    PerpsPortfolio,
+    PerpsPosition,
+    PerpsProxyKey,
+)
+from polymarket.models.perps.funds import (
+    PerpsDeposit,
+    PerpsDepositUpdate,
+    PerpsWithdrawal,
+    PerpsWithdrawalUpdate,
+)
+
+_EPOCH_MS = 1_747_660_800_123
+_TIMESTAMP = datetime(2025, 5, 19, 13, 20, 0, 123000, tzinfo=UTC)
+
+
+def test_account_and_funds_annotations_expose_canonical_types_with_extras() -> None:
+    expected_fields = {
+        PerpsBalance: {"balance": Decimal, "value": Decimal},
+        PerpsAccountStats: {
+            "volume_7d": Decimal,
+            "taker_volume_7d": Decimal,
+            "maker_volume_7d": Decimal,
+            "account_maker_share_7d": Decimal,
+            "entity_maker_share_7d": Decimal | None,
+        },
+        PerpsPosition: {
+            "size": Decimal,
+            "entry_price": Decimal,
+            "initial_margin": Decimal,
+            "maintenance_margin": Decimal,
+            "position_value": Decimal,
+            "liquidation_price": Decimal,
+            "unrealized_pnl": Decimal,
+            "return_on_equity": Decimal,
+            "cumulative_funding": Decimal,
+        },
+        PerpsMarginSummary: {
+            "total_account_value": Decimal,
+            "total_initial_margin": Decimal,
+            "total_maintenance_margin": Decimal,
+            "total_position_value": Decimal,
+        },
+        PerpsPortfolio: {"withdrawable": Decimal, "timestamp": datetime},
+        PerpsFundingPayment: {
+            "size": Decimal,
+            "funding_rate": Decimal,
+            "funding": Decimal,
+            "timestamp": datetime,
+        },
+        PerpsEquityPoint: {"timestamp": datetime, "equity": Decimal},
+        PerpsPnlPoint: {"timestamp": datetime, "pnl": Decimal},
+        PerpsProxyKey: {"expires_at": datetime},
+        PerpsDeposit: {
+            "amount": Decimal,
+            "created_at": datetime,
+            "confirmed_at": datetime | None,
+        },
+        PerpsDepositUpdate: {"hash": str | None, "amount": Decimal},
+        PerpsWithdrawal: {
+            "amount": Decimal,
+            "fee": Decimal,
+            "hash": str | None,
+            "created_at": datetime,
+            "confirmed_at": datetime | None,
+        },
+        PerpsWithdrawalUpdate: {
+            "amount": Decimal,
+            "fee": Decimal,
+            "hash": str | None,
+        },
+    }
+
+    for model, expected in expected_fields.items():
+        hints = get_type_hints(model, include_extras=True)
+        assert {field: hints[field] for field in expected} == expected
+
+
+def test_model_signatures_expose_canonical_types_and_wire_aliases() -> None:
+    balance = inspect.signature(PerpsBalance).parameters
+    assert balance["balance"].annotation is Decimal
+
+    funding = inspect.signature(PerpsFundingPayment).parameters
+    assert funding["funding"].annotation is Decimal
+    assert funding["timestamp"].annotation is datetime
+
+    proxy = inspect.signature(PerpsProxyKey).parameters
+    assert "expiry" in proxy
+    assert proxy["expiry"].annotation is datetime
+
+    deposit = inspect.signature(PerpsDeposit).parameters
+    assert deposit["amount"].annotation is Decimal
+    assert deposit["created_timestamp"].annotation is datetime
+    assert deposit["confirmed_timestamp"].annotation == (datetime | None)
+
+    withdrawal = inspect.signature(PerpsWithdrawal).parameters
+    assert "withdraw_id" in withdrawal
+    assert withdrawal["hash"].annotation == (str | None)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1.25", Decimal("1.25")),
+        (2, Decimal("2")),
+        (1.5, Decimal("1.5")),
+        (Decimal("3.75"), Decimal("3.75")),
+    ],
+)
+def test_decimal_fields_preserve_perps_number_or_string_grammar(
+    raw: object, expected: Decimal
+) -> None:
+    balance = PerpsBalance.parse_response({"asset": "USDC", "balance": raw, "value": raw})
+    assert balance.balance == expected
+    assert balance.value == expected
+
+
+def test_decimal_fields_reject_booleans() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsBalance.parse_response({"asset": "USDC", "balance": True, "value": "1"})
+
+
+def test_tuple_points_preprocess_before_field_validation() -> None:
+    equity = PerpsEquityPoint.parse_response([_EPOCH_MS, "10.5"])
+    pnl = PerpsPnlPoint.parse_response((_EPOCH_MS, -2.25))
+
+    assert equity.timestamp == _TIMESTAMP
+    assert equity.equity == Decimal("10.5")
+    assert pnl.timestamp == _TIMESTAMP
+    assert pnl.pnl == Decimal("-2.25")
+
+    with pytest.raises(UnexpectedResponseError):
+        PerpsEquityPoint.parse_response([_EPOCH_MS, "10.5", "extra"])
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_required_timestamps_preserve_strict_integer_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsEquityPoint.parse_response([raw, "1"])
+
+
+def test_required_timestamps_pass_datetime_instances_through() -> None:
+    point = PerpsEquityPoint.parse_response([_TIMESTAMP, "1"])
+    assert point.timestamp is _TIMESTAMP
+
+
+def test_funding_payment_preserves_compact_aliases() -> None:
+    payment = PerpsFundingPayment.parse_response(
+        {"iid": 7, "sz": "2", "fr": "0.001", "fua": "USDC", "fund": "0.25", "ts": _EPOCH_MS}
+    )
+
+    assert payment.instrument_id == 7
+    assert payment.size == Decimal("2")
+    assert payment.funding_rate == Decimal("0.001")
+    assert payment.funding_asset == "USDC"
+    assert payment.funding == Decimal("0.25")
+    assert payment.timestamp == _TIMESTAMP
+
+
+def _deposit_payload(**overrides: object) -> dict[str, object]:
+    return {
+        "hash": "0xabc",
+        "asset": "USDC",
+        "amount": "100.5",
+        "status": "pending",
+        "from": "0xfrom",
+        "to": "0xto",
+        "confirmations": 0,
+        "required_confirmations": 3,
+        "created_timestamp": _EPOCH_MS,
+        **overrides,
+    }
+
+
+def test_funds_timestamps_preserve_optional_and_datetime_behavior() -> None:
+    omitted = PerpsDeposit.parse_response(_deposit_payload())
+    explicit_none = PerpsDeposit.parse_response(_deposit_payload(confirmed_timestamp=None))
+    datetimes = PerpsDeposit.parse_response(
+        _deposit_payload(created_timestamp=_TIMESTAMP, confirmed_timestamp=_TIMESTAMP)
+    )
+
+    assert omitted.created_at == _TIMESTAMP
+    assert omitted.confirmed_at is None
+    assert explicit_none.confirmed_at is None
+    assert datetimes.created_at is _TIMESTAMP
+    assert datetimes.confirmed_at is _TIMESTAMP
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_funds_created_timestamp_preserves_strict_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsDeposit.parse_response(_deposit_payload(created_timestamp=raw))
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_optional_transaction_hash_placeholders_normalize_to_none(placeholder: str) -> None:
+    deposit = PerpsDepositUpdate.parse_response(
+        {"hash": placeholder, "asset": "USDC", "amount": "1", "status": "pending"}
+    )
+    withdrawal = PerpsWithdrawalUpdate.parse_response(
+        {
+            "withdraw_id": 1,
+            "asset": "USDC",
+            "amount": "1",
+            "fee": "0.1",
+            "status": "pending",
+            "to": "0xto",
+            "hash": placeholder,
+        }
+    )
+
+    assert deposit.hash is None
+    assert withdrawal.hash is None
+
+
+def test_proxy_expiry_normalizes_nanoseconds_before_epoch_ms_parsing() -> None:
+    proxy = PerpsProxyKey.parse_response(
+        {"proxy": "0xproxy", "label": "bot", "expiry": _EPOCH_MS * 1_000_000}
+    )
+    assert proxy.expires_at == _TIMESTAMP
+
+
+@pytest.mark.parametrize("raw", [str(_EPOCH_MS), float(_EPOCH_MS), True, None])
+def test_proxy_expiry_preserves_strict_epoch_ms_grammar(raw: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsProxyKey.parse_response({"proxy": "0xproxy", "expiry": raw})

--- a/tests/unit/test_perps_events.py
+++ b/tests/unit/test_perps_events.py
@@ -1,19 +1,27 @@
 """Perps realtime event parsing tests."""
 
+import inspect
+from collections import UserDict
+from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_args, get_type_hints
 
 import pytest
 from pydantic import ValidationError
+from pydantic.fields import FieldInfo
 
 from polymarket.models.perps.events import (
     PerpsBookEvent,
     PerpsCandleEvent,
     PerpsDepositEvent,
+    PerpsMarketEvent,
     PerpsNotificationEvent,
     PerpsOrderEvent,
     PerpsResyncEvent,
     PerpsTickerEvent,
     PerpsTpSlEvent,
+    PerpsTradeEvent,
+    _SessionUpdateEvent,  # pyright: ignore[reportPrivateUsage]
     parse_perps_market_event,
     parse_perps_market_events,
     parse_perps_session_event,
@@ -21,6 +29,9 @@ from polymarket.models.perps.events import (
 from polymarket.models.perps.notifications import (
     PerpsCrossLiquidationWarningNotification,
     PerpsIsolatedLiquidationWarningNotification,
+    PerpsLiquidationWarningNotification,
+    PerpsNotification,
+    PerpsNotificationEntry,
     PerpsPositionChangeNotification,
     PerpsPositionClosedNotification,
     PerpsPositionLiquidatedNotification,
@@ -191,20 +202,23 @@ def _notification_frame(notification: dict[str, object]) -> dict[str, object]:
     return {"ch": "notifications", "ts": 1751500000000, "sq": 42, "data": notification}
 
 
+def _position_change_notification(**overrides: object) -> dict[str, object]:
+    notification: dict[str, object] = {
+        "id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0",
+        "type": "position_increased",
+        "instrument_id": 3,
+        "side": "short",
+        "size": "1.5",
+        "avg_price": "99.5",
+        "leverage": 4,
+    }
+    notification.update(overrides)
+    return notification
+
+
 def test_session_notification_event_parses_position_change() -> None:
     event = parse_perps_session_event(
-        _notification_frame(
-            {
-                "id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0",
-                "type": "position_increased",
-                "instrument_id": 3,
-                "side": "short",
-                "size": "1.5",
-                "avg_price": "99.5",
-                "leverage": 4,
-                "order_type": "stop_loss",
-            }
-        )
+        _notification_frame(_position_change_notification(order_type="stop_loss"))
     )
     assert isinstance(event, PerpsNotificationEvent)
     assert event.sequence == 42
@@ -296,6 +310,159 @@ def test_session_notification_with_unknown_type_fails_validation() -> None:
                 {"id": "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0", "type": "new_notification_kind"}
             )
         )
+
+
+@pytest.mark.parametrize("value", [True, [], object()])
+def test_notification_decimal_fields_keep_exact_perps_validation(value: object) -> None:
+    with pytest.raises(ValidationError, match="expected decimal-ish value"):
+        parse_perps_session_event(_notification_frame(_position_change_notification(size=value)))
+
+
+def test_notification_decimal_fields_accept_numbers_via_exact_string_conversion() -> None:
+    event = parse_perps_session_event(
+        _notification_frame(_position_change_notification(size=2, avg_price=99.25))
+    )
+    assert isinstance(event, PerpsNotificationEvent)
+    assert isinstance(event.payload, PerpsPositionChangeNotification)
+    assert event.payload.size == Decimal("2")
+    assert event.payload.avg_price == Decimal("99.25")
+
+
+@pytest.mark.parametrize("timestamp", [None, True, 1751500000000.0, "1751500000000"])
+def test_required_event_timestamp_keeps_exact_epoch_ms_validation(timestamp: object) -> None:
+    frame = _notification_frame(_position_change_notification())
+    frame["ts"] = timestamp
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        parse_perps_session_event(frame)
+
+
+def test_required_event_timestamp_rejects_invalid_value_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEvent.model_validate(
+            UserDict(
+                {
+                    "type": "notification",
+                    "channel": "notifications",
+                    "timestamp": "1751500000000",
+                    "sequence": 42,
+                    "payload": _position_change_notification(),
+                }
+            )
+        )
+
+
+def test_resync_optional_timestamp_preserves_missing_none_and_epoch_ms_semantics() -> None:
+    missing = PerpsResyncEvent.model_validate({"reason": "reconnect"})
+    explicit_none = PerpsResyncEvent.model_validate({"reason": "reconnect", "timestamp": None})
+    epoch = PerpsResyncEvent.model_validate({"reason": "sequence_gap", "timestamp": 1751500000000})
+
+    assert missing.timestamp is None
+    assert explicit_none.timestamp is None
+    assert epoch.timestamp == datetime.fromtimestamp(1751500000, tz=UTC)
+
+
+@pytest.mark.parametrize("timestamp", [True, 1751500000000.0, "1751500000000"])
+def test_resync_optional_timestamp_rejects_non_epoch_ms_values(timestamp: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsResyncEvent.model_validate({"reason": "reconnect", "timestamp": timestamp})
+
+
+def test_resync_timestamp_rejects_invalid_value_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsResyncEvent.model_validate(
+            UserDict({"reason": "reconnect", "timestamp": "1751500000000"})
+        )
+
+
+def test_notification_entry_timestamp_aliases_keep_optional_read_semantics() -> None:
+    entry = PerpsNotificationEntry.model_validate(
+        {
+            "notification": _position_change_notification(),
+            "read_at": None,
+            "ts": 1751500000000,
+        }
+    )
+    named = PerpsNotificationEntry.model_validate(
+        {
+            "notification": _position_change_notification(),
+            "timestamp": 1751500000000,
+        }
+    )
+
+    assert entry.read_at is None
+    assert entry.timestamp == datetime.fromtimestamp(1751500000, tz=UTC)
+    assert named.timestamp == entry.timestamp
+
+
+@pytest.mark.parametrize("field", ["read_at", "ts"])
+def test_notification_entry_timestamp_aliases_reject_bool(field: str) -> None:
+    data: dict[str, object] = {
+        "notification": _position_change_notification(),
+        "ts": 1751500000000,
+    }
+    data[field] = True
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEntry.model_validate(data)
+
+
+def test_notification_entry_rejects_invalid_timestamp_in_generic_mapping() -> None:
+    with pytest.raises(ValidationError, match="epoch-ms timestamp"):
+        PerpsNotificationEntry.model_validate(
+            UserDict(
+                {
+                    "notification": _position_change_notification(),
+                    "ts": "1751500000000",
+                }
+            )
+        )
+
+
+def test_perps_notification_and_event_annotations_expose_canonical_types() -> None:
+    position_hints = get_type_hints(PerpsPositionChangeNotification, include_extras=True)
+    liquidated_hints = get_type_hints(PerpsPositionLiquidatedNotification, include_extras=True)
+    entry_hints = get_type_hints(PerpsNotificationEntry, include_extras=True)
+    trade_hints = get_type_hints(PerpsTradeEvent, include_extras=True)
+    resync_hints = get_type_hints(PerpsResyncEvent, include_extras=True)
+
+    assert position_hints["size"] is Decimal
+    assert position_hints["avg_price"] is Decimal
+    assert liquidated_hints["pnl"] == Decimal | None
+    assert entry_hints["read_at"] == datetime | None
+    assert entry_hints["timestamp"] is datetime
+    assert trade_hints["timestamp"] is datetime
+    assert resync_hints["timestamp"] == datetime | None
+
+
+def test_discriminated_union_metadata_survives_annotation_migration() -> None:
+    aliases = (
+        (PerpsLiquidationWarningNotification, "margin_type"),
+        (PerpsNotification, "type"),
+        (PerpsMarketEvent, "type"),
+        (_SessionUpdateEvent, "type"),
+    )
+    for annotation, discriminator in aliases:
+        metadata = get_args(annotation)[1:]
+        assert any(
+            isinstance(item, FieldInfo) and item.discriminator == discriminator for item in metadata
+        )
+
+    notification_hints = get_type_hints(PerpsNotificationEvent, include_extras=True)
+    assert notification_hints["payload"] == PerpsNotification
+
+
+def test_model_signatures_expose_canonical_types_and_timestamp_alias() -> None:
+    notification_params = inspect.signature(PerpsPositionChangeNotification).parameters
+    entry_params = inspect.signature(PerpsNotificationEntry).parameters
+    trade_params = inspect.signature(PerpsTradeEvent).parameters
+    resync_params = inspect.signature(PerpsResyncEvent).parameters
+
+    assert notification_params["size"].annotation is Decimal
+    assert notification_params["avg_price"].annotation is Decimal
+    assert entry_params["read_at"].annotation == datetime | None
+    assert entry_params["ts"].annotation is datetime
+    assert "timestamp" not in entry_params
+    assert trade_params["timestamp"].annotation is datetime
+    assert resync_params["timestamp"].annotation == datetime | None
 
 
 def test_notifications_resync_frame_parses_as_server_resync_event() -> None:

--- a/tests/unit/test_perps_market_models.py
+++ b/tests/unit/test_perps_market_models.py
@@ -1,0 +1,247 @@
+"""Perps public market model validation contracts."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+from pydantic import ValidationError
+
+from polymarket.models.perps.market import (
+    PerpsBbo,
+    PerpsBook,
+    PerpsBookLevel,
+    PerpsCandle,
+    PerpsFeeScheduleEntry,
+    PerpsFeeTier,
+    PerpsFundingRate,
+    PerpsInstrument,
+    PerpsRiskTier,
+    PerpsStatistic,
+    PerpsTicker,
+    PerpsTickerUpdate,
+    PerpsTrade,
+)
+
+_EPOCH_MS = 1_751_500_000_000
+_TIMESTAMP = datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("model", "fields"),
+    [
+        (PerpsRiskTier, {"lower_bound": Decimal}),
+        (
+            PerpsInstrument,
+            {
+                "price_bounds": Decimal,
+                "liquidation_fee": Decimal,
+                "min_notional": Decimal,
+                "max_market_notional": Decimal,
+                "max_limit_notional": Decimal,
+            },
+        ),
+        (
+            PerpsTicker,
+            {
+                "index_price": Decimal,
+                "mark_price": Decimal,
+                "last_price": Decimal,
+                "mid_price": Decimal,
+                "open_interest": Decimal,
+                "funding_rate": Decimal,
+                "next_funding": datetime,
+                "timestamp": datetime | None,
+                "open_price": Decimal | None,
+                "volume_24h": Decimal | None,
+            },
+        ),
+        (
+            PerpsTickerUpdate,
+            {
+                "index_price": Decimal,
+                "mark_price": Decimal,
+                "last_price": Decimal,
+                "mid_price": Decimal,
+                "open_interest": Decimal,
+                "funding_rate": Decimal,
+                "next_funding": datetime,
+            },
+        ),
+        (
+            PerpsCandle,
+            {
+                "timestamp": datetime,
+                "open": Decimal,
+                "high": Decimal,
+                "low": Decimal,
+                "close": Decimal,
+                "volume": Decimal,
+            },
+        ),
+        (PerpsStatistic, {"volume": Decimal, "open_price": Decimal}),
+        (PerpsBookLevel, {"price": Decimal, "quantity": Decimal}),
+        (PerpsBook, {"timestamp": datetime}),
+        (
+            PerpsBbo,
+            {
+                "bid_price": Decimal,
+                "bid_quantity": Decimal,
+                "ask_price": Decimal,
+                "ask_quantity": Decimal,
+                "timestamp": datetime | None,
+            },
+        ),
+        (
+            PerpsTrade,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "timestamp": datetime,
+                "hash": str | None,
+            },
+        ),
+        (PerpsFundingRate, {"funding_rate": Decimal, "timestamp": datetime}),
+        (
+            PerpsFeeTier,
+            {
+                "min_volume_30d": Decimal,
+                "taker_fee_rate": Decimal,
+                "maker_fee_rate": Decimal,
+            },
+        ),
+        (
+            PerpsFeeScheduleEntry,
+            {"taker_fee_rate": Decimal, "maker_fee_rate": Decimal},
+        ),
+    ],
+)
+def test_public_annotations_are_canonical(model: type[object], fields: dict[str, object]) -> None:
+    hints = get_type_hints(model, include_extras=True)
+    for field, expected in fields.items():
+        assert hints[field] == expected
+
+
+def test_generated_signatures_use_canonical_types_and_compact_aliases() -> None:
+    ticker_parameters = inspect.signature(PerpsTickerUpdate).parameters
+    assert ticker_parameters["idx"].annotation is Decimal
+    assert ticker_parameters["nxf"].annotation is datetime
+
+    trade_parameters = inspect.signature(PerpsTrade).parameters
+    assert trade_parameters["price"].annotation is Decimal
+    assert trade_parameters["timestamp"].annotation is datetime
+    assert trade_parameters["hash"].annotation == (str | None)
+
+
+def test_compact_market_payload_preserves_decimal_and_timestamp_parsing() -> None:
+    ticker = PerpsTickerUpdate.model_validate(
+        {
+            "iid": 4,
+            "idx": 100,
+            "mark": 100.1,
+            "last": Decimal("100.2"),
+            "mid": "100.15",
+            "oi": "5000",
+            "fr": "0.0001",
+            "nxf": _EPOCH_MS,
+        }
+    )
+
+    assert ticker.index_price == Decimal("100")
+    assert ticker.mark_price == Decimal("100.1")
+    assert ticker.last_price == Decimal("100.2")
+    assert ticker.next_funding == _TIMESTAMP
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_decimal_fields_reject_bool(value: bool) -> None:
+    with pytest.raises(ValidationError, match="decimal-ish"):
+        PerpsBookLevel.model_validate([value, "1"])
+
+
+@pytest.mark.parametrize("value", [1.5, "1751500000000", True, None])
+def test_required_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms"):
+        PerpsFundingRate.model_validate({"funding_rate": "0.001", "timestamp": value})
+
+
+def test_tuple_preprocessing_and_optional_values_are_preserved() -> None:
+    candle = PerpsCandle.model_validate((_EPOCH_MS, 1, 2.5, "0.5", Decimal("1.5"), 10, 3))
+    bbo = PerpsBbo.model_validate(
+        {"iid": 7, "bp": "1", "bq": "2", "ap": "3", "aq": "4", "timestamp": None}
+    )
+
+    assert candle.timestamp == _TIMESTAMP
+    assert candle.open == Decimal("1")
+    assert candle.high == Decimal("2.5")
+    assert candle.volume == Decimal("10")
+    assert bbo.timestamp is None
+
+
+def test_optional_decimal_fields_accept_none_and_missing_values() -> None:
+    ticker = PerpsTicker.model_validate(
+        {
+            "instrument_id": 7,
+            "symbol": "XYZ-PERP",
+            "index_price": "100",
+            "mark_price": "101",
+            "last_price": "100.5",
+            "mid_price": "100.6",
+            "open_interest": "5000",
+            "funding_rate": "0.0001",
+            "next_funding": _EPOCH_MS,
+            "open_price": None,
+        }
+    )
+
+    assert ticker.open_price is None
+    assert ticker.volume_24h is None
+    assert ticker.timestamp is None
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_trade_normalizes_placeholder_transaction_hash(placeholder: str) -> None:
+    trade = PerpsTrade.model_validate(
+        {
+            "tid": 1,
+            "iid": 7,
+            "side": "long",
+            "p": "100",
+            "qty": "2",
+            "ts": _EPOCH_MS,
+            "hash": placeholder,
+        }
+    )
+
+    assert trade.hash is None
+
+
+def test_optional_timestamp_accepts_datetime_without_rewriting_it() -> None:
+    bbo = PerpsBbo.model_validate(
+        {
+            "instrument_id": 7,
+            "bid_price": "1",
+            "bid_quantity": "2",
+            "ask_price": "3",
+            "ask_quantity": "4",
+            "timestamp": _TIMESTAMP,
+        }
+    )
+
+    assert bbo.timestamp is _TIMESTAMP
+
+
+@pytest.mark.parametrize("value", [1.5, "1751500000000", True])
+def test_optional_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
+    with pytest.raises(ValidationError, match="epoch-ms"):
+        PerpsBbo.model_validate(
+            {
+                "iid": 7,
+                "bp": "1",
+                "bq": "2",
+                "ap": "3",
+                "aq": "4",
+                "timestamp": value,
+            }
+        )

--- a/tests/unit/test_perps_market_models.py
+++ b/tests/unit/test_perps_market_models.py
@@ -160,6 +160,46 @@ def test_decimal_fields_reject_bool(value: bool) -> None:
         PerpsBookLevel.model_validate([value, "1"])
 
 
+def test_market_fields_preserve_multiple_validation_errors() -> None:
+    with pytest.raises(ValidationError) as captured:
+        PerpsTickerUpdate.model_validate(
+            {
+                "iid": 4,
+                "idx": True,
+                "mark": [],
+                "last": "100.2",
+                "mid": "100.15",
+                "oi": "5000",
+                "fr": "0.0001",
+                "nxf": "1751500000000",
+            }
+        )
+
+    assert [error["loc"] for error in captured.value.errors()] == [
+        ("idx",),
+        ("mark",),
+        ("nxf",),
+    ]
+
+
+def test_tuple_models_preserve_nested_field_error_locations() -> None:
+    with pytest.raises(ValidationError) as captured:
+        PerpsBook.model_validate(
+            {
+                "instrument_id": 4,
+                "bids": [[True, []]],
+                "asks": [],
+                "timestamp": _EPOCH_MS,
+                "sequence": 1,
+            }
+        )
+
+    assert [error["loc"] for error in captured.value.errors()] == [
+        ("bids", 0, "price"),
+        ("bids", 0, "quantity"),
+    ]
+
+
 @pytest.mark.parametrize("value", [1.5, "1751500000000", True, None])
 def test_required_timestamp_preserves_strict_epoch_ms_input(value: object) -> None:
     with pytest.raises(ValidationError, match="epoch-ms"):

--- a/tests/unit/test_perps_order_models.py
+++ b/tests/unit/test_perps_order_models.py
@@ -1,0 +1,237 @@
+"""Perps order and fill model validation tests."""
+
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import get_type_hints
+
+import pytest
+
+from polymarket.errors import UnexpectedResponseError
+from polymarket.models.perps.orders import PerpsFill, PerpsOrder, PerpsTpSlOrderFields
+
+
+def _compact_order(**overrides: object) -> dict[str, object]:
+    return {
+        "oid": 5,
+        "iid": 1,
+        "buy": True,
+        "p": "0.5",
+        "qty": "10",
+        "tif": "gtc",
+        "po": False,
+        "ro": True,
+        "status": "open",
+        "rest": "10",
+        "fill": "0",
+        "cts": 1751500000000,
+        "uts": 1751500000001,
+        **overrides,
+    }
+
+
+def _expanded_order(**overrides: object) -> dict[str, object]:
+    return {
+        "order_id": 5,
+        "instrument_id": 1,
+        "buy": False,
+        "price": "0.5",
+        "quantity": "10",
+        "tif": "gtc",
+        "post_only": False,
+        "ro": True,
+        "status": "open",
+        "resting_quantity": "10",
+        "filled_quantity": "0",
+        "created_timestamp": 1751500000000,
+        "updated_timestamp": 1751500000001,
+        **overrides,
+    }
+
+
+def _compact_fill(**overrides: object) -> dict[str, object]:
+    return {
+        "tid": 9,
+        "oid": 5,
+        "iid": 1,
+        "side": "long",
+        "p": "100.5",
+        "qty": "2",
+        "taker": True,
+        "fee": "0.01",
+        "fea": "USDC",
+        "psz": "0",
+        "pep": "0",
+        "pnl": "1.25",
+        "liq": False,
+        "ts": 1751500000000,
+        **overrides,
+    }
+
+
+def _expanded_fill(**overrides: object) -> dict[str, object]:
+    return {
+        "trade_id": 9,
+        "order_id": 5,
+        "instrument_id": 1,
+        "side": "short",
+        "price": "100.5",
+        "quantity": "2",
+        "taker": False,
+        "fee": "0.01",
+        "fee_asset": "USDC",
+        "previous_size": "3",
+        "previous_entry_price": "99",
+        "pnl": "-1.25",
+        "liquidation": False,
+        "timestamp": 1751500000000,
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize(
+    ("model", "expected", "signature_names"),
+    [
+        (
+            PerpsTpSlOrderFields,
+            {"trigger_price": Decimal, "armed_quantity": Decimal | None},
+            {"trigger_price": "trp", "armed_quantity": "armed_qty"},
+        ),
+        (
+            PerpsOrder,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "resting_quantity": Decimal,
+                "filled_quantity": Decimal,
+                "created_at": datetime,
+                "updated_at": datetime,
+            },
+            {},
+        ),
+        (
+            PerpsFill,
+            {
+                "price": Decimal,
+                "quantity": Decimal,
+                "fee": Decimal,
+                "previous_size": Decimal,
+                "previous_entry_price": Decimal,
+                "pnl": Decimal,
+                "timestamp": datetime,
+                "hash": str | None,
+            },
+            {},
+        ),
+    ],
+)
+def test_annotations_and_signatures_expose_canonical_types(
+    model: type[PerpsTpSlOrderFields] | type[PerpsOrder] | type[PerpsFill],
+    expected: dict[str, object],
+    signature_names: dict[str, str],
+) -> None:
+    hints = get_type_hints(model, include_extras=True)
+    parameters = inspect.signature(model).parameters
+
+    for field, annotation in expected.items():
+        assert hints[field] == annotation
+        assert model.model_fields[field].annotation == annotation
+        assert parameters[signature_names.get(field, field)].annotation == annotation
+
+
+def test_order_preserves_compact_and_expanded_aliases_and_buy_normalization() -> None:
+    compact = PerpsOrder.parse_response(_compact_order())
+    expanded = PerpsOrder.parse_response(_expanded_order())
+
+    assert compact.side == "BUY"
+    assert expanded.side == "SELL"
+    assert compact.price == expanded.price == Decimal("0.5")
+    assert compact.created_at == expanded.created_at == datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+def test_order_parses_nested_tpsl_decimals() -> None:
+    order = PerpsOrder.parse_response(
+        _compact_order(
+            tpsl={
+                "kind": "tp",
+                "scope": "position",
+                "trp": 105,
+                "armed_qty": 1.5,
+            }
+        )
+    )
+
+    assert order.tp_sl is not None
+    assert order.tp_sl.trigger_price == Decimal("105")
+    assert order.tp_sl.armed_quantity == Decimal("1.5")
+
+
+@pytest.mark.parametrize("field", ["trp", "armed_qty"])
+def test_tpsl_decimal_fields_reject_bool(field: str) -> None:
+    payload: dict[str, object] = {
+        "kind": "tp",
+        "scope": "position",
+        "trp": "105",
+        "armed_qty": "1.5",
+    }
+    payload[field] = True
+
+    with pytest.raises(UnexpectedResponseError):
+        PerpsTpSlOrderFields.parse_response(payload)
+
+
+@pytest.mark.parametrize("field", ["p", "qty", "rest", "fill"])
+def test_order_decimal_fields_reject_bool(field: str) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(**{field: True}))
+
+
+@pytest.mark.parametrize("field", ["cts", "uts"])
+@pytest.mark.parametrize("value", [True, 1751500000000.0, "1751500000000", None])
+def test_order_timestamps_remain_strict_epoch_milliseconds(field: str, value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(**{field: value}))
+
+
+def test_order_rejects_pre_normalized_side_in_buy_field() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsOrder.parse_response(_compact_order(buy="BUY"))
+
+
+def test_order_timestamps_accept_datetime_instances() -> None:
+    timestamp = datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+    order = PerpsOrder.parse_response(_compact_order(cts=timestamp, uts=timestamp))
+
+    assert order.created_at is timestamp
+    assert order.updated_at is timestamp
+
+
+def test_fill_preserves_compact_and_expanded_aliases_and_numeric_conversion() -> None:
+    compact = PerpsFill.parse_response(_compact_fill(p=100.5, qty=2))
+    expanded = PerpsFill.parse_response(_expanded_fill())
+
+    assert compact.price == expanded.price == Decimal("100.5")
+    assert compact.quantity == expanded.quantity == Decimal("2")
+    assert compact.timestamp == expanded.timestamp == datetime(2025, 7, 2, 23, 46, 40, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("placeholder", ["", "0x"])
+def test_fill_normalizes_placeholder_hashes(placeholder: str) -> None:
+    assert PerpsFill.parse_response(_compact_fill(hash=placeholder)).hash is None
+
+
+def test_fill_preserves_transaction_hash() -> None:
+    transaction_hash = "0x" + "1" * 64
+    assert PerpsFill.parse_response(_compact_fill(hash=transaction_hash)).hash == transaction_hash
+
+
+@pytest.mark.parametrize("field", ["p", "qty", "fee", "psz", "pep", "pnl"])
+def test_fill_decimal_fields_reject_bool(field: str) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsFill.parse_response(_compact_fill(**{field: False}))
+
+
+@pytest.mark.parametrize("value", [True, 1751500000000.0, "1751500000000", None])
+def test_fill_timestamp_remains_strict_epoch_milliseconds(value: object) -> None:
+    with pytest.raises(UnexpectedResponseError):
+        PerpsFill.parse_response(_compact_fill(ts=value))

--- a/tests/unit/test_perps_session.py
+++ b/tests/unit/test_perps_session.py
@@ -608,6 +608,28 @@ def test_notification_sequence_gaps_do_not_emit_local_resync() -> None:
     asyncio.run(asyncio.wait_for(run(), timeout=10.0))
 
 
+def test_malformed_notification_decimal_is_dropped_without_disrupting_dispatch() -> None:
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        malformed = _notification_update(10, "5f4a3c2b-1d0e-49f8-a7b6-c5d4e3f2a1b0")
+        malformed["data"]["size"] = True
+        await ws.send(json.dumps(malformed))
+        await ws.send(json.dumps(_order_update(1, sequence=1)))
+        with contextlib.suppress(Exception):
+            async for _ in ws:
+                pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            event = await asyncio.wait_for(session.__anext__(), timeout=5.0)
+            assert isinstance(event, PerpsOrderEvent)
+            assert event.payload.id == 1
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(session.__anext__(), timeout=0.1)
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
 def test_server_notifications_resync_frame_emits_server_resync_event() -> None:
     async def handler(ws: ServerConnection) -> None:
         await _handshake(ws)

--- a/tests/unit/test_public_model_annotations.py
+++ b/tests/unit/test_public_model_annotations.py
@@ -1,0 +1,84 @@
+import inspect
+from types import ModuleType
+from typing import cast, get_args, get_type_hints
+
+from pydantic import BaseModel
+from pydantic.functional_serializers import PlainSerializer
+from pydantic.functional_validators import BeforeValidator
+
+import polymarket
+import polymarket.models
+import polymarket.models.clob
+import polymarket.models.perps
+import polymarket.streams
+
+_PUBLIC_MODULES = (
+    polymarket,
+    polymarket.models,
+    polymarket.models.clob,
+    polymarket.models.perps,
+    polymarket.streams,
+)
+
+_REMOVED_ALIASES = (
+    "DecimalFromE6String",
+    "DecimalFromString",
+    "EpochMsOrIsoTimestamp",
+    "EpochMsTimestamp",
+    "EpochOrIsoTimestamp",
+    "EpochSecondsOrMsTimestamp",
+    "EpochSecondsTimestamp",
+    "ExpirationTimestamp",
+    "OptionalPerpsTimestamp",
+    "OptionalTxHash",
+    "PerpsTimestamp",
+    "RequiredEpochOrIsoTimestamp",
+    "TradeStatusField",
+    "_DecimalFromNumberOrString",
+    "_DecimalFromString",
+    "_OptionalDecimalFromNumberOrString",
+)
+
+
+def _public_models(module: ModuleType) -> set[type[BaseModel]]:
+    models: set[type[BaseModel]] = set()
+    exports = cast(tuple[str, ...], module.__dict__["__all__"])
+    for name in exports:
+        value: object = getattr(module, name)
+        if isinstance(value, type) and issubclass(value, BaseModel):
+            models.add(value)
+    return models
+
+
+def _all_public_models() -> set[type[BaseModel]]:
+    models: set[type[BaseModel]] = set()
+    for module in _PUBLIC_MODULES:
+        models.update(_public_models(module))
+    return models
+
+
+def _contains_validation_metadata(annotation: object) -> bool:
+    if isinstance(annotation, BeforeValidator | PlainSerializer):
+        return True
+    return any(_contains_validation_metadata(arg) for arg in get_args(annotation))
+
+
+def test_public_model_fields_expose_canonical_annotations() -> None:
+    for model in _all_public_models():
+        hints = get_type_hints(model, include_extras=True)
+        signature = inspect.signature(model)
+        for field in model.model_fields:
+            annotation = hints[field]
+            assert not _contains_validation_metadata(annotation), f"{model.__name__}.{field}"
+
+        for parameter in signature.parameters.values():
+            assert not _contains_validation_metadata(parameter.annotation), (
+                f"{model.__name__}({parameter.name}=...)"
+            )
+
+
+def test_public_model_source_annotations_do_not_use_removed_aliases() -> None:
+    for model in _all_public_models():
+        source_annotations = repr(model.__dict__.get("__annotations__", {}))
+        for alias in _REMOVED_ALIASES:
+            assert alias not in source_annotations, f"{model.__name__} still uses {alias}"

--- a/tests/unit/test_rewards_models.py
+++ b/tests/unit/test_rewards_models.py
@@ -1,17 +1,19 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import get_type_hints
 
 import pytest
 
 from polymarket.errors import UnexpectedResponseError
-from polymarket.models.clob._validators import (
-    _DecimalFromNumberOrString,  # pyright: ignore[reportPrivateUsage]
-)
+from polymarket.models.base import BaseModel
 from polymarket.models.clob.rewards import (
     CurrentReward,
+    CurrentRewardConfig,
     EarningBreakdown,
     MarketReward,
     MarketRewardConfig,
+    MarketRewardToken,
     TotalUserEarning,
     UserEarning,
     UserRewardsConfig,
@@ -182,39 +184,93 @@ def test_user_earning_rejects_out_of_range_epoch() -> None:
         )
 
 
-def test_decimalish_string_accepts_int() -> None:
-    from pydantic import BaseModel as _Base
+def test_reward_decimal_fields_expose_canonical_annotations_and_signatures() -> None:
+    fields_by_model: tuple[tuple[type[BaseModel], dict[str, object]], ...] = (
+        (
+            CurrentRewardConfig,
+            {"rate_per_day": Decimal, "total_rewards": Decimal | None},
+        ),
+        (
+            CurrentReward,
+            {
+                "rewards_min_size": Decimal | None,
+                "sponsored_daily_rate": Decimal | None,
+                "native_daily_rate": Decimal | None,
+                "total_daily_rate": Decimal | None,
+            },
+        ),
+        (
+            MarketRewardConfig,
+            {"rate_per_day": Decimal, "total_rewards": Decimal | None},
+        ),
+        (MarketRewardToken, {"price": Decimal}),
+        (MarketReward, {"rewards_min_size": Decimal | None}),
+        (UserEarning, {"asset_rate": Decimal, "earnings": Decimal}),
+        (TotalUserEarning, {"asset_rate": Decimal, "earnings": Decimal}),
+        (UserRewardsConfig, {"rate_per_day": Decimal, "total_rewards": Decimal}),
+        (EarningBreakdown, {"asset_rate": Decimal, "earnings": Decimal}),
+        (UserRewardsEarning, {"rewards_min_size": Decimal}),
+    )
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    assert Foo.model_validate({"v": 10}).v == Decimal("10")
-
-
-def test_decimalish_string_accepts_float_via_str() -> None:
-    from pydantic import BaseModel as _Base
-
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    assert Foo.model_validate({"v": 0.1}).v == Decimal("0.1")
+    for model, expected_fields in fields_by_model:
+        hints = get_type_hints(model)
+        parameters = inspect.signature(model).parameters
+        for field, annotation in expected_fields.items():
+            assert hints[field] == annotation
+            assert parameters[field].annotation == annotation
 
 
-def test_decimalish_string_accepts_decimal_string() -> None:
-    from pydantic import BaseModel as _Base
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (10, Decimal("10")),
+        (0.1, Decimal("0.1")),
+        ("0.001", Decimal("0.001")),
+        (Decimal("1.25"), Decimal("1.25")),
+    ],
+)
+def test_reward_decimal_fields_accept_number_string_and_decimal(
+    value: int | float | str | Decimal, expected: Decimal
+) -> None:
+    token = MarketRewardToken.parse_response(
+        {"token_id": "8501497", "outcome": "Yes", "price": value}
+    )
+    assert token.price == expected
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
 
-    assert Foo.model_validate({"v": "0.001"}).v == Decimal("0.001")
+def test_reward_decimal_fields_reject_bool() -> None:
+    with pytest.raises(UnexpectedResponseError):
+        MarketRewardToken.parse_response({"token_id": "8501497", "outcome": "Yes", "price": True})
 
 
-def test_decimalish_string_rejects_bool() -> None:
-    from pydantic import BaseModel as _Base
-    from pydantic import ValidationError
+@pytest.mark.parametrize(
+    ("model", "payload", "field"),
+    [
+        (
+            CurrentRewardConfig,
+            {"asset_address": "0xUSDC", "start_date": 1700000000000, "rate_per_day": "1"},
+            "total_rewards",
+        ),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "rewards_min_size"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "sponsored_daily_rate"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "native_daily_rate"),
+        (CurrentReward, {"condition_id": _CONDITION_ID}, "total_daily_rate"),
+        (
+            MarketRewardConfig,
+            {"asset_address": "0xUSDC", "start_date": 1700000000000, "rate_per_day": "1"},
+            "total_rewards",
+        ),
+        (
+            MarketReward,
+            {"condition_id": _CONDITION_ID, "question": "Q?", "tokens": []},
+            "rewards_min_size",
+        ),
+    ],
+)
+def test_optional_reward_decimals_accept_none_but_reject_empty_string(
+    model: type[BaseModel], payload: dict[str, object], field: str
+) -> None:
+    assert getattr(model.parse_response(payload | {field: None}), field) is None
 
-    class Foo(_Base):
-        v: _DecimalFromNumberOrString
-
-    with pytest.raises(ValidationError):
-        Foo.model_validate({"v": True})
+    with pytest.raises(UnexpectedResponseError):
+        model.parse_response(payload | {field: ""})

--- a/tests/unit/test_streams_market_events.py
+++ b/tests/unit/test_streams_market_events.py
@@ -1,16 +1,24 @@
-from typing import Any
+import inspect
+from datetime import datetime
+from decimal import Decimal
+from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
 
 import pytest
 from pydantic import ValidationError
 
 from polymarket.models.clob.market_events import (
     MarketBestBidAskEvent,
+    MarketBestBidAskPayload,
     MarketBookEvent,
+    MarketBookPayload,
+    MarketEvent,
     MarketLastTradePriceEvent,
+    MarketLastTradePricePayload,
     MarketPriceChangeEvent,
     MarketResolvedEvent,
     MarketTickSizeChangeEvent,
     NewMarketEvent,
+    PriceChange,
     parse_market_event,
 )
 
@@ -296,3 +304,47 @@ def test_empty_string_required_decimal_rejected() -> None:
     payload = dict(_LAST_TRADE) | {"price": ""}
     with pytest.raises(ValidationError):
         parse_market_event(payload)
+
+
+def test_market_payload_annotations_expose_canonical_types() -> None:
+    price_change_hints = get_type_hints(PriceChange, include_extras=True)
+    assert price_change_hints["price"] is Decimal
+    assert price_change_hints["best_bid"] == (Decimal | None)
+    assert price_change_hints["side"] == Literal["BUY", "SELL"]
+
+    book_hints = get_type_hints(MarketBookPayload, include_extras=True)
+    assert book_hints["timestamp"] == (datetime | None)
+    assert book_hints["tick_size"] == (Decimal | None)
+
+
+def test_market_payload_constructor_signatures_expose_canonical_types() -> None:
+    price_change_parameters = inspect.signature(PriceChange).parameters
+    assert price_change_parameters["price"].annotation is Decimal
+    assert price_change_parameters["best_bid"].annotation == (Decimal | None)
+    assert price_change_parameters["side"].annotation == Literal["BUY", "SELL"]
+
+    last_trade_parameters = inspect.signature(MarketLastTradePricePayload).parameters
+    assert last_trade_parameters["timestamp"].annotation == (datetime | None)
+    assert last_trade_parameters["fee_rate_bps"].annotation == (Decimal | None)
+
+
+def test_market_event_keeps_discriminated_union_metadata() -> None:
+    assert get_origin(MarketEvent) is Annotated
+    event_union, metadata = get_args(MarketEvent)
+    assert get_args(event_union) == (
+        MarketBookEvent,
+        MarketPriceChangeEvent,
+        MarketLastTradePriceEvent,
+        MarketTickSizeChangeEvent,
+        MarketBestBidAskEvent,
+        NewMarketEvent,
+        MarketResolvedEvent,
+    )
+    assert metadata.discriminator == "type"
+
+
+def test_optional_market_decimal_annotations_are_consistent() -> None:
+    hints = get_type_hints(MarketBestBidAskPayload, include_extras=True)
+    assert hints["best_bid"] == (Decimal | None)
+    assert hints["best_ask"] == (Decimal | None)
+    assert hints["spread"] == (Decimal | None)

--- a/tests/unit/test_streams_rtds_events.py
+++ b/tests/unit/test_streams_rtds_events.py
@@ -1,6 +1,7 @@
+import inspect
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 
@@ -13,6 +14,7 @@ from polymarket.models.rtds_events import (
     CryptoPricesChainlinkTwapPayload,
     EquityPricesSubscribeEvent,
     EquityPricesUpdateEvent,
+    PriceUpdatePayload,
     ReactionCreatedEvent,
     api_topic_to_wire,
     parse_rtds_event,
@@ -186,6 +188,48 @@ def test_crypto_chainlink_wire_topic_remapped_to_api_topic() -> None:
     assert event.payload.symbol == "ETH/USD"
 
 
+def test_rtds_fields_expose_canonical_annotations() -> None:
+    price_hints = get_type_hints(PriceUpdatePayload, include_extras=True)
+    event_hints = get_type_hints(CommentCreatedEvent, include_extras=True)
+
+    assert price_hints["value"] is Decimal
+    assert event_hints["timestamp"] == (datetime | None)
+    assert inspect.signature(PriceUpdatePayload).parameters["value"].annotation is Decimal
+    assert inspect.signature(CommentCreatedEvent).parameters["timestamp"].annotation == (
+        datetime | None
+    )
+
+
+@pytest.mark.parametrize("value", [b"1.5", True, None, object()])
+def test_decimalish_fields_do_not_accept_broader_decimal_inputs(value: object) -> None:
+    with pytest.raises(ValueError):
+        PriceUpdatePayload.model_validate({"symbol": "BTC", "timestamp": 0, "value": value})
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected"),
+    [
+        (1710000000000, datetime.fromtimestamp(1710000000, tz=UTC)),
+        ("1710000000000", datetime.fromtimestamp(1710000000, tz=UTC)),
+        ("2024-03-09T12:00:00+00:00", datetime(2024, 3, 9, 12, tzinfo=UTC)),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_rtds_timestamp_preserves_accepted_inputs(
+    timestamp: object, expected: datetime | None
+) -> None:
+    event = parse_rtds_event({**_CRYPTO_BINANCE, "timestamp": timestamp})
+
+    assert event.timestamp == expected
+
+
+@pytest.mark.parametrize("timestamp", [True, 1710000000000.0, b"1710000000000", "+1", "-1"])
+def test_rtds_timestamp_preserves_rejected_inputs(timestamp: object) -> None:
+    with pytest.raises(ValueError):
+        parse_rtds_event({**_CRYPTO_BINANCE, "timestamp": timestamp})
+
+
 @pytest.mark.parametrize(
     ("wire_topic", "window_seconds"),
     [
@@ -323,6 +367,17 @@ def test_crypto_chainlink_twap_still_validates_display_value(display_value: obje
         payload["value"] = display_value
 
     with pytest.raises(ValueError):
+        parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
+
+
+def test_crypto_chainlink_twap_validates_display_value_before_full_accuracy_value() -> None:
+    payload = {
+        **_CRYPTO_CHAINLINK_TWAP["payload"],
+        "value": object(),
+        "full_accuracy_value": "invalid",
+    }
+
+    with pytest.raises(ValueError, match="expected decimal-ish value, got object"):
         parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
 
 

--- a/tests/unit/test_streams_rtds_events.py
+++ b/tests/unit/test_streams_rtds_events.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Any, get_type_hints
 
 import pytest
+from pydantic import ValidationError
 
 from polymarket.models.rtds_events import (
     CommentCreatedEvent,
@@ -379,6 +380,20 @@ def test_crypto_chainlink_twap_validates_display_value_before_full_accuracy_valu
 
     with pytest.raises(ValueError, match="expected decimal-ish value, got object"):
         parse_rtds_event({**_CRYPTO_CHAINLINK_TWAP, "payload": payload})
+
+
+def test_crypto_chainlink_twap_preserves_invalid_display_value_error_input() -> None:
+    display_value = object()
+    payload = {
+        **_CRYPTO_CHAINLINK_TWAP["payload"],
+        "value": display_value,
+        "full_accuracy_value": "invalid",
+    }
+
+    with pytest.raises(ValidationError) as captured:
+        CryptoPricesChainlinkTwapPayload.model_validate(payload)
+
+    assert captured.value.errors()[0]["input"] is display_value
 
 
 def test_crypto_chainlink_twap_payload_round_trips_public_shape() -> None:

--- a/tests/unit/test_streams_sports_events.py
+++ b/tests/unit/test_streams_sports_events.py
@@ -1,5 +1,6 @@
+import inspect
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 from pydantic import ValidationError
@@ -41,6 +42,15 @@ def test_camelcase_wire_fields_map_to_snake_case() -> None:
     assert event.payload.league_abbreviation == "NBA"
     assert event.payload.home_team == "LAL"
     assert event.payload.away_team == "BOS"
+
+
+def test_finished_timestamp_exposes_canonical_annotation_and_alias_signature() -> None:
+    hints = get_type_hints(SportsGameResult, include_extras=True)
+    parameters = inspect.signature(SportsGameResult).parameters
+
+    assert hints["finished_at"] == (datetime | None)
+    assert parameters["finishedTimestamp"].annotation == (datetime | None)
+    assert "finished_at" not in parameters
 
 
 def test_required_fields_only() -> None:
@@ -94,6 +104,16 @@ def test_finished_timestamp_accepts_iso_string() -> None:
     event = parse_sports_event(payload)
     assert event.payload.finished_at is not None
     assert event.payload.finished_at.year == 2024
+
+
+@pytest.mark.parametrize(
+    "finished_timestamp", [True, 1710000000000.0, b"1710000000000", "+1", "-1"]
+)
+def test_finished_timestamp_preserves_rejected_inputs(finished_timestamp: object) -> None:
+    payload = dict(_WIRE) | {"finishedTimestamp": finished_timestamp}
+
+    with pytest.raises(ValidationError):
+        parse_sports_event(payload)
 
 
 def test_missing_required_field_raises_validation_error() -> None:

--- a/tests/unit/test_streams_user_events.py
+++ b/tests/unit/test_streams_user_events.py
@@ -1,14 +1,23 @@
-from typing import Any
+import inspect
+from datetime import datetime
+from decimal import Decimal
+from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
 
 import pytest
 from pydantic import ValidationError
 
+from polymarket.models.clob.account import TradeStatus
 from polymarket.models.clob.user_events import (
+    UserEvent,
     UserOrderEvent,
+    UserOrderPayload,
     UserTradeEvent,
+    UserTradeMakerOrder,
+    UserTradePayload,
     parse_user_event,
     parse_user_events,
 )
+from polymarket.models.types import OrderSide
 
 _ORDER_PLACEMENT: dict[str, Any] = {
     "event_type": "order",
@@ -58,6 +67,39 @@ _TRADE: dict[str, Any] = {
         }
     ],
 }
+
+
+def test_user_payload_annotations_expose_canonical_types() -> None:
+    order_hints = get_type_hints(UserOrderPayload, include_extras=True)
+    maker_hints = get_type_hints(UserTradeMakerOrder, include_extras=True)
+    trade_hints = get_type_hints(UserTradePayload, include_extras=True)
+
+    assert order_hints["side"] == OrderSide
+    assert order_hints["original_size"] is Decimal
+    assert order_hints["timestamp"] == (datetime | None)
+    assert order_hints["expires_at"] == (datetime | None)
+    assert maker_hints["fee_rate_bps"] == (Decimal | None)
+    assert trade_hints["status"] == TradeStatus
+    assert trade_hints["trader_side"] == (Literal["TAKER", "MAKER"] | None)
+
+
+def test_user_payload_signature_exposes_canonical_types() -> None:
+    parameters = inspect.signature(UserTradePayload).parameters
+
+    assert parameters["side"].annotation == OrderSide
+    assert parameters["size"].annotation is Decimal
+    assert parameters["status"].annotation == TradeStatus
+    assert parameters["timestamp"].annotation == (datetime | None)
+    assert parameters["fee_rate_bps"].annotation == (Decimal | None)
+    assert parameters["trader_side"].annotation == (Literal["TAKER", "MAKER"] | None)
+
+
+def test_user_event_keeps_discriminated_union_metadata() -> None:
+    union, metadata = get_args(UserEvent)
+
+    assert get_origin(UserEvent) is Annotated
+    assert union == (UserOrderEvent | UserTradeEvent)
+    assert metadata.discriminator == "type"
 
 
 def test_order_placement_parses_with_normalized_envelope() -> None:


### PR DESCRIPTION
## Summary

- expose canonical `Decimal`, `datetime`, status, side, and optional value types across 262 fields in 101 public models
- keep each wire format explicit through model-level field validators and private collection adapters
- preserve aliases, tuple/list preprocessing, discriminated unions, strict input grammars, validation locations, error aggregation, and stream drop behavior
- remove validation-only public annotation aliases and enforce the canonical-annotation invariant across exported Pydantic models
- remove unused collateral E6 JSON serialization while retaining E6 response parsing; collateral execution continues to submit the plan hash and router call rather than serializing the plan

## Review context

This PR flattens [Stack #250](https://github.com/Polymarket/py-sdk/pull/250) into one review and merge unit. The existing stacked PRs remain open until this replacement is accepted.

The highest-value areas to inspect are:

- collateral E6 parsing and serialization behavior
- Chainlink TWAP full-accuracy handling and sports timestamp alias precedence
- Perps compact aliases, tuple-shaped market data, timestamps, and hash sentinels
- private adapters and field validators that preserve Pydantic validation diagnostics without leaking metadata into public annotations

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not integration" -q` (2,202 passed, 184 deselected)
- `uv build`
- `make api-reference`
- independent compatibility review of every stack layer and the final aggregate behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor of response parsing and public typing across trading, Perps, and collateral models; runtime behavior should match prior validators but any missed edge case could affect order, balance, or plan parsing.
> 
> **Overview**
> **Public model surface** — Exported Pydantic models across CLOB, Perps, collateral return, RTDS, and sports streams now annotate fields with canonical `Decimal`, `datetime`, enums, and literals instead of wire-oriented `Annotated` aliases (`DecimalFromString`, `PerpsTimestamp`, `EpochMsTimestamp`, etc.). Parsing stays at the boundary via shared helpers (`parse_decimal_string`, `_coerce_decimalish`, epoch parsers) wired through `field_validator` hooks; private `TypeAdapter` paths (e.g. CLOB midpoints/prices) use local `BeforeValidator` wrappers without changing public types.
> 
> **Docs and shared validators** — `AGENTS.md` adds **Public Model Types** rules (no `TYPE_CHECKING` split annotations, explicit request encoding, keep discriminators). `models/_validators.py` drops `TYPE_CHECKING` alias exports and `serialize_e6_decimal_string`; E6 amounts still parse in but are no longer round-tripped through model JSON serializers.
> 
> **Collateral & behavior** — Collateral return plans keep E6 parsing on `amount` fields while decimal plan totals use strict decimal-string rules; tests drop JSON round-trip expectations for scaled amounts. Existing wire quirks are preserved: trade status prefix normalization, order-book empty `last_trade_price`, Perps hash/`0x` sentinels, proxy expiry nanosecond normalization, and stream validation/drop behavior, with new unit tests locking annotations, signatures, and input grammars across ~100+ public models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41e44a832d9bbe8727085e73b731b55cee21ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->