### PR TITLE
ci: sync uv.lock version through release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,14 @@
       "changelog-path": "CHANGELOG.md",
       "versioning": "prerelease",
       "prerelease": false,
-      "prerelease-type": "b"
+      "prerelease-type": "b",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name=='polymarket-client')].version"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name=='polymarket-client')].version"
+          "jsonpath": "$.package[?(@.name.value=='polymarket-client')].version"
         }
       ]
     }


### PR DESCRIPTION
Updates the polymarket-client entry in uv.lock as part of each release-please PR, avoiding a separate lockfile sync commit.

Alternative to #231.