### PR TITLE
fix(client): handle tokens without trades

### DIFF
--- a/examples/market_prices.py
+++ b/examples/market_prices.py
@@ -37,8 +37,8 @@ def main() -> None:
                 "buyPrice": buy_price,
                 "midpoint": midpoint,
                 "spread": spread,
-                "lastTradePrice": last_trade.price,
-                "lastTradeSide": last_trade.side,
+                "lastTradePrice": last_trade.price if last_trade is not None else "N/A",
+                "lastTradeSide": last_trade.side if last_trade is not None else "N/A",
             }
         )
 

--- a/src/polymarket/_internal/actions/clob.py
+++ b/src/polymarket/_internal/actions/clob.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from decimal import Decimal
-from typing import Annotated, cast
+from typing import Annotated, Literal, cast
 
 from pydantic import BeforeValidator, TypeAdapter, ValidationError, field_validator
 
@@ -44,6 +44,16 @@ class _SpreadResponse(BaseModel):
     @field_validator("spread", mode="before")
     @classmethod
     def _parse_spread(cls, value: object) -> object:
+        return parse_decimal_string(value)
+
+
+class _LastTradePriceResponse(BaseModel):
+    price: Decimal
+    side: OrderSide | Literal[""]
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def _parse_price(cls, value: object) -> object:
         return parse_decimal_string(value)
 
 
@@ -200,8 +210,11 @@ def build_last_trade_price_request(*, token_id: str) -> tuple[str, dict[str, str
     return "/last-trade-price", {"token_id": _require_string_token_id(token_id)}
 
 
-def parse_last_trade_price(data: object) -> LastTradePrice:
-    return LastTradePrice.parse_response(data)
+def parse_last_trade_price(data: object) -> LastTradePrice | None:
+    response = _LastTradePriceResponse.parse_response(data)
+    if response.side == "":
+        return None
+    return LastTradePrice(price=response.price, side=response.side)
 
 
 def build_last_trade_prices_request(

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1273,11 +1273,10 @@ class AsyncPublicClient:
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))
 
-    async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+    async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice | None:
         """Get the most recent trade price for a token.
 
-        For a token without trades, ``side`` is ``None`` and ``price`` is the
-        ``Decimal("0.5")`` placeholder.
+        Returns ``None`` when the token has not traded.
         """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1286,7 +1286,11 @@ class AsyncPublicClient:
     async def get_last_trade_prices(
         self, *, token_ids: Sequence[str]
     ) -> tuple[LastTradePriceForToken, ...]:
-        """Get the most recent trade prices for multiple tokens."""
+        """Get the most recent trade prices for multiple tokens.
+
+        Tokens without trades are omitted. Match returned entries by ``token_id``;
+        the result is not positionally aligned with ``token_ids``.
+        """
         path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
         return _clob_actions.parse_last_trade_prices(
             await self._ctx.clob.post_json(path, json=body)

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1274,7 +1274,11 @@ class AsyncPublicClient:
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))
 
     async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
-        """Get the most recent trade price for a token."""
+        """Get the most recent trade price for a token.
+
+        For a token without trades, ``side`` is ``None`` and ``price`` is the
+        ``Decimal("0.5")`` placeholder.
+        """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(
             await self._ctx.clob.get_json(path, params=params)

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1880,7 +1880,11 @@ class AsyncSecureClient:
     async def get_last_trade_prices(
         self, *, token_ids: Sequence[str]
     ) -> tuple[LastTradePriceForToken, ...]:
-        """Get the most recent trade prices for multiple tokens."""
+        """Get the most recent trade prices for multiple tokens.
+
+        Tokens without trades are omitted. Match returned entries by ``token_id``;
+        the result is not positionally aligned with ``token_ids``.
+        """
         path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
         return _clob_actions.parse_last_trade_prices(
             await self._ctx.clob.post_json(path, json=body)

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1867,11 +1867,10 @@ class AsyncSecureClient:
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))
 
-    async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+    async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice | None:
         """Get the most recent trade price for a token.
 
-        For a token without trades, ``side`` is ``None`` and ``price`` is the
-        ``Decimal("0.5")`` placeholder.
+        Returns ``None`` when the token has not traded.
         """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1868,7 +1868,11 @@ class AsyncSecureClient:
         return _clob_actions.parse_spreads(await self._ctx.clob.post_json(path, json=body))
 
     async def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
-        """Get the most recent trade price for a token."""
+        """Get the most recent trade price for a token.
+
+        For a token without trades, ``side`` is ``None`` and ``price`` is the
+        ``Decimal("0.5")`` placeholder.
+        """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(
             await self._ctx.clob.get_json(path, params=params)

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -1070,7 +1070,11 @@ class PublicClient:
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
 
     def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
-        """Get the most recent trade price for a token."""
+        """Get the most recent trade price for a token.
+
+        For a token without trades, ``side`` is ``None`` and ``price`` is the
+        ``Decimal("0.5")`` placeholder.
+        """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
 

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -1080,7 +1080,11 @@ class PublicClient:
     def get_last_trade_prices(
         self, *, token_ids: Sequence[str]
     ) -> tuple[LastTradePriceForToken, ...]:
-        """Get the most recent trade prices for multiple tokens."""
+        """Get the most recent trade prices for multiple tokens.
+
+        Tokens without trades are omitted. Match returned entries by ``token_id``;
+        the result is not positionally aligned with ``token_ids``.
+        """
         path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
         return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
 

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -1069,11 +1069,10 @@ class PublicClient:
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
 
-    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice | None:
         """Get the most recent trade price for a token.
 
-        For a token without trades, ``side`` is ``None`` and ``price`` is the
-        ``Decimal("0.5")`` placeholder.
+        Returns ``None`` when the token has not traded.
         """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1393,11 +1393,10 @@ class SecureClient:
         path, body = _clob_actions.build_spreads_request(token_ids=token_ids)
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
 
-    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
+    def get_last_trade_price(self, *, token_id: str) -> LastTradePrice | None:
         """Get the most recent trade price for a token.
 
-        For a token without trades, ``side`` is ``None`` and ``price`` is the
-        ``Decimal("0.5")`` placeholder.
+        Returns ``None`` when the token has not traded.
         """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1404,7 +1404,11 @@ class SecureClient:
     def get_last_trade_prices(
         self, *, token_ids: Sequence[str]
     ) -> tuple[LastTradePriceForToken, ...]:
-        """Get the most recent trade prices for multiple tokens."""
+        """Get the most recent trade prices for multiple tokens.
+
+        Tokens without trades are omitted. Match returned entries by ``token_id``;
+        the result is not positionally aligned with ``token_ids``.
+        """
         path, body = _clob_actions.build_last_trade_prices_request(token_ids=token_ids)
         return _clob_actions.parse_last_trade_prices(self._ctx.clob.post_json(path, json=body))
 

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -1394,7 +1394,11 @@ class SecureClient:
         return _clob_actions.parse_spreads(self._ctx.clob.post_json(path, json=body))
 
     def get_last_trade_price(self, *, token_id: str) -> LastTradePrice:
-        """Get the most recent trade price for a token."""
+        """Get the most recent trade price for a token.
+
+        For a token without trades, ``side`` is ``None`` and ``price`` is the
+        ``Decimal("0.5")`` placeholder.
+        """
         path, params = _clob_actions.build_last_trade_price_request(token_id=token_id)
         return _clob_actions.parse_last_trade_price(self._ctx.clob.get_json(path, params=params))
 

--- a/src/polymarket/models/clob/last_trade.py
+++ b/src/polymarket/models/clob/last_trade.py
@@ -11,12 +11,17 @@ from polymarket.models.types import OrderSide, TokenId
 
 class LastTradePrice(BaseModel):
     price: Decimal
-    side: OrderSide
+    side: OrderSide | None
 
     @field_validator("price", mode="before")
     @classmethod
     def _parse_price(cls, value: object) -> object:
         return parse_decimal_string(value)
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _empty_side_to_none(cls, value: object) -> object:
+        return None if value == "" else value
 
 
 class LastTradePriceForToken(BaseModel):

--- a/src/polymarket/models/clob/last_trade.py
+++ b/src/polymarket/models/clob/last_trade.py
@@ -11,17 +11,12 @@ from polymarket.models.types import OrderSide, TokenId
 
 class LastTradePrice(BaseModel):
     price: Decimal
-    side: OrderSide | None
+    side: OrderSide
 
     @field_validator("price", mode="before")
     @classmethod
     def _parse_price(cls, value: object) -> object:
         return parse_decimal_string(value)
-
-    @field_validator("side", mode="before")
-    @classmethod
-    def _empty_side_to_none(cls, value: object) -> object:
-        return None if value == "" else value
 
 
 class LastTradePriceForToken(BaseModel):

--- a/tests/integration/test_clob_reads.py
+++ b/tests/integration/test_clob_reads.py
@@ -152,7 +152,7 @@ def test_async_get_spreads_returns_decimal_per_token(active_clob_token: TokenId)
 
 @pytest.mark.integration
 def test_async_get_last_trade_price_returns_model(active_clob_token: TokenId) -> None:
-    async def run() -> LastTradePrice:
+    async def run() -> LastTradePrice | None:
         async with AsyncPublicClient() as client:
             return await client.get_last_trade_price(token_id=active_clob_token)
 

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -500,6 +500,14 @@ def test_parse_last_trade_price_returns_model() -> None:
     assert result.side == "BUY"
 
 
+def test_parse_last_trade_price_normalizes_empty_side() -> None:
+    result = parse_last_trade_price({"price": "0.5", "side": ""})
+
+    assert result.price == Decimal("0.5")
+    assert_type(result.side, OrderSide | None)
+    assert result.side is None
+
+
 def test_parse_last_trade_price_rejects_numeric_price() -> None:
     with pytest.raises(UnexpectedResponseError):
         parse_last_trade_price({"price": 0.53, "side": "BUY"})

--- a/tests/unit/test_clob_actions.py
+++ b/tests/unit/test_clob_actions.py
@@ -30,7 +30,7 @@ from polymarket._internal.actions.clob import (
     parse_spreads,
 )
 from polymarket.errors import UnexpectedResponseError, UserInputError
-from polymarket.models import OrderSide, PriceRequest, TokenId
+from polymarket.models import LastTradePrice, OrderSide, PriceRequest, TokenId
 
 
 def test_build_midpoint_request_targets_midpoint_path_with_token_id() -> None:
@@ -496,16 +496,16 @@ def test_build_last_trade_price_request_targets_last_trade_price_path() -> None:
 def test_parse_last_trade_price_returns_model() -> None:
     result = parse_last_trade_price({"price": "0.53", "side": "BUY"})
 
+    assert result is not None
     assert result.price == Decimal("0.53")
     assert result.side == "BUY"
 
 
-def test_parse_last_trade_price_normalizes_empty_side() -> None:
+def test_parse_last_trade_price_returns_none_without_trades() -> None:
     result = parse_last_trade_price({"price": "0.5", "side": ""})
 
-    assert result.price == Decimal("0.5")
-    assert_type(result.side, OrderSide | None)
-    assert result.side is None
+    assert_type(result, LastTradePrice | None)
+    assert result is None
 
 
 def test_parse_last_trade_price_rejects_numeric_price() -> None:

--- a/tests/unit/test_clob_transport.py
+++ b/tests/unit/test_clob_transport.py
@@ -230,13 +230,14 @@ def test_async_get_spreads_posts_token_ids() -> None:
 def test_async_get_last_trade_price_returns_model() -> None:
     captured: list[httpx.Request] = []
 
-    async def run() -> LastTradePrice:
+    async def run() -> LastTradePrice | None:
         async with AsyncPublicClient() as client:
             _install_async_clob(client, _clob_handler(captured, {"price": "0.53", "side": "BUY"}))
             return await client.get_last_trade_price(token_id="123")
 
     result = asyncio.run(run())
 
+    assert result is not None
     assert result.price == Decimal("0.53")
     assert result.side == "BUY"
     assert urlparse(str(captured[0].url)).path == "/last-trade-price"


### PR DESCRIPTION
Returns None for a token without trades and documents the placeholder price response.

DEV-506

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change: callers must handle `LastTradePrice | None` on `get_last_trade_price`; behavior is limited to CLOB read parsing with no auth or trading impact.
> 
> **Overview**
> **`get_last_trade_price`** now returns **`None`** when the CLOB responds with an empty **`side`** (the API’s placeholder for tokens that have never traded), instead of surfacing a bogus **`LastTradePrice`**.
> 
> Parsing goes through a new **`_LastTradePriceResponse`** in **`clob`** actions that accepts **`side: ""`** and maps it to **`None`**. Return types and docstrings are updated on **public**, **secure**, and **async** clients; **`get_last_trade_prices`** docs note that untraded tokens are omitted and results must be matched by **`token_id`**, not by input order.
> 
> The **`market_prices`** example prints **`N/A`** when there is no last trade. Unit/transport tests cover the no-trade response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a0b1963ad5943e087fa1d16d36e2284257d3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->