### PR TITLE
test(rfq): remove obsolete hanging integration tests

### DIFF
--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -11,7 +11,7 @@ import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket import PRODUCTION, ApiKeyCreds, AsyncSecureClient
-from polymarket.errors import ConnectionLostError, TransportError, UnexpectedResponseError
+from polymarket.errors import ConnectionLostError, TransportError
 from polymarket.rfq import (
     RfqConfirmationRequestEvent,
     RfqErrorCode,
@@ -263,33 +263,6 @@ async def test_rfq_session_normalizes_combo_condition_id_wire_form(
             assert isinstance(event, RfqQuoteRequestEvent)
             assert event.condition_id == CONDITION_ID
             break
-
-
-@pytest.mark.integration
-async def test_rfq_session_rejects_non_combo_condition_id(
-    require_env: Callable[[str], str],
-) -> None:
-    async def handler(ws: ServerConnection) -> None:
-        async for raw in ws:
-            assert isinstance(raw, str)
-            frame = json.loads(raw)
-            if frame["type"] == "auth":
-                await ws.send(json.dumps({"type": "auth", "success": True}))
-                await ws.send(
-                    json.dumps(
-                        _quote_request_message(
-                            condition_id="0x022def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000"
-                        )
-                    )
-                )
-
-    async with (
-        _ws_server(handler) as ws_url,
-        _rfq_client(require_env, ws_url) as client,
-        client.open_rfq_session() as session,
-    ):
-        with pytest.raises(UnexpectedResponseError, match="combo condition ID"):
-            await session.__anext__()
 
 
 @pytest.mark.integration
@@ -670,34 +643,6 @@ async def test_rfq_session_connection_lost_rejects_pending_and_raises(
 
         with pytest.raises(ConnectionLostError):
             await session.__anext__()
-
-
-@pytest.mark.integration
-async def test_rfq_session_malformed_frame_fails_and_clears_client_session(
-    require_env: Callable[[str], str],
-) -> None:
-    connection_count = 0
-
-    async def handler(ws: ServerConnection) -> None:
-        nonlocal connection_count
-        connection_count += 1
-        async for raw in ws:
-            assert isinstance(raw, str)
-            frame = json.loads(raw)
-            if frame["type"] != "auth":
-                continue
-            await ws.send(json.dumps({"type": "auth", "success": True}))
-            if connection_count == 1:
-                await ws.send(json.dumps({"type": "RFQ_REQUEST", "rfq_id": RFQ_ID}))
-
-    async with _ws_server(handler) as ws_url, _rfq_client(require_env, ws_url) as client:
-        session = await client.open_rfq_session()
-        with pytest.raises(UnexpectedResponseError, match="requestor_public_id"):
-            await session.__anext__()
-
-        next_session = await client.open_rfq_session()
-        assert next_session is not session
-        assert connection_count == 2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- remove `test_rfq_session_rejects_non_combo_condition_id`
- remove `test_rfq_session_malformed_frame_fails_and_clears_client_session`
- remove the now-unused `UnexpectedResponseError` import

Linear: [DEV-554](https://linear.app/polymarket/issue/DEV-554/fix-python-integration-tests-hanging-on-malformed-rfq-frames)

## Root cause

These tests encoded the original RFQ behavior: malformed known WebSocket frames were expected to fail the session and surface an `UnexpectedResponseError`.

PR #174 deliberately changed the stream contract so unknown or malformed frames are dropped without closing the connection. The two integration tests were not updated. Each still awaited `session.__anext__()` with no timeout, expecting an exception that can no longer arrive. Because the malformed frame is dropped and the session remains open, the queue stays empty and pytest waits indefinitely.

This matches the observed CI behavior. [Run #186](https://github.com/Polymarket/py-sdk/actions/runs/31111032569) completed 139 tests, printed four passing RFQ tests, and then remained inside the next RFQ test until the runner was canceled. [Run #187](https://github.com/Polymarket/py-sdk/actions/runs/31119938507/job/92796490026) subsequently hung in the same integration step.

## Why remove rather than rewrite

Neither test provides unique integration coverage under the current contract:

- combo condition-ID rejection is covered by `tests/unit/test_model_types.py`
- malformed known frames being dropped while the RFQ session remains open is covered by `tests/unit/test_streams_invalid_frames.py`
- reusing an existing open RFQ session remains covered by `test_rfq_session_reuses_existing_open_session`

The obsolete tests also create a real `AsyncSecureClient` and bootstrap live credentials despite exercising narrow parser and invalid-frame policy. Removing them keeps that policy in deterministic unit coverage and avoids spending live-integration time on duplicate assertions.

## Impact

No production RFQ behavior changes. The integration suite can proceed past the RFQ tests instead of waiting indefinitely on stale expectations.

## Validation

- `ruff check --stdin-filename tests/integration/test_rfq.py -`
- targeted RFQ invalid-frame and combo condition-ID unit tests: **9 passed**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup with no SDK or RFQ runtime changes.
> 
> **Overview**
> **Removes obsolete RFQ integration tests** that caused the suite to hang indefinitely in CI.
> 
> Deletes `test_rfq_session_rejects_non_combo_condition_id` and `test_rfq_session_malformed_frame_fails_and_clears_client_session`, which still expected `UnexpectedResponseError` when rejecting combo condition IDs or receiving malformed frames. After PR #174, unknown/malformed frames are dropped without closing the session, so `session.__anext__()` never completed.
> 
> Also drops the unused `UnexpectedResponseError` import from `tests/integration/test_rfq.py`. **No production code changes**; equivalent behavior remains covered by unit tests (`test_model_types.py`, `test_streams_invalid_frames.py`) and `test_rfq_session_reuses_existing_open_session`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf213bfcb4b375675fbc7feac9505b33583bd49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->