### PR TITLE
refactor: make environment configuration private

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,26 +45,6 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Custom transaction calls:
-
-```python
-from polymarket.calls import merge_v2_call
-from polymarket.types import EvmAddress
-
-router = EvmAddress(client.environment.protocol_v2_router)
-
-handle = client.execute_transaction(
-    calls=[
-        merge_v2_call(router=router, condition_id="0x03...", amount=1_000_000),
-        merge_v2_call(router=router, condition_id="0x03...", amount=2_000_000),
-        merge_v2_call(router=router, condition_id="0x03...", amount=500_000),
-    ],
-    metadata="Merge 3 combo positions",
-)
-
-outcome = handle.wait()
-```
-
 Batch position merges:
 
 ```python

--- a/src/polymarket/_internal/actions/combos.py
+++ b/src/polymarket/_internal/actions/combos.py
@@ -13,6 +13,7 @@ from polymarket._internal.actions.relayer.gasless import (
 )
 from polymarket._internal.actions.relayer.submit import onchain_nonce_from_submit_error
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.wallet import WalletType
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import RelayerExecuteResponse
@@ -56,7 +57,9 @@ async def execute_collateral_return_plan(
     if ctx.api_key is None:
         raise UserInputError(_MISSING_API_KEY_MESSAGE)
     _require_supported_wallet_type(ctx.wallet_type)
-    _require_plan_matches_client(plan, wallet=ctx.wallet, chain_id=ctx.environment.chain_id)
+    _require_plan_matches_client(
+        plan, wallet=ctx.wallet, chain_id=get_environment_config(ctx.environment).chain_id
+    )
 
     call = TransactionCall(to=plan.router_call.to, data=plan.router_call.data, value=0)
     return await submit_gasless_with_retry(
@@ -70,7 +73,9 @@ def execute_collateral_return_plan_sync(
     if ctx.api_key is None:
         raise UserInputError(_MISSING_API_KEY_MESSAGE)
     _require_supported_wallet_type(ctx.wallet_type)
-    _require_plan_matches_client(plan, wallet=ctx.wallet, chain_id=ctx.environment.chain_id)
+    _require_plan_matches_client(
+        plan, wallet=ctx.wallet, chain_id=get_environment_config(ctx.environment).chain_id
+    )
 
     call = TransactionCall(to=plan.router_call.to, data=plan.router_call.data, value=0)
     return submit_gasless_with_retry_sync(

--- a/src/polymarket/_internal/actions/combos.py
+++ b/src/polymarket/_internal/actions/combos.py
@@ -13,7 +13,6 @@ from polymarket._internal.actions.relayer.gasless import (
 )
 from polymarket._internal.actions.relayer.submit import onchain_nonce_from_submit_error
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
-from polymarket._internal.environment import get_environment_config
 from polymarket._internal.wallet import WalletType
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import RelayerExecuteResponse
@@ -57,9 +56,7 @@ async def execute_collateral_return_plan(
     if ctx.api_key is None:
         raise UserInputError(_MISSING_API_KEY_MESSAGE)
     _require_supported_wallet_type(ctx.wallet_type)
-    _require_plan_matches_client(
-        plan, wallet=ctx.wallet, chain_id=get_environment_config(ctx.environment).chain_id
-    )
+    _require_plan_matches_client(plan, wallet=ctx.wallet, chain_id=ctx.environment_config.chain_id)
 
     call = TransactionCall(to=plan.router_call.to, data=plan.router_call.data, value=0)
     return await submit_gasless_with_retry(
@@ -73,9 +70,7 @@ def execute_collateral_return_plan_sync(
     if ctx.api_key is None:
         raise UserInputError(_MISSING_API_KEY_MESSAGE)
     _require_supported_wallet_type(ctx.wallet_type)
-    _require_plan_matches_client(
-        plan, wallet=ctx.wallet, chain_id=get_environment_config(ctx.environment).chain_id
-    )
+    _require_plan_matches_client(plan, wallet=ctx.wallet, chain_id=ctx.environment_config.chain_id)
 
     call = TransactionCall(to=plan.router_call.to, data=plan.router_call.data, value=0)
     return submit_gasless_with_retry_sync(

--- a/src/polymarket/_internal/actions/orders/context.py
+++ b/src/polymarket/_internal/actions/orders/context.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from polymarket._internal.actions.orders.math import decimal_places
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import Environment
+from polymarket._internal.environment import EnvironmentConfig
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.types import EvmAddress
 
@@ -58,12 +57,8 @@ def validate_price_on_tick_grid(price: Decimal, tick_size: Decimal, field: str) 
     return price
 
 
-def resolve_exchange_address(environment: Environment, neg_risk: bool) -> EvmAddress:
-    return EvmAddress(
-        get_environment_config(environment).neg_risk_exchange
-        if neg_risk
-        else get_environment_config(environment).standard_exchange
-    )
+def resolve_exchange_address(config: EnvironmentConfig, neg_risk: bool) -> EvmAddress:
+    return EvmAddress(config.neg_risk_exchange if neg_risk else config.standard_exchange)
 
 
 __all__ = [

--- a/src/polymarket/_internal/actions/orders/context.py
+++ b/src/polymarket/_internal/actions/orders/context.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from polymarket._internal.actions.orders.math import decimal_places
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import Environment
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.types import EvmAddress
@@ -58,7 +59,11 @@ def validate_price_on_tick_grid(price: Decimal, tick_size: Decimal, field: str) 
 
 
 def resolve_exchange_address(environment: Environment, neg_risk: bool) -> EvmAddress:
-    return EvmAddress(environment.neg_risk_exchange if neg_risk else environment.standard_exchange)
+    return EvmAddress(
+        get_environment_config(environment).neg_risk_exchange
+        if neg_risk
+        else get_environment_config(environment).standard_exchange
+    )
 
 
 __all__ = [

--- a/src/polymarket/_internal/actions/orders/limit.py
+++ b/src/polymarket/_internal/actions/orders/limit.py
@@ -17,7 +17,6 @@ from polymarket._internal.actions.orders.math import (
 )
 from polymarket._internal.actions.orders.types import OrderDraft
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
-from polymarket._internal.environment import get_environment_config
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -114,8 +113,8 @@ def _build_limit_order_draft(
         tick_size=metadata.tick_size,
     )
     return OrderDraft(
-        chain_id=get_environment_config(ctx.environment).chain_id,
-        exchange_address=resolve_exchange_address(ctx.environment, metadata.neg_risk),
+        chain_id=ctx.environment_config.chain_id,
+        exchange_address=resolve_exchange_address(ctx.environment_config, metadata.neg_risk),
         expiration=params.expiration if params.expiration is not None else 0,
         funder_address=ctx.wallet,
         offered_amount=offered,

--- a/src/polymarket/_internal/actions/orders/limit.py
+++ b/src/polymarket/_internal/actions/orders/limit.py
@@ -17,6 +17,7 @@ from polymarket._internal.actions.orders.math import (
 )
 from polymarket._internal.actions.orders.types import OrderDraft
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -113,7 +114,7 @@ def _build_limit_order_draft(
         tick_size=metadata.tick_size,
     )
     return OrderDraft(
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
         exchange_address=resolve_exchange_address(ctx.environment, metadata.neg_risk),
         expiration=params.expiration if params.expiration is not None else 0,
         funder_address=ctx.wallet,

--- a/src/polymarket/_internal/actions/orders/market.py
+++ b/src/polymarket/_internal/actions/orders/market.py
@@ -22,6 +22,7 @@ from polymarket._internal.actions.orders.math import (
 )
 from polymarket._internal.actions.orders.types import MarketOrderType, OrderDraft
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -298,7 +299,7 @@ def _build_market_order_draft(
         tick_size=tick_size,
     )
     return OrderDraft(
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
         exchange_address=resolve_exchange_address(ctx.environment, neg_risk),
         expiration=0,
         funder_address=ctx.wallet,

--- a/src/polymarket/_internal/actions/orders/market.py
+++ b/src/polymarket/_internal/actions/orders/market.py
@@ -22,7 +22,6 @@ from polymarket._internal.actions.orders.math import (
 )
 from polymarket._internal.actions.orders.types import MarketOrderType, OrderDraft
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
-from polymarket._internal.environment import get_environment_config
 from polymarket._internal.validation import require_nonempty, validate_builder_code
 from polymarket.errors import UserInputError
 from polymarket.models.types import OrderSide, TokenId
@@ -299,8 +298,8 @@ def _build_market_order_draft(
         tick_size=tick_size,
     )
     return OrderDraft(
-        chain_id=get_environment_config(ctx.environment).chain_id,
-        exchange_address=resolve_exchange_address(ctx.environment, neg_risk),
+        chain_id=ctx.environment_config.chain_id,
+        exchange_address=resolve_exchange_address(ctx.environment_config, neg_risk),
         expiration=0,
         funder_address=ctx.wallet,
         offered_amount=offered,

--- a/src/polymarket/_internal/actions/orders/place.py
+++ b/src/polymarket/_internal/actions/orders/place.py
@@ -9,7 +9,6 @@ from polymarket._internal.actions.orders.allowance import (
     fetch_current_order_allowance_sync,
 )
 from polymarket._internal.actions.orders.context import resolve_exchange_address
-from polymarket._internal.environment import get_environment_config
 from polymarket._internal.wallet import signature_type_for
 from polymarket.errors import RequestRejectedError
 from polymarket.models.clob import AssetType
@@ -79,9 +78,8 @@ async def _approve_order_if_under_allowance(
     client: AsyncSecureClient, signed_order: SignedOrder
 ) -> bool:
     ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
-    env = ctx.environment
     metadata = await ctx.order_metadata.resolve_market(ctx, token_id=signed_order.token_id)
-    spender = resolve_exchange_address(env, metadata.neg_risk)
+    spender = resolve_exchange_address(ctx.environment_config, metadata.neg_risk)
     current = await fetch_current_order_allowance(
         ctx, side=signed_order.side, token_id=signed_order.token_id, spender=spender
     )
@@ -91,13 +89,13 @@ async def _approve_order_if_under_allowance(
 
     if signed_order.side == "BUY":
         handle = await client.approve_erc20(
-            token_address=get_environment_config(env).collateral_token,
+            token_address=ctx.environment_config.collateral_token,
             spender_address=str(spender),
             amount="max",
         )
     else:
         handle = await client.approve_erc1155_for_all(
-            token_address=get_environment_config(env).conditional_tokens,
+            token_address=ctx.environment_config.conditional_tokens,
             operator_address=str(spender),
         )
     await handle.wait()
@@ -107,9 +105,8 @@ async def _approve_order_if_under_allowance(
 
 def _approve_order_if_under_allowance_sync(client: SecureClient, signed_order: SignedOrder) -> bool:
     ctx = client._ctx  # pyright: ignore[reportPrivateUsage]
-    env = ctx.environment
     metadata = ctx.order_metadata.resolve_market(ctx, token_id=signed_order.token_id)
-    spender = resolve_exchange_address(env, metadata.neg_risk)
+    spender = resolve_exchange_address(ctx.environment_config, metadata.neg_risk)
     current = fetch_current_order_allowance_sync(
         ctx, side=signed_order.side, token_id=signed_order.token_id, spender=spender
     )
@@ -119,13 +116,13 @@ def _approve_order_if_under_allowance_sync(client: SecureClient, signed_order: S
 
     if signed_order.side == "BUY":
         handle = client.approve_erc20(
-            token_address=get_environment_config(env).collateral_token,
+            token_address=ctx.environment_config.collateral_token,
             spender_address=str(spender),
             amount="max",
         )
     else:
         handle = client.approve_erc1155_for_all(
-            token_address=get_environment_config(env).conditional_tokens,
+            token_address=ctx.environment_config.conditional_tokens,
             operator_address=str(spender),
         )
     handle.wait()

--- a/src/polymarket/_internal/actions/orders/place.py
+++ b/src/polymarket/_internal/actions/orders/place.py
@@ -9,6 +9,7 @@ from polymarket._internal.actions.orders.allowance import (
     fetch_current_order_allowance_sync,
 )
 from polymarket._internal.actions.orders.context import resolve_exchange_address
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.wallet import signature_type_for
 from polymarket.errors import RequestRejectedError
 from polymarket.models.clob import AssetType
@@ -90,13 +91,13 @@ async def _approve_order_if_under_allowance(
 
     if signed_order.side == "BUY":
         handle = await client.approve_erc20(
-            token_address=env.collateral_token,
+            token_address=get_environment_config(env).collateral_token,
             spender_address=str(spender),
             amount="max",
         )
     else:
         handle = await client.approve_erc1155_for_all(
-            token_address=env.conditional_tokens,
+            token_address=get_environment_config(env).conditional_tokens,
             operator_address=str(spender),
         )
     await handle.wait()
@@ -118,13 +119,13 @@ def _approve_order_if_under_allowance_sync(client: SecureClient, signed_order: S
 
     if signed_order.side == "BUY":
         handle = client.approve_erc20(
-            token_address=env.collateral_token,
+            token_address=get_environment_config(env).collateral_token,
             spender_address=str(spender),
             amount="max",
         )
     else:
         handle = client.approve_erc1155_for_all(
-            token_address=env.conditional_tokens,
+            token_address=get_environment_config(env).conditional_tokens,
             operator_address=str(spender),
         )
     handle.wait()

--- a/src/polymarket/_internal/actions/relayer/approvals.py
+++ b/src/polymarket/_internal/actions/relayer/approvals.py
@@ -13,9 +13,8 @@ from polymarket._internal.actions.relayer.calls import (
     erc1155_is_approved_for_all_call,
     erc1155_set_approval_for_all_call,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import EnvironmentConfig
 from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
-from polymarket.environments import Environment
 from polymarket.types import EvmAddress
 
 
@@ -33,9 +32,9 @@ class _Erc1155TradingApproval:
 
 
 async def resolve_missing_trading_approval_calls(
-    rpc: JsonRpcClient, *, wallet: EvmAddress, environment: Environment
+    rpc: JsonRpcClient, *, wallet: EvmAddress, config: EnvironmentConfig
 ) -> list[TransactionCall]:
-    erc20, erc1155 = _required_trading_approvals(environment)
+    erc20, erc1155 = _required_trading_approvals(config)
     erc20_checks = [
         erc20_allowance_call(
             token_address=approval.token_address,
@@ -84,9 +83,9 @@ async def resolve_missing_trading_approval_calls(
 
 
 def resolve_missing_trading_approval_calls_sync(
-    rpc: SyncJsonRpcClient, *, wallet: EvmAddress, environment: Environment
+    rpc: SyncJsonRpcClient, *, wallet: EvmAddress, config: EnvironmentConfig
 ) -> list[TransactionCall]:
-    erc20, erc1155 = _required_trading_approvals(environment)
+    erc20, erc1155 = _required_trading_approvals(config)
     erc20_checks = [
         erc20_allowance_call(
             token_address=approval.token_address,
@@ -135,92 +134,80 @@ def resolve_missing_trading_approval_calls_sync(
 
 
 def _required_trading_approvals(
-    environment: Environment,
+    config: EnvironmentConfig,
 ) -> tuple[list[_Erc20TradingApproval], list[_Erc1155TradingApproval]]:
-    collateral = cast(EvmAddress, get_environment_config(environment).collateral_token)
-    conditional = cast(EvmAddress, get_environment_config(environment).conditional_tokens)
+    collateral = cast(EvmAddress, config.collateral_token)
+    conditional = cast(EvmAddress, config.conditional_tokens)
     return (
         [
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, get_environment_config(environment).standard_exchange),
+                spender=cast(EvmAddress, config.standard_exchange),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, get_environment_config(environment).neg_risk_exchange),
+                spender=cast(EvmAddress, config.neg_risk_exchange),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, get_environment_config(environment).collateral_adapter),
+                spender=cast(EvmAddress, config.collateral_adapter),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(
-                    EvmAddress, get_environment_config(environment).neg_risk_collateral_adapter
-                ),
+                spender=cast(EvmAddress, config.neg_risk_collateral_adapter),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, get_environment_config(environment).protocol_v2_router),
+                spender=cast(EvmAddress, config.protocol_v2_router),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, get_environment_config(environment).exchange_v3),
+                spender=cast(EvmAddress, config.exchange_v3),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(
-                    EvmAddress, get_environment_config(environment).perps_deposit_contract
-                ),
+                spender=cast(EvmAddress, config.perps_deposit_contract),
                 amount=MAX_UINT256,
             ),
         ],
         [
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, get_environment_config(environment).standard_exchange),
+                operator=cast(EvmAddress, config.standard_exchange),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, get_environment_config(environment).neg_risk_exchange),
+                operator=cast(EvmAddress, config.neg_risk_exchange),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, get_environment_config(environment).collateral_adapter),
+                operator=cast(EvmAddress, config.collateral_adapter),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(
-                    EvmAddress, get_environment_config(environment).neg_risk_collateral_adapter
-                ),
+                operator=cast(EvmAddress, config.neg_risk_collateral_adapter),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, get_environment_config(environment).auto_redeem_operator),
+                operator=cast(EvmAddress, config.auto_redeem_operator),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(
-                    EvmAddress, get_environment_config(environment).position_manager
-                ),
-                operator=cast(EvmAddress, get_environment_config(environment).protocol_v2_router),
+                token_address=cast(EvmAddress, config.position_manager),
+                operator=cast(EvmAddress, config.protocol_v2_router),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(
-                    EvmAddress, get_environment_config(environment).position_manager
-                ),
-                operator=cast(EvmAddress, get_environment_config(environment).exchange_v3),
+                token_address=cast(EvmAddress, config.position_manager),
+                operator=cast(EvmAddress, config.exchange_v3),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(
-                    EvmAddress, get_environment_config(environment).position_manager
-                ),
-                operator=cast(EvmAddress, get_environment_config(environment).auto_redeem_operator),
+                token_address=cast(EvmAddress, config.position_manager),
+                operator=cast(EvmAddress, config.auto_redeem_operator),
             ),
         ],
     )

--- a/src/polymarket/_internal/actions/relayer/approvals.py
+++ b/src/polymarket/_internal/actions/relayer/approvals.py
@@ -13,6 +13,7 @@ from polymarket._internal.actions.relayer.calls import (
     erc1155_is_approved_for_all_call,
     erc1155_set_approval_for_all_call,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
 from polymarket.environments import Environment
 from polymarket.types import EvmAddress
@@ -136,78 +137,90 @@ def resolve_missing_trading_approval_calls_sync(
 def _required_trading_approvals(
     environment: Environment,
 ) -> tuple[list[_Erc20TradingApproval], list[_Erc1155TradingApproval]]:
-    collateral = cast(EvmAddress, environment.collateral_token)
-    conditional = cast(EvmAddress, environment.conditional_tokens)
+    collateral = cast(EvmAddress, get_environment_config(environment).collateral_token)
+    conditional = cast(EvmAddress, get_environment_config(environment).conditional_tokens)
     return (
         [
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.standard_exchange),
+                spender=cast(EvmAddress, get_environment_config(environment).standard_exchange),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.neg_risk_exchange),
+                spender=cast(EvmAddress, get_environment_config(environment).neg_risk_exchange),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.collateral_adapter),
+                spender=cast(EvmAddress, get_environment_config(environment).collateral_adapter),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.neg_risk_collateral_adapter),
+                spender=cast(
+                    EvmAddress, get_environment_config(environment).neg_risk_collateral_adapter
+                ),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.protocol_v2_router),
+                spender=cast(EvmAddress, get_environment_config(environment).protocol_v2_router),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.exchange_v3),
+                spender=cast(EvmAddress, get_environment_config(environment).exchange_v3),
                 amount=MAX_UINT256,
             ),
             _Erc20TradingApproval(
                 token_address=collateral,
-                spender=cast(EvmAddress, environment.perps_deposit_contract),
+                spender=cast(
+                    EvmAddress, get_environment_config(environment).perps_deposit_contract
+                ),
                 amount=MAX_UINT256,
             ),
         ],
         [
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, environment.standard_exchange),
+                operator=cast(EvmAddress, get_environment_config(environment).standard_exchange),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, environment.neg_risk_exchange),
+                operator=cast(EvmAddress, get_environment_config(environment).neg_risk_exchange),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, environment.collateral_adapter),
+                operator=cast(EvmAddress, get_environment_config(environment).collateral_adapter),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, environment.neg_risk_collateral_adapter),
+                operator=cast(
+                    EvmAddress, get_environment_config(environment).neg_risk_collateral_adapter
+                ),
             ),
             _Erc1155TradingApproval(
                 token_address=conditional,
-                operator=cast(EvmAddress, environment.auto_redeem_operator),
+                operator=cast(EvmAddress, get_environment_config(environment).auto_redeem_operator),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(EvmAddress, environment.position_manager),
-                operator=cast(EvmAddress, environment.protocol_v2_router),
+                token_address=cast(
+                    EvmAddress, get_environment_config(environment).position_manager
+                ),
+                operator=cast(EvmAddress, get_environment_config(environment).protocol_v2_router),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(EvmAddress, environment.position_manager),
-                operator=cast(EvmAddress, environment.exchange_v3),
+                token_address=cast(
+                    EvmAddress, get_environment_config(environment).position_manager
+                ),
+                operator=cast(EvmAddress, get_environment_config(environment).exchange_v3),
             ),
             _Erc1155TradingApproval(
-                token_address=cast(EvmAddress, environment.position_manager),
-                operator=cast(EvmAddress, environment.auto_redeem_operator),
+                token_address=cast(
+                    EvmAddress, get_environment_config(environment).position_manager
+                ),
+                operator=cast(EvmAddress, get_environment_config(environment).auto_redeem_operator),
             ),
         ],
     )

--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -33,7 +33,6 @@ from polymarket._internal.actions.relayer.submit import (
     submit_gasless_sync,
 )
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
-from polymarket._internal.environment import get_environment_config
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import (
     RelayerExecuteResponse,
@@ -84,8 +83,7 @@ async def submit_gasless_with_retry(
     submit: Callable[[], Awaitable[RelayerExecuteResponse]],
 ) -> GaslessTransactionHandle:
     """Run a gasless submit, retrying transient relayer rejections."""
-    env = ctx.environment
-    poll_delay_s = get_environment_config(env).relayer_poll_frequency_ms / 1000
+    poll_delay_s = ctx.environment_config.relayer_poll_frequency_ms / 1000
     for attempt in range(GASLESS_SUBMIT_RETRY_ATTEMPTS + 1):
         try:
             response = await submit()
@@ -98,7 +96,7 @@ async def submit_gasless_with_retry(
                 transaction_id=response.transaction_id,
                 transaction_hash=response.transaction_hash,
                 _relayer=ctx.relayer,
-                _max_polls=get_environment_config(env).relayer_max_polls,
+                _max_polls=ctx.environment_config.relayer_max_polls,
                 _poll_delay_s=poll_delay_s,
             )
     raise AssertionError("unreachable")
@@ -161,13 +159,11 @@ async def build_signed_deposit_wallet_payload(
         calls=calls,
         nonce=nonce,
         deadline=deadline,
-        chain_id=get_environment_config(ctx.environment).chain_id,
+        chain_id=ctx.environment_config.chain_id,
     )
     return build_deposit_wallet_payload(
         signer_address=ctx.signer.address,
-        deposit_wallet_factory=get_environment_config(
-            ctx.environment
-        ).wallet_derivation.deposit_wallet_factory,
+        deposit_wallet_factory=ctx.environment_config.wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
         nonce=nonce,
@@ -216,7 +212,7 @@ async def build_signed_proxy_payload(
     params = await fetch_relay_payload(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.PROXY
     )
-    to = get_environment_config(ctx.environment).wallet_derivation.proxy_factory
+    to = ctx.environment_config.wallet_derivation.proxy_factory
     data = encode_proxy_call(calls)
     relay = EvmAddress(params.address)
     gas_limit = await _estimate_proxy_gas_limit(
@@ -230,7 +226,7 @@ async def build_signed_proxy_payload(
         gas_price=_PROXY_GAS_PRICE,
         gas_limit=gas_limit,
         nonce=params.nonce,
-        relay_hub=EvmAddress(get_environment_config(ctx.environment).relay_hub),
+        relay_hub=EvmAddress(ctx.environment_config.relay_hub),
         relay=relay,
     )
     signature = sign_proxy_message(ctx.signer, hash_)
@@ -243,7 +239,7 @@ async def build_signed_proxy_payload(
         signature=signature,
         gas_limit=gas_limit,
         relay=relay,
-        relay_hub=get_environment_config(ctx.environment).relay_hub,
+        relay_hub=ctx.environment_config.relay_hub,
         metadata=metadata,
     )
 
@@ -306,7 +302,7 @@ async def build_signed_safe_payload(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
     )
     target, data, value, operation = _resolve_safe_call(
-        get_environment_config(ctx.environment).safe_multisend, calls
+        ctx.environment_config.safe_multisend, calls
     )
     signature = sign_safe_transaction(
         ctx.signer,
@@ -316,7 +312,7 @@ async def build_signed_safe_payload(
         value=value,
         operation=operation,
         nonce=params.nonce,
-        chain_id=get_environment_config(ctx.environment).chain_id,
+        chain_id=ctx.environment_config.chain_id,
     )
     return build_safe_payload(
         signer_address=ctx.signer.address,
@@ -395,18 +391,17 @@ async def submit_deposit_wallet_create(
         {
             "type": RelayerTransactionType.WALLET_CREATE.value,
             "from": ctx.signer.address,
-            "to": get_environment_config(ctx.environment).wallet_derivation.deposit_wallet_factory,
+            "to": ctx.environment_config.wallet_derivation.deposit_wallet_factory,
             "metadata": metadata,
         }
     )
     response = await submit_gasless(ctx.relayer, payload=payload)
-    env = ctx.environment
     return GaslessTransactionHandle(
         transaction_id=response.transaction_id,
         transaction_hash=response.transaction_hash,
         _relayer=ctx.relayer,
-        _max_polls=get_environment_config(env).relayer_max_polls,
-        _poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
+        _max_polls=ctx.environment_config.relayer_max_polls,
+        _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
     )
 
 
@@ -442,8 +437,7 @@ def submit_gasless_with_retry_sync(
     submit: Callable[[], RelayerExecuteResponse],
 ) -> SyncGaslessTransactionHandle:
     """Run a gasless submit, retrying transient relayer rejections."""
-    env = ctx.environment
-    poll_delay_s = get_environment_config(env).relayer_poll_frequency_ms / 1000
+    poll_delay_s = ctx.environment_config.relayer_poll_frequency_ms / 1000
     for attempt in range(GASLESS_SUBMIT_RETRY_ATTEMPTS + 1):
         try:
             response = submit()
@@ -456,7 +450,7 @@ def submit_gasless_with_retry_sync(
                 transaction_id=response.transaction_id,
                 transaction_hash=response.transaction_hash,
                 _relayer=ctx.relayer,
-                _max_polls=get_environment_config(env).relayer_max_polls,
+                _max_polls=ctx.environment_config.relayer_max_polls,
                 _poll_delay_s=poll_delay_s,
             )
     raise AssertionError("unreachable")
@@ -519,13 +513,11 @@ def build_signed_deposit_wallet_payload_sync(
         calls=calls,
         nonce=nonce,
         deadline=deadline,
-        chain_id=get_environment_config(ctx.environment).chain_id,
+        chain_id=ctx.environment_config.chain_id,
     )
     return build_deposit_wallet_payload(
         signer_address=ctx.signer.address,
-        deposit_wallet_factory=get_environment_config(
-            ctx.environment
-        ).wallet_derivation.deposit_wallet_factory,
+        deposit_wallet_factory=ctx.environment_config.wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
         nonce=nonce,
@@ -544,7 +536,7 @@ def build_signed_proxy_payload_sync(
     params = fetch_relay_payload_sync(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.PROXY
     )
-    to = get_environment_config(ctx.environment).wallet_derivation.proxy_factory
+    to = ctx.environment_config.wallet_derivation.proxy_factory
     data = encode_proxy_call(calls)
     relay = EvmAddress(params.address)
     gas_limit = _estimate_proxy_gas_limit_sync(
@@ -558,7 +550,7 @@ def build_signed_proxy_payload_sync(
         gas_price=_PROXY_GAS_PRICE,
         gas_limit=gas_limit,
         nonce=params.nonce,
-        relay_hub=EvmAddress(get_environment_config(ctx.environment).relay_hub),
+        relay_hub=EvmAddress(ctx.environment_config.relay_hub),
         relay=relay,
     )
     signature = sign_proxy_message(ctx.signer, hash_)
@@ -571,7 +563,7 @@ def build_signed_proxy_payload_sync(
         signature=signature,
         gas_limit=gas_limit,
         relay=relay,
-        relay_hub=get_environment_config(ctx.environment).relay_hub,
+        relay_hub=ctx.environment_config.relay_hub,
         metadata=metadata,
     )
 
@@ -600,7 +592,7 @@ def build_signed_safe_payload_sync(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
     )
     target, data, value, operation = _resolve_safe_call(
-        get_environment_config(ctx.environment).safe_multisend, calls
+        ctx.environment_config.safe_multisend, calls
     )
     signature = sign_safe_transaction(
         ctx.signer,
@@ -610,7 +602,7 @@ def build_signed_safe_payload_sync(
         value=value,
         operation=operation,
         nonce=params.nonce,
-        chain_id=get_environment_config(ctx.environment).chain_id,
+        chain_id=ctx.environment_config.chain_id,
     )
     return build_safe_payload(
         signer_address=ctx.signer.address,
@@ -641,18 +633,17 @@ def submit_deposit_wallet_create_sync(
         {
             "type": RelayerTransactionType.WALLET_CREATE.value,
             "from": ctx.signer.address,
-            "to": get_environment_config(ctx.environment).wallet_derivation.deposit_wallet_factory,
+            "to": ctx.environment_config.wallet_derivation.deposit_wallet_factory,
             "metadata": metadata,
         }
     )
     response = submit_gasless_sync(ctx.relayer, payload=payload)
-    env = ctx.environment
     return SyncGaslessTransactionHandle(
         transaction_id=response.transaction_id,
         transaction_hash=response.transaction_hash,
         _relayer=ctx.relayer,
-        _max_polls=get_environment_config(env).relayer_max_polls,
-        _poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
+        _max_polls=ctx.environment_config.relayer_max_polls,
+        _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
     )
 
 

--- a/src/polymarket/_internal/actions/relayer/gasless.py
+++ b/src/polymarket/_internal/actions/relayer/gasless.py
@@ -33,6 +33,7 @@ from polymarket._internal.actions.relayer.submit import (
     submit_gasless_sync,
 )
 from polymarket._internal.context import AsyncSecureClientContext, SyncSecureClientContext
+from polymarket._internal.environment import get_environment_config
 from polymarket.errors import RequestRejectedError, UserInputError
 from polymarket.models.clob.relayer import (
     RelayerExecuteResponse,
@@ -84,7 +85,7 @@ async def submit_gasless_with_retry(
 ) -> GaslessTransactionHandle:
     """Run a gasless submit, retrying transient relayer rejections."""
     env = ctx.environment
-    poll_delay_s = env.relayer_poll_frequency_ms / 1000
+    poll_delay_s = get_environment_config(env).relayer_poll_frequency_ms / 1000
     for attempt in range(GASLESS_SUBMIT_RETRY_ATTEMPTS + 1):
         try:
             response = await submit()
@@ -97,7 +98,7 @@ async def submit_gasless_with_retry(
                 transaction_id=response.transaction_id,
                 transaction_hash=response.transaction_hash,
                 _relayer=ctx.relayer,
-                _max_polls=env.relayer_max_polls,
+                _max_polls=get_environment_config(env).relayer_max_polls,
                 _poll_delay_s=poll_delay_s,
             )
     raise AssertionError("unreachable")
@@ -160,11 +161,13 @@ async def build_signed_deposit_wallet_payload(
         calls=calls,
         nonce=nonce,
         deadline=deadline,
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
     )
     return build_deposit_wallet_payload(
         signer_address=ctx.signer.address,
-        deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
+        deposit_wallet_factory=get_environment_config(
+            ctx.environment
+        ).wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
         nonce=nonce,
@@ -213,7 +216,7 @@ async def build_signed_proxy_payload(
     params = await fetch_relay_payload(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.PROXY
     )
-    to = ctx.environment.wallet_derivation.proxy_factory
+    to = get_environment_config(ctx.environment).wallet_derivation.proxy_factory
     data = encode_proxy_call(calls)
     relay = EvmAddress(params.address)
     gas_limit = await _estimate_proxy_gas_limit(
@@ -227,7 +230,7 @@ async def build_signed_proxy_payload(
         gas_price=_PROXY_GAS_PRICE,
         gas_limit=gas_limit,
         nonce=params.nonce,
-        relay_hub=EvmAddress(ctx.environment.relay_hub),
+        relay_hub=EvmAddress(get_environment_config(ctx.environment).relay_hub),
         relay=relay,
     )
     signature = sign_proxy_message(ctx.signer, hash_)
@@ -240,7 +243,7 @@ async def build_signed_proxy_payload(
         signature=signature,
         gas_limit=gas_limit,
         relay=relay,
-        relay_hub=ctx.environment.relay_hub,
+        relay_hub=get_environment_config(ctx.environment).relay_hub,
         metadata=metadata,
     )
 
@@ -302,7 +305,9 @@ async def build_signed_safe_payload(
     params = await fetch_execute_params(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
     )
-    target, data, value, operation = _resolve_safe_call(ctx.environment.safe_multisend, calls)
+    target, data, value, operation = _resolve_safe_call(
+        get_environment_config(ctx.environment).safe_multisend, calls
+    )
     signature = sign_safe_transaction(
         ctx.signer,
         safe_address=ctx.wallet,
@@ -311,7 +316,7 @@ async def build_signed_safe_payload(
         value=value,
         operation=operation,
         nonce=params.nonce,
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
     )
     return build_safe_payload(
         signer_address=ctx.signer.address,
@@ -390,7 +395,7 @@ async def submit_deposit_wallet_create(
         {
             "type": RelayerTransactionType.WALLET_CREATE.value,
             "from": ctx.signer.address,
-            "to": ctx.environment.wallet_derivation.deposit_wallet_factory,
+            "to": get_environment_config(ctx.environment).wallet_derivation.deposit_wallet_factory,
             "metadata": metadata,
         }
     )
@@ -400,8 +405,8 @@ async def submit_deposit_wallet_create(
         transaction_id=response.transaction_id,
         transaction_hash=response.transaction_hash,
         _relayer=ctx.relayer,
-        _max_polls=env.relayer_max_polls,
-        _poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+        _max_polls=get_environment_config(env).relayer_max_polls,
+        _poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
     )
 
 
@@ -438,7 +443,7 @@ def submit_gasless_with_retry_sync(
 ) -> SyncGaslessTransactionHandle:
     """Run a gasless submit, retrying transient relayer rejections."""
     env = ctx.environment
-    poll_delay_s = env.relayer_poll_frequency_ms / 1000
+    poll_delay_s = get_environment_config(env).relayer_poll_frequency_ms / 1000
     for attempt in range(GASLESS_SUBMIT_RETRY_ATTEMPTS + 1):
         try:
             response = submit()
@@ -451,7 +456,7 @@ def submit_gasless_with_retry_sync(
                 transaction_id=response.transaction_id,
                 transaction_hash=response.transaction_hash,
                 _relayer=ctx.relayer,
-                _max_polls=env.relayer_max_polls,
+                _max_polls=get_environment_config(env).relayer_max_polls,
                 _poll_delay_s=poll_delay_s,
             )
     raise AssertionError("unreachable")
@@ -514,11 +519,13 @@ def build_signed_deposit_wallet_payload_sync(
         calls=calls,
         nonce=nonce,
         deadline=deadline,
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
     )
     return build_deposit_wallet_payload(
         signer_address=ctx.signer.address,
-        deposit_wallet_factory=ctx.environment.wallet_derivation.deposit_wallet_factory,
+        deposit_wallet_factory=get_environment_config(
+            ctx.environment
+        ).wallet_derivation.deposit_wallet_factory,
         wallet=ctx.wallet,
         calls=calls,
         nonce=nonce,
@@ -537,7 +544,7 @@ def build_signed_proxy_payload_sync(
     params = fetch_relay_payload_sync(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.PROXY
     )
-    to = ctx.environment.wallet_derivation.proxy_factory
+    to = get_environment_config(ctx.environment).wallet_derivation.proxy_factory
     data = encode_proxy_call(calls)
     relay = EvmAddress(params.address)
     gas_limit = _estimate_proxy_gas_limit_sync(
@@ -551,7 +558,7 @@ def build_signed_proxy_payload_sync(
         gas_price=_PROXY_GAS_PRICE,
         gas_limit=gas_limit,
         nonce=params.nonce,
-        relay_hub=EvmAddress(ctx.environment.relay_hub),
+        relay_hub=EvmAddress(get_environment_config(ctx.environment).relay_hub),
         relay=relay,
     )
     signature = sign_proxy_message(ctx.signer, hash_)
@@ -564,7 +571,7 @@ def build_signed_proxy_payload_sync(
         signature=signature,
         gas_limit=gas_limit,
         relay=relay,
-        relay_hub=ctx.environment.relay_hub,
+        relay_hub=get_environment_config(ctx.environment).relay_hub,
         metadata=metadata,
     )
 
@@ -592,7 +599,9 @@ def build_signed_safe_payload_sync(
     params = fetch_execute_params_sync(
         ctx.relayer, address=ctx.signer.address, type=RelayerTransactionType.SAFE
     )
-    target, data, value, operation = _resolve_safe_call(ctx.environment.safe_multisend, calls)
+    target, data, value, operation = _resolve_safe_call(
+        get_environment_config(ctx.environment).safe_multisend, calls
+    )
     signature = sign_safe_transaction(
         ctx.signer,
         safe_address=ctx.wallet,
@@ -601,7 +610,7 @@ def build_signed_safe_payload_sync(
         value=value,
         operation=operation,
         nonce=params.nonce,
-        chain_id=ctx.environment.chain_id,
+        chain_id=get_environment_config(ctx.environment).chain_id,
     )
     return build_safe_payload(
         signer_address=ctx.signer.address,
@@ -632,7 +641,7 @@ def submit_deposit_wallet_create_sync(
         {
             "type": RelayerTransactionType.WALLET_CREATE.value,
             "from": ctx.signer.address,
-            "to": ctx.environment.wallet_derivation.deposit_wallet_factory,
+            "to": get_environment_config(ctx.environment).wallet_derivation.deposit_wallet_factory,
             "metadata": metadata,
         }
     )
@@ -642,8 +651,8 @@ def submit_deposit_wallet_create_sync(
         transaction_id=response.transaction_id,
         transaction_hash=response.transaction_hash,
         _relayer=ctx.relayer,
-        _max_polls=env.relayer_max_polls,
-        _poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+        _max_polls=get_environment_config(env).relayer_max_polls,
+        _poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
     )
 
 

--- a/src/polymarket/_internal/context.py
+++ b/src/polymarket/_internal/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 
 from eth_account.signers.local import LocalAccount
 
@@ -8,6 +8,7 @@ from polymarket._internal.actions.orders.cache import (
     AsyncOrderMetadataCache,
     SyncOrderMetadataCache,
 )
+from polymarket._internal.environment import EnvironmentConfig, get_environment_config
 from polymarket._internal.eoa.rpc import JsonRpcClient, SyncJsonRpcClient
 from polymarket._internal.wallet import WalletType
 from polymarket.auth import ApiKey
@@ -17,16 +18,22 @@ from polymarket.models.clob import ApiKeyCreds
 from polymarket.types import EvmAddress
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class SyncClientContext:
     environment: Environment
+    environment_config: EnvironmentConfig = field(init=False, repr=False)
     gamma: SyncTransport
     data: SyncTransport
     rfq: SyncTransport
     clob: SyncTransport
+    _resolved_environment_config: InitVar[EnvironmentConfig | None] = None
+
+    def __post_init__(self, _resolved_environment_config: EnvironmentConfig | None) -> None:
+        config = _resolved_environment_config or get_environment_config(self.environment)
+        object.__setattr__(self, "environment_config", config)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class SyncSecureClientContext(SyncClientContext):
     signer: LocalAccount
     credentials: ApiKeyCreds
@@ -40,17 +47,23 @@ class SyncSecureClientContext(SyncClientContext):
     order_metadata: SyncOrderMetadataCache
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class AsyncClientContext:
     environment: Environment
+    environment_config: EnvironmentConfig = field(init=False, repr=False)
     gamma: AsyncTransport
     data: AsyncTransport
     rfq: AsyncTransport
     clob: AsyncTransport
     perps: AsyncTransport
+    _resolved_environment_config: InitVar[EnvironmentConfig | None] = None
+
+    def __post_init__(self, _resolved_environment_config: EnvironmentConfig | None) -> None:
+        config = _resolved_environment_config or get_environment_config(self.environment)
+        object.__setattr__(self, "environment_config", config)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class AsyncSecureClientContext(AsyncClientContext):
     signer: LocalAccount
     credentials: ApiKeyCreds

--- a/src/polymarket/_internal/environment.py
+++ b/src/polymarket/_internal/environment.py
@@ -1,0 +1,30 @@
+from polymarket.environments import (
+    Environment,
+    _create_environment,  # pyright: ignore[reportPrivateUsage]
+    _EnvironmentConfig,  # pyright: ignore[reportPrivateUsage]
+    _WalletDerivation,  # pyright: ignore[reportPrivateUsage]
+)
+
+EnvironmentConfig = _EnvironmentConfig
+WalletDerivationConfig = _WalletDerivation
+
+
+def get_environment_config(environment: Environment) -> _EnvironmentConfig:
+    return environment._config  # pyright: ignore[reportPrivateUsage]
+
+
+def create_environment(*, name: str, config: EnvironmentConfig) -> Environment:
+    return _create_environment(name=name, config=config)
+
+
+def with_environment_config(environment: Environment, *, config: EnvironmentConfig) -> Environment:
+    return create_environment(name=environment.name, config=config)
+
+
+__all__ = [
+    "EnvironmentConfig",
+    "WalletDerivationConfig",
+    "create_environment",
+    "get_environment_config",
+    "with_environment_config",
+]

--- a/src/polymarket/_internal/environment.py
+++ b/src/polymarket/_internal/environment.py
@@ -1,4 +1,5 @@
 from polymarket.environments import (
+    PRODUCTION,
     Environment,
     _create_environment,  # pyright: ignore[reportPrivateUsage]
     _EnvironmentConfig,  # pyright: ignore[reportPrivateUsage]
@@ -13,6 +14,9 @@ def get_environment_config(environment: Environment) -> _EnvironmentConfig:
     return environment._config  # pyright: ignore[reportPrivateUsage]
 
 
+PRODUCTION_CONFIG = get_environment_config(PRODUCTION)
+
+
 def create_environment(*, name: str, config: EnvironmentConfig) -> Environment:
     return _create_environment(name=name, config=config)
 
@@ -23,6 +27,7 @@ def with_environment_config(environment: Environment, *, config: EnvironmentConf
 
 __all__ = [
     "EnvironmentConfig",
+    "PRODUCTION_CONFIG",
     "WalletDerivationConfig",
     "create_environment",
     "get_environment_config",

--- a/src/polymarket/_internal/eoa/rpc.py
+++ b/src/polymarket/_internal/eoa/rpc.py
@@ -56,14 +56,14 @@ class JsonRpcClient:
             if self._verified_chain_id != expected:
                 raise UserInputError(
                     f"RPC chain id {self._verified_chain_id} does not match "
-                    f"environment.chain_id {expected}. Configure rpc_url for the correct chain."
+                    f"environment chain id {expected}. Configure the client for the correct chain."
                 )
             return
         actual = await self.eth_chain_id()
         if actual != expected:
             raise UserInputError(
-                f"RPC chain id {actual} does not match environment.chain_id {expected}. "
-                "Configure rpc_url for the correct chain."
+                f"RPC chain id {actual} does not match environment chain id {expected}. "
+                "Configure the client for the correct chain."
             )
         self._verified_chain_id = actual
 
@@ -167,14 +167,14 @@ class SyncJsonRpcClient:
             if self._verified_chain_id != expected:
                 raise UserInputError(
                     f"RPC chain id {self._verified_chain_id} does not match "
-                    f"environment.chain_id {expected}. Configure rpc_url for the correct chain."
+                    f"environment chain id {expected}. Configure the client for the correct chain."
                 )
             return
         actual = self.eth_chain_id()
         if actual != expected:
             raise UserInputError(
-                f"RPC chain id {actual} does not match environment.chain_id {expected}. "
-                "Configure rpc_url for the correct chain."
+                f"RPC chain id {actual} does not match environment chain id {expected}. "
+                "Configure the client for the correct chain."
             )
         self._verified_chain_id = actual
 

--- a/src/polymarket/_internal/wallet.py
+++ b/src/polymarket/_internal/wallet.py
@@ -7,12 +7,12 @@ from eth_abi.packed import encode_packed
 from eth_utils.address import to_checksum_address
 from eth_utils.crypto import keccak
 
+from polymarket._internal.environment import WalletDerivationConfig
 from polymarket._internal.eoa.rpc import (
     JsonRpcClient,
     SyncJsonRpcClient,
     is_json_rpc_contract_revert,
 )
-from polymarket.environments import WalletDerivation
 from polymarket.errors import UserInputError
 
 WalletType: TypeAlias = Literal["EOA", "POLY_PROXY", "GNOSIS_SAFE", "DEPOSIT_WALLET"]
@@ -55,7 +55,7 @@ def signature_type_for(wallet_type: WalletType) -> int:
     return _SIGNATURE_TYPE_BY_WALLET[wallet_type]
 
 
-def derive_proxy_wallet_address(signer: str, config: WalletDerivation) -> str:
+def derive_proxy_wallet_address(signer: str, config: WalletDerivationConfig) -> str:
     bytecode = bytes.fromhex(
         _PROXY_BYTECODE_TEMPLATE.format(
             factory=_strip_0x(config.proxy_factory).lower(),
@@ -67,20 +67,20 @@ def derive_proxy_wallet_address(signer: str, config: WalletDerivation) -> str:
     return _create2(config.proxy_factory, salt, bytecode_hash)
 
 
-def derive_safe_wallet_address(signer: str, config: WalletDerivation) -> str:
+def derive_safe_wallet_address(signer: str, config: WalletDerivationConfig) -> str:
     bytecode_hash = bytes.fromhex(_strip_0x(config.safe_init_code_hash))
     salt = keccak(abi_encode(["address"], [signer]))
     return _create2(config.safe_factory, salt, bytecode_hash)
 
 
-def derive_uups_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+def derive_uups_deposit_wallet_address(signer: str, config: WalletDerivationConfig) -> str:
     args = _deposit_wallet_args(signer, config)
     bytecode_hash = _uups_deposit_init_code_hash(config.deposit_wallet_implementation, args)
     salt = keccak(args)
     return _create2(config.deposit_wallet_factory, salt, bytecode_hash)
 
 
-def derive_beacon_deposit_wallet_address(signer: str, config: WalletDerivation) -> str:
+def derive_beacon_deposit_wallet_address(signer: str, config: WalletDerivationConfig) -> str:
     args = _deposit_wallet_args(signer, config)
     bytecode_hash = _beacon_deposit_init_code_hash(config.deposit_wallet_beacon, args)
     salt = keccak(args)
@@ -103,7 +103,7 @@ async def is_beacon_deposit_wallet_factory(rpc: JsonRpcClient, factory: str) -> 
 
 
 async def derive_current_deposit_wallet_address(
-    rpc: JsonRpcClient, signer: str, config: WalletDerivation
+    rpc: JsonRpcClient, signer: str, config: WalletDerivationConfig
 ) -> str:
     if await is_beacon_deposit_wallet_factory(rpc, config.deposit_wallet_factory):
         return derive_beacon_deposit_wallet_address(signer, config)
@@ -126,14 +126,14 @@ def is_beacon_deposit_wallet_factory_sync(rpc: SyncJsonRpcClient, factory: str) 
 
 
 def derive_current_deposit_wallet_address_sync(
-    rpc: SyncJsonRpcClient, signer: str, config: WalletDerivation
+    rpc: SyncJsonRpcClient, signer: str, config: WalletDerivationConfig
 ) -> str:
     if is_beacon_deposit_wallet_factory_sync(rpc, config.deposit_wallet_factory):
         return derive_beacon_deposit_wallet_address(signer, config)
     return derive_uups_deposit_wallet_address(signer, config)
 
 
-def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) -> WalletType:
+def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivationConfig) -> WalletType:
     try:
         signer_checksum = to_checksum_address(signer)
     except ValueError as error:
@@ -160,7 +160,7 @@ def classify_wallet_type(*, signer: str, wallet: str, config: WalletDerivation) 
     )
 
 
-def _deposit_wallet_args(signer: str, config: WalletDerivation) -> bytes:
+def _deposit_wallet_args(signer: str, config: WalletDerivationConfig) -> bytes:
     signer_bytes = bytes.fromhex(_strip_0x(signer))
     wallet_id = signer_bytes.rjust(32, b"\x00")
     return abi_encode(["address", "bytes32"], [config.deposit_wallet_factory, wallet_id])

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -153,21 +153,15 @@ class AsyncPublicClient:
         *,
         logger: logging.Logger | None = None,
     ) -> None:
+        config = get_environment_config(environment)
         self._ctx = AsyncClientContext(
             environment=environment,
-            gamma=AsyncTransport(
-                base_url=get_environment_config(environment).gamma_url, logger=logger
-            ),
-            data=AsyncTransport(
-                base_url=get_environment_config(environment).data_url, logger=logger
-            ),
-            rfq=AsyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger),
-            clob=AsyncTransport(
-                base_url=get_environment_config(environment).clob_url, logger=logger
-            ),
-            perps=AsyncTransport(
-                base_url=get_environment_config(environment).perps_url, logger=logger
-            ),
+            _resolved_environment_config=config,
+            gamma=AsyncTransport(base_url=config.gamma_url, logger=logger),
+            data=AsyncTransport(base_url=config.data_url, logger=logger),
+            rfq=AsyncTransport(base_url=config.rfq_url, logger=logger),
+            clob=AsyncTransport(base_url=config.clob_url, logger=logger),
+            perps=AsyncTransport(base_url=config.perps_url, logger=logger),
         )
         self._market_manager: ClobMarketStreamManager | None = None
         self._sports_manager: SportsStreamManager | None = None
@@ -295,7 +289,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.clob.market import ClobMarketStreamManager
 
             self._market_manager = ClobMarketStreamManager(
-                url=get_environment_config(self._ctx.environment).clob_market_ws_url,
+                url=self._ctx.environment_config.clob_market_ws_url,
                 logger=self._streams_logger,
             )
         return self._market_manager
@@ -305,7 +299,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.rtds.manager import RtdsStreamManager
 
             self._rtds_manager = RtdsStreamManager(
-                url=get_environment_config(self._ctx.environment).rtds_ws_url,
+                url=self._ctx.environment_config.rtds_ws_url,
                 logger=self._streams_logger,
             )
         return self._rtds_manager
@@ -315,7 +309,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.sports.manager import SportsStreamManager
 
             self._sports_manager = SportsStreamManager(
-                url=get_environment_config(self._ctx.environment).sports_ws_url,
+                url=self._ctx.environment_config.sports_ws_url,
                 logger=self._streams_logger,
             )
         return self._sports_manager
@@ -325,7 +319,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
 
             self._perps_manager = PerpsMarketStreamManager(
-                url=get_environment_config(self._ctx.environment).perps_ws_url,
+                url=self._ctx.environment_config.perps_ws_url,
                 logger=self._streams_logger,
             )
         return self._perps_manager

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -46,6 +46,7 @@ from polymarket._internal.dispatch import (
     async_paginate_offset,
     async_paginate_page_based,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.streams.handle import AsyncSubscriptionHandle, SubscriptionHandle
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION, Environment
@@ -154,11 +155,19 @@ class AsyncPublicClient:
     ) -> None:
         self._ctx = AsyncClientContext(
             environment=environment,
-            gamma=AsyncTransport(base_url=environment.gamma_url, logger=logger),
-            data=AsyncTransport(base_url=environment.data_url, logger=logger),
-            rfq=AsyncTransport(base_url=environment.rfq_url, logger=logger),
-            clob=AsyncTransport(base_url=environment.clob_url, logger=logger),
-            perps=AsyncTransport(base_url=environment.perps_url, logger=logger),
+            gamma=AsyncTransport(
+                base_url=get_environment_config(environment).gamma_url, logger=logger
+            ),
+            data=AsyncTransport(
+                base_url=get_environment_config(environment).data_url, logger=logger
+            ),
+            rfq=AsyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger),
+            clob=AsyncTransport(
+                base_url=get_environment_config(environment).clob_url, logger=logger
+            ),
+            perps=AsyncTransport(
+                base_url=get_environment_config(environment).perps_url, logger=logger
+            ),
         )
         self._market_manager: ClobMarketStreamManager | None = None
         self._sports_manager: SportsStreamManager | None = None
@@ -286,7 +295,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.clob.market import ClobMarketStreamManager
 
             self._market_manager = ClobMarketStreamManager(
-                url=self._ctx.environment.clob_market_ws_url,
+                url=get_environment_config(self._ctx.environment).clob_market_ws_url,
                 logger=self._streams_logger,
             )
         return self._market_manager
@@ -296,7 +305,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.rtds.manager import RtdsStreamManager
 
             self._rtds_manager = RtdsStreamManager(
-                url=self._ctx.environment.rtds_ws_url,
+                url=get_environment_config(self._ctx.environment).rtds_ws_url,
                 logger=self._streams_logger,
             )
         return self._rtds_manager
@@ -306,7 +315,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.sports.manager import SportsStreamManager
 
             self._sports_manager = SportsStreamManager(
-                url=self._ctx.environment.sports_ws_url,
+                url=get_environment_config(self._ctx.environment).sports_ws_url,
                 logger=self._streams_logger,
             )
         return self._sports_manager
@@ -316,7 +325,7 @@ class AsyncPublicClient:
             from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
 
             self._perps_manager = PerpsMarketStreamManager(
-                url=self._ctx.environment.perps_ws_url,
+                url=get_environment_config(self._ctx.environment).perps_ws_url,
                 logger=self._streams_logger,
             )
         return self._perps_manager

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -127,7 +127,7 @@ from polymarket._internal.dispatch import (
     async_paginate_offset,
     async_paginate_page_based,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import EnvironmentConfig, get_environment_config
 from polymarket._internal.eoa.broadcast import broadcast_eoa_call
 from polymarket._internal.eoa.rpc import JsonRpcClient
 from polymarket._internal.hmac import build_hmac_signature
@@ -396,6 +396,7 @@ class AsyncSecureClient:
         _validate_nonce(nonce)
         if credentials is not None and nonce != 0:
             raise UserInputError("nonce cannot be combined with credentials.")
+        config = get_environment_config(environment)
         try:
             signer = cast(LocalAccount, Account.from_key(private_key))
         except (ValueError, TypeError) as error:
@@ -404,7 +405,7 @@ class AsyncSecureClient:
         resolved_wallet = await _resolve_requested_wallet(
             signer=signer,
             wallet=wallet,
-            environment=environment,
+            config=config,
             logger=logger,
         )
         try:
@@ -412,12 +413,10 @@ class AsyncSecureClient:
         except ValueError as error:
             raise UserInputError(f"Invalid wallet address: {error}") from error
 
-        bootstrap_clob = AsyncTransport(
-            base_url=get_environment_config(environment).clob_url, logger=logger
-        )
+        bootstrap_clob = AsyncTransport(base_url=config.clob_url, logger=logger)
         try:
             resolved_credentials = await _bootstrap_credentials(
-                environment=environment,
+                config=config,
                 signer=signer,
                 clob=bootstrap_clob,
                 provided=credentials,
@@ -432,6 +431,7 @@ class AsyncSecureClient:
             signer=signer,
             wallet=wallet_checksum,
             environment=environment,
+            config=config,
             credentials=resolved_credentials,
             api_key=api_key,
             logger=logger,
@@ -444,6 +444,7 @@ class AsyncSecureClient:
         signer: LocalAccount,
         wallet: str,
         environment: Environment,
+        config: EnvironmentConfig,
         credentials: ApiKeyCreds,
         api_key: ApiKey | None,
         logger: logging.Logger | None,
@@ -452,46 +453,41 @@ class AsyncSecureClient:
         wallet_type = classify_wallet_type(
             signer=signer.address,
             wallet=wallet_checksum,
-            config=get_environment_config(environment).wallet_derivation,
+            config=config.wallet_derivation,
         )
         branded_wallet = cast(EvmAddress, wallet_checksum)
 
-        gamma = AsyncTransport(
-            base_url=get_environment_config(environment).gamma_url, logger=logger
-        )
-        data = AsyncTransport(base_url=get_environment_config(environment).data_url, logger=logger)
-        rfq = AsyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger)
-        clob = AsyncTransport(base_url=get_environment_config(environment).clob_url, logger=logger)
+        gamma = AsyncTransport(base_url=config.gamma_url, logger=logger)
+        data = AsyncTransport(base_url=config.data_url, logger=logger)
+        rfq = AsyncTransport(base_url=config.rfq_url, logger=logger)
+        clob = AsyncTransport(base_url=config.clob_url, logger=logger)
         relayer_resolver = make_relayer_header_resolver(api_key) if api_key is not None else None
         relayer = AsyncTransport(
-            base_url=get_environment_config(environment).relayer_url,
+            base_url=config.relayer_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         combos = AsyncTransport(
-            base_url=get_environment_config(environment).collateral_return_url,
+            base_url=config.collateral_return_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         secure_clob = AsyncTransport(
-            base_url=get_environment_config(environment).clob_url,
+            base_url=config.clob_url,
             logger=logger,
             header_resolver=_make_l2_header_resolver(signer, credentials),
         )
-        rpc_transport = AsyncTransport(
-            base_url=get_environment_config(environment).rpc_url, logger=logger
-        )
+        rpc_transport = AsyncTransport(base_url=config.rpc_url, logger=logger)
         rpc = JsonRpcClient(rpc_transport)
 
         ctx = AsyncSecureClientContext(
             environment=environment,
+            _resolved_environment_config=config,
             gamma=gamma,
             data=data,
             rfq=rfq,
             clob=clob,
-            perps=AsyncTransport(
-                base_url=get_environment_config(environment).perps_url, logger=logger
-            ),
+            perps=AsyncTransport(base_url=config.perps_url, logger=logger),
             signer=signer,
             credentials=credentials,
             secure_clob=secure_clob,
@@ -655,7 +651,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.clob.market import ClobMarketStreamManager
 
             self._market_manager = ClobMarketStreamManager(
-                url=get_environment_config(self._ctx.environment).clob_market_ws_url,
+                url=self._ctx.environment_config.clob_market_ws_url,
                 logger=self._streams_logger,
             )
         return self._market_manager
@@ -665,7 +661,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.sports.manager import SportsStreamManager
 
             self._sports_manager = SportsStreamManager(
-                url=get_environment_config(self._ctx.environment).sports_ws_url,
+                url=self._ctx.environment_config.sports_ws_url,
                 logger=self._streams_logger,
             )
         return self._sports_manager
@@ -675,7 +671,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.rtds.manager import RtdsStreamManager
 
             self._rtds_manager = RtdsStreamManager(
-                url=get_environment_config(self._ctx.environment).rtds_ws_url,
+                url=self._ctx.environment_config.rtds_ws_url,
                 logger=self._streams_logger,
             )
         return self._rtds_manager
@@ -685,7 +681,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.clob.user import ClobUserStreamManager
 
             self._user_manager = ClobUserStreamManager(
-                url=get_environment_config(self._ctx.environment).clob_user_ws_url,
+                url=self._ctx.environment_config.clob_user_ws_url,
                 resolve_credentials=self._resolve_api_key_credentials,
                 logger=self._streams_logger,
             )
@@ -696,7 +692,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
 
             self._perps_manager = PerpsMarketStreamManager(
-                url=get_environment_config(self._ctx.environment).perps_ws_url,
+                url=self._ctx.environment_config.perps_ws_url,
                 logger=self._streams_logger,
             )
         return self._perps_manager
@@ -746,7 +742,7 @@ class AsyncSecureClient:
             resolved = await _perps_credentials.create_credentials(
                 self._ctx.perps,
                 signer=self._ctx.signer,
-                chain_id=get_environment_config(self._ctx.environment).chain_id,
+                chain_id=self._ctx.environment_config.chain_id,
                 expires_in=(
                     expires_in
                     if expires_in is not None
@@ -755,10 +751,10 @@ class AsyncSecureClient:
                 label=label,
             )
         session = PerpsSession(
-            chain_id=get_environment_config(self._ctx.environment).chain_id,
+            chain_id=self._ctx.environment_config.chain_id,
             credentials=resolved,
-            rest_url=get_environment_config(self._ctx.environment).perps_url,
-            ws_url=get_environment_config(self._ctx.environment).perps_ws_url,
+            rest_url=self._ctx.environment_config.perps_url,
+            ws_url=self._ctx.environment_config.perps_ws_url,
             logger=self._streams_logger,
             on_close=self._perps_sessions.discard,
         )
@@ -782,7 +778,7 @@ class AsyncSecureClient:
         await _perps_credentials.revoke_credentials(
             self._ctx.perps,
             signer=self._ctx.signer,
-            chain_id=get_environment_config(self._ctx.environment).chain_id,
+            chain_id=self._ctx.environment_config.chain_id,
             proxy=proxy,
         )
 
@@ -806,13 +802,12 @@ class AsyncSecureClient:
         Returns:
             A transaction handle. Await ``wait()`` to wait for a terminal outcome.
         """
-        env = self._ctx.environment
         call = _perps_funds.perps_deposit_call(
             deposit_contract=cast(
-                EvmAddress, to_checksum_address(get_environment_config(env).perps_deposit_contract)
+                EvmAddress, to_checksum_address(self._ctx.environment_config.perps_deposit_contract)
             ),
             token=cast(
-                EvmAddress, to_checksum_address(get_environment_config(env).collateral_token)
+                EvmAddress, to_checksum_address(self._ctx.environment_config.collateral_token)
             ),
             amount=amount,
             to=cast(EvmAddress, self._ctx.signer.address),
@@ -836,13 +831,12 @@ class AsyncSecureClient:
             The withdrawal identifier. Track its status with the session's
             ``list_withdrawals``.
         """
-        env = self._ctx.environment
         return await _perps_funds.withdraw_from_perps(
             self._ctx.perps,
             signer=self._ctx.signer,
-            chain_id=get_environment_config(env).chain_id,
-            deposit_contract=get_environment_config(env).perps_deposit_contract,
-            token=get_environment_config(env).collateral_token,
+            chain_id=self._ctx.environment_config.chain_id,
+            deposit_contract=self._ctx.environment_config.perps_deposit_contract,
+            token=self._ctx.environment_config.collateral_token,
             amount=amount,
             to=str(self._ctx.wallet),
         )
@@ -887,14 +881,14 @@ class AsyncSecureClient:
                 self._rfq_session = None
 
         session = RfqQuoterSession(
-            chain_id=get_environment_config(self._ctx.environment).chain_id,
+            chain_id=self._ctx.environment_config.chain_id,
             credentials=self._ctx.credentials,
-            exchange=EvmAddress(get_environment_config(self._ctx.environment).exchange_v3),
-            headers=get_environment_config(self._ctx.environment).rfq_quoter_ws_headers,
+            exchange=EvmAddress(self._ctx.environment_config.exchange_v3),
+            headers=self._ctx.environment_config.rfq_quoter_ws_headers,
             logger=self._streams_logger,
             on_close=clear_session,
             signer=self._ctx.signer,
-            url=get_environment_config(self._ctx.environment).rfq_quoter_ws_url,
+            url=self._ctx.environment_config.rfq_quoter_ws_url,
             wallet=self._ctx.wallet,
             wallet_type=self._ctx.wallet_type,
         )
@@ -2407,7 +2401,7 @@ class AsyncSecureClient:
         calls = await resolve_missing_trading_approval_calls(
             self._ctx.rpc,
             wallet=self._ctx.wallet,
-            environment=self._ctx.environment,
+            config=self._ctx.environment_config,
         )
         if not calls:
             return DeprecatedTransactionHandle()
@@ -2456,14 +2450,13 @@ class AsyncSecureClient:
         )
 
     async def _broadcast_eoa_call(self, call: TransactionCall) -> EoaTransactionHandle:
-        env = self._ctx.environment
         return await broadcast_eoa_call(
             rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
-            chain_id=get_environment_config(env).chain_id,
-            max_polls=get_environment_config(env).relayer_max_polls,
-            poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
+            chain_id=self._ctx.environment_config.chain_id,
+            max_polls=self._ctx.environment_config.relayer_max_polls,
+            poll_delay_s=self._ctx.environment_config.relayer_poll_frequency_ms / 1000,
         )
 
     async def _dispatch_single_call(
@@ -2507,7 +2500,7 @@ class AsyncSecureClient:
     async def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
         current_deposit_wallet = derive_beacon_deposit_wallet_address(
-            ctx.signer.address, get_environment_config(ctx.environment).wallet_derivation
+            ctx.signer.address, ctx.environment_config.wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2538,7 +2531,6 @@ class AsyncSecureClient:
         """
         if (condition_id is None) == (legs is None):
             raise UserInputError("Provide exactly one of condition_id or legs")
-        env = self._ctx.environment
         if legs is not None:
             if amount <= 0:
                 raise UserInputError("Split amount must be positive for combo positions")
@@ -2547,12 +2539,12 @@ class AsyncSecureClient:
             calls = [
                 combinatorial_prepare_condition_call(
                     combinatorial_module=cast(
-                        EvmAddress, get_environment_config(env).combinatorial_module
+                        EvmAddress, self._ctx.environment_config.combinatorial_module
                     ),
                     legs=list(canonical_legs),
                 ),
                 split_v2_call(
-                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                    router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=amount,
                 ),
@@ -2567,7 +2559,7 @@ class AsyncSecureClient:
         context = await self._resolve_market_position_context(condition_id=condition_id)
         call = split_position_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
             amount=amount,
         )
@@ -2600,12 +2592,11 @@ class AsyncSecureClient:
         """
         if (condition_id is None) == (legs is None):
             raise UserInputError("Provide exactly one of condition_id or legs")
-        env = self._ctx.environment
         if legs is not None:
             canonical_legs = canonicalize_combo_legs(legs)
             combo = derive_combo_position_context(canonical_legs)
             balance_call = erc1155_balance_of_batch_call(
-                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                 owners=[self._ctx.wallet, self._ctx.wallet],
                 token_ids=list(combo.position_ids),
             )
@@ -2618,12 +2609,12 @@ class AsyncSecureClient:
             calls = [
                 combinatorial_prepare_condition_call(
                     combinatorial_module=cast(
-                        EvmAddress, get_environment_config(env).combinatorial_module
+                        EvmAddress, self._ctx.environment_config.combinatorial_module
                     ),
                     legs=list(canonical_legs),
                 ),
                 merge_v2_call(
-                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                    router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=resolved_amount,
                 ),
@@ -2647,7 +2638,7 @@ class AsyncSecureClient:
         resolved_amount = resolve_merge_amount_from_balances(context.condition_id, balances, amount)
         call = merge_positions_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
             amount=resolved_amount,
         )
@@ -2679,7 +2670,6 @@ class AsyncSecureClient:
         if not positions:
             raise UserInputError("positions must include at least one merge request")
 
-        env = self._ctx.environment
         normalized = [
             normalize_batch_merge_position_request(cast(Mapping[str, object], position))
             for position in positions
@@ -2700,7 +2690,7 @@ class AsyncSecureClient:
                 seen_conditions.add(condition_key)
                 token_ids = derive_combo_outcome_position_ids(decoded.condition_id)
                 balance_call = erc1155_balance_of_batch_call(
-                    token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                    token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                     owners=[self._ctx.wallet, self._ctx.wallet],
                     token_ids=list(token_ids),
                 )
@@ -2712,7 +2702,7 @@ class AsyncSecureClient:
                 )
                 calls.append(
                     merge_v2_call(
-                        router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                        router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                         condition_id=decoded.condition_id,
                         amount=resolved_amount,
                     )
@@ -2741,7 +2731,7 @@ class AsyncSecureClient:
             calls.append(
                 merge_positions_call(
                     target=context.adapter_address,
-                    collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+                    collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
                     condition_id=context.condition_id,
                     amount=resolved_amount,
                 )
@@ -2786,11 +2776,10 @@ class AsyncSecureClient:
         """
         if sum(value is not None for value in (condition_id, market_id, position_id)) != 1:
             raise UserInputError("Provide exactly one of condition_id, market_id, or position_id")
-        env = self._ctx.environment
         if position_id is not None:
             decoded = decode_combo_outcome_position_id(position_id)
             balance_call = erc1155_balance_of_call(
-                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                 owner=self._ctx.wallet,
                 token_id=position_id,
             )
@@ -2800,7 +2789,7 @@ class AsyncSecureClient:
             if balance == 0:
                 raise UserInputError("Combo position has no balance to redeem")
             call = redeem_v2_call(
-                router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                 condition_id=decoded.condition_id,
                 outcome_index=decoded.outcome_index,
                 amount=balance,
@@ -2816,7 +2805,7 @@ class AsyncSecureClient:
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
         )
         resolved_metadata = (
@@ -2880,7 +2869,6 @@ class AsyncSecureClient:
     ) -> MarketPositionContext:
         if (condition_id is None) == (market_id is None):
             raise UserInputError("Provide exactly one of condition_id or market_id")
-        env = self._ctx.environment
         if condition_id is not None:
             context = f"condition {condition_id}"
             if closed is None:
@@ -2910,12 +2898,12 @@ class AsyncSecureClient:
         return normalize_market_position_context(
             markets[0],
             context=context,
-            collateral_adapter=cast(EvmAddress, get_environment_config(env).collateral_adapter),
+            collateral_adapter=cast(EvmAddress, self._ctx.environment_config.collateral_adapter),
             neg_risk_collateral_adapter=cast(
-                EvmAddress, get_environment_config(env).neg_risk_collateral_adapter
+                EvmAddress, self._ctx.environment_config.neg_risk_collateral_adapter
             ),
-            conditional_tokens=cast(EvmAddress, get_environment_config(env).conditional_tokens),
-            neg_risk_adapter=cast(EvmAddress, get_environment_config(env).neg_risk_adapter),
+            conditional_tokens=cast(EvmAddress, self._ctx.environment_config.conditional_tokens),
+            neg_risk_adapter=cast(EvmAddress, self._ctx.environment_config.neg_risk_adapter),
         )
 
     async def post_order(self, signed_order: SignedOrder) -> OrderResponse:
@@ -3282,7 +3270,7 @@ async def _close_all(*resources: AsyncCloseable | None) -> None:
 
 async def _bootstrap_credentials(
     *,
-    environment: Environment,
+    config: EnvironmentConfig,
     signer: LocalAccount,
     clob: AsyncTransport,
     provided: ApiKeyCreds | None,
@@ -3293,7 +3281,7 @@ async def _bootstrap_credentials(
     if provided is not None and (
         not validate
         or await _credentials_are_active(
-            environment=environment,
+            config=config,
             signer=signer,
             credentials=provided,
             logger=logger,
@@ -3303,7 +3291,7 @@ async def _bootstrap_credentials(
 
     signature = sign_api_key_auth(
         signer,
-        chain_id=get_environment_config(environment).chain_id,
+        chain_id=config.chain_id,
         timestamp=int(time.time()),
         nonce=nonce,
     )
@@ -3314,17 +3302,15 @@ async def _resolve_requested_wallet(
     *,
     signer: LocalAccount,
     wallet: str | None,
-    environment: Environment,
+    config: EnvironmentConfig,
     logger: logging.Logger | None,
 ) -> str:
     if wallet is not None:
         return wallet
     legacy_deposit_wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(environment).wallet_derivation
+        signer.address, config.wallet_derivation
     )
-    relayer = AsyncTransport(
-        base_url=get_environment_config(environment).relayer_url, logger=logger
-    )
+    relayer = AsyncTransport(base_url=config.relayer_url, logger=logger)
     try:
         if await fetch_deployed(
             relayer,
@@ -3332,9 +3318,7 @@ async def _resolve_requested_wallet(
             type=RelayerTransactionType.WALLET,
         ):
             return legacy_deposit_wallet
-        return derive_beacon_deposit_wallet_address(
-            signer.address, get_environment_config(environment).wallet_derivation
-        )
+        return derive_beacon_deposit_wallet_address(signer.address, config.wallet_derivation)
     finally:
         await relayer.close()
 
@@ -3353,13 +3337,13 @@ def _relayer_transaction_type_for_wallet(
 
 async def _credentials_are_active(
     *,
-    environment: Environment,
+    config: EnvironmentConfig,
     signer: LocalAccount,
     credentials: ApiKeyCreds,
     logger: logging.Logger | None,
 ) -> bool:
     probe = AsyncTransport(
-        base_url=get_environment_config(environment).clob_url,
+        base_url=config.clob_url,
         logger=logger,
         header_resolver=_make_l2_header_resolver(signer, credentials),
     )

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -127,6 +127,7 @@ from polymarket._internal.dispatch import (
     async_paginate_offset,
     async_paginate_page_based,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.eoa.broadcast import broadcast_eoa_call
 from polymarket._internal.eoa.rpc import JsonRpcClient
 from polymarket._internal.hmac import build_hmac_signature
@@ -411,7 +412,9 @@ class AsyncSecureClient:
         except ValueError as error:
             raise UserInputError(f"Invalid wallet address: {error}") from error
 
-        bootstrap_clob = AsyncTransport(base_url=environment.clob_url, logger=logger)
+        bootstrap_clob = AsyncTransport(
+            base_url=get_environment_config(environment).clob_url, logger=logger
+        )
         try:
             resolved_credentials = await _bootstrap_credentials(
                 environment=environment,
@@ -449,31 +452,35 @@ class AsyncSecureClient:
         wallet_type = classify_wallet_type(
             signer=signer.address,
             wallet=wallet_checksum,
-            config=environment.wallet_derivation,
+            config=get_environment_config(environment).wallet_derivation,
         )
         branded_wallet = cast(EvmAddress, wallet_checksum)
 
-        gamma = AsyncTransport(base_url=environment.gamma_url, logger=logger)
-        data = AsyncTransport(base_url=environment.data_url, logger=logger)
-        rfq = AsyncTransport(base_url=environment.rfq_url, logger=logger)
-        clob = AsyncTransport(base_url=environment.clob_url, logger=logger)
+        gamma = AsyncTransport(
+            base_url=get_environment_config(environment).gamma_url, logger=logger
+        )
+        data = AsyncTransport(base_url=get_environment_config(environment).data_url, logger=logger)
+        rfq = AsyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger)
+        clob = AsyncTransport(base_url=get_environment_config(environment).clob_url, logger=logger)
         relayer_resolver = make_relayer_header_resolver(api_key) if api_key is not None else None
         relayer = AsyncTransport(
-            base_url=environment.relayer_url,
+            base_url=get_environment_config(environment).relayer_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         combos = AsyncTransport(
-            base_url=environment.collateral_return_url,
+            base_url=get_environment_config(environment).collateral_return_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         secure_clob = AsyncTransport(
-            base_url=environment.clob_url,
+            base_url=get_environment_config(environment).clob_url,
             logger=logger,
             header_resolver=_make_l2_header_resolver(signer, credentials),
         )
-        rpc_transport = AsyncTransport(base_url=environment.rpc_url, logger=logger)
+        rpc_transport = AsyncTransport(
+            base_url=get_environment_config(environment).rpc_url, logger=logger
+        )
         rpc = JsonRpcClient(rpc_transport)
 
         ctx = AsyncSecureClientContext(
@@ -482,7 +489,9 @@ class AsyncSecureClient:
             data=data,
             rfq=rfq,
             clob=clob,
-            perps=AsyncTransport(base_url=environment.perps_url, logger=logger),
+            perps=AsyncTransport(
+                base_url=get_environment_config(environment).perps_url, logger=logger
+            ),
             signer=signer,
             credentials=credentials,
             secure_clob=secure_clob,
@@ -646,7 +655,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.clob.market import ClobMarketStreamManager
 
             self._market_manager = ClobMarketStreamManager(
-                url=self._ctx.environment.clob_market_ws_url,
+                url=get_environment_config(self._ctx.environment).clob_market_ws_url,
                 logger=self._streams_logger,
             )
         return self._market_manager
@@ -656,7 +665,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.sports.manager import SportsStreamManager
 
             self._sports_manager = SportsStreamManager(
-                url=self._ctx.environment.sports_ws_url,
+                url=get_environment_config(self._ctx.environment).sports_ws_url,
                 logger=self._streams_logger,
             )
         return self._sports_manager
@@ -666,7 +675,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.rtds.manager import RtdsStreamManager
 
             self._rtds_manager = RtdsStreamManager(
-                url=self._ctx.environment.rtds_ws_url,
+                url=get_environment_config(self._ctx.environment).rtds_ws_url,
                 logger=self._streams_logger,
             )
         return self._rtds_manager
@@ -676,7 +685,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.clob.user import ClobUserStreamManager
 
             self._user_manager = ClobUserStreamManager(
-                url=self._ctx.environment.clob_user_ws_url,
+                url=get_environment_config(self._ctx.environment).clob_user_ws_url,
                 resolve_credentials=self._resolve_api_key_credentials,
                 logger=self._streams_logger,
             )
@@ -687,7 +696,7 @@ class AsyncSecureClient:
             from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
 
             self._perps_manager = PerpsMarketStreamManager(
-                url=self._ctx.environment.perps_ws_url,
+                url=get_environment_config(self._ctx.environment).perps_ws_url,
                 logger=self._streams_logger,
             )
         return self._perps_manager
@@ -737,7 +746,7 @@ class AsyncSecureClient:
             resolved = await _perps_credentials.create_credentials(
                 self._ctx.perps,
                 signer=self._ctx.signer,
-                chain_id=self._ctx.environment.chain_id,
+                chain_id=get_environment_config(self._ctx.environment).chain_id,
                 expires_in=(
                     expires_in
                     if expires_in is not None
@@ -746,10 +755,10 @@ class AsyncSecureClient:
                 label=label,
             )
         session = PerpsSession(
-            chain_id=self._ctx.environment.chain_id,
+            chain_id=get_environment_config(self._ctx.environment).chain_id,
             credentials=resolved,
-            rest_url=self._ctx.environment.perps_url,
-            ws_url=self._ctx.environment.perps_ws_url,
+            rest_url=get_environment_config(self._ctx.environment).perps_url,
+            ws_url=get_environment_config(self._ctx.environment).perps_ws_url,
             logger=self._streams_logger,
             on_close=self._perps_sessions.discard,
         )
@@ -773,7 +782,7 @@ class AsyncSecureClient:
         await _perps_credentials.revoke_credentials(
             self._ctx.perps,
             signer=self._ctx.signer,
-            chain_id=self._ctx.environment.chain_id,
+            chain_id=get_environment_config(self._ctx.environment).chain_id,
             proxy=proxy,
         )
 
@@ -799,8 +808,12 @@ class AsyncSecureClient:
         """
         env = self._ctx.environment
         call = _perps_funds.perps_deposit_call(
-            deposit_contract=cast(EvmAddress, to_checksum_address(env.perps_deposit_contract)),
-            token=cast(EvmAddress, to_checksum_address(env.collateral_token)),
+            deposit_contract=cast(
+                EvmAddress, to_checksum_address(get_environment_config(env).perps_deposit_contract)
+            ),
+            token=cast(
+                EvmAddress, to_checksum_address(get_environment_config(env).collateral_token)
+            ),
             amount=amount,
             to=cast(EvmAddress, self._ctx.signer.address),
         )
@@ -827,9 +840,9 @@ class AsyncSecureClient:
         return await _perps_funds.withdraw_from_perps(
             self._ctx.perps,
             signer=self._ctx.signer,
-            chain_id=env.chain_id,
-            deposit_contract=env.perps_deposit_contract,
-            token=env.collateral_token,
+            chain_id=get_environment_config(env).chain_id,
+            deposit_contract=get_environment_config(env).perps_deposit_contract,
+            token=get_environment_config(env).collateral_token,
             amount=amount,
             to=str(self._ctx.wallet),
         )
@@ -874,14 +887,14 @@ class AsyncSecureClient:
                 self._rfq_session = None
 
         session = RfqQuoterSession(
-            chain_id=self._ctx.environment.chain_id,
+            chain_id=get_environment_config(self._ctx.environment).chain_id,
             credentials=self._ctx.credentials,
-            exchange=EvmAddress(self._ctx.environment.exchange_v3),
-            headers=self._ctx.environment.rfq_quoter_ws_headers,
+            exchange=EvmAddress(get_environment_config(self._ctx.environment).exchange_v3),
+            headers=get_environment_config(self._ctx.environment).rfq_quoter_ws_headers,
             logger=self._streams_logger,
             on_close=clear_session,
             signer=self._ctx.signer,
-            url=self._ctx.environment.rfq_quoter_ws_url,
+            url=get_environment_config(self._ctx.environment).rfq_quoter_ws_url,
             wallet=self._ctx.wallet,
             wallet_type=self._ctx.wallet_type,
         )
@@ -2448,9 +2461,9 @@ class AsyncSecureClient:
             rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
-            chain_id=env.chain_id,
-            max_polls=env.relayer_max_polls,
-            poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+            chain_id=get_environment_config(env).chain_id,
+            max_polls=get_environment_config(env).relayer_max_polls,
+            poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
         )
 
     async def _dispatch_single_call(
@@ -2494,7 +2507,7 @@ class AsyncSecureClient:
     async def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
         current_deposit_wallet = derive_beacon_deposit_wallet_address(
-            ctx.signer.address, ctx.environment.wallet_derivation
+            ctx.signer.address, get_environment_config(ctx.environment).wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2533,11 +2546,13 @@ class AsyncSecureClient:
             combo = derive_combo_position_context(canonical_legs)
             calls = [
                 combinatorial_prepare_condition_call(
-                    combinatorial_module=cast(EvmAddress, env.combinatorial_module),
+                    combinatorial_module=cast(
+                        EvmAddress, get_environment_config(env).combinatorial_module
+                    ),
                     legs=list(canonical_legs),
                 ),
                 split_v2_call(
-                    router=cast(EvmAddress, env.protocol_v2_router),
+                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=amount,
                 ),
@@ -2552,7 +2567,7 @@ class AsyncSecureClient:
         context = await self._resolve_market_position_context(condition_id=condition_id)
         call = split_position_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
             amount=amount,
         )
@@ -2590,7 +2605,7 @@ class AsyncSecureClient:
             canonical_legs = canonicalize_combo_legs(legs)
             combo = derive_combo_position_context(canonical_legs)
             balance_call = erc1155_balance_of_batch_call(
-                token_address=cast(EvmAddress, env.position_manager),
+                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                 owners=[self._ctx.wallet, self._ctx.wallet],
                 token_ids=list(combo.position_ids),
             )
@@ -2602,11 +2617,13 @@ class AsyncSecureClient:
             )
             calls = [
                 combinatorial_prepare_condition_call(
-                    combinatorial_module=cast(EvmAddress, env.combinatorial_module),
+                    combinatorial_module=cast(
+                        EvmAddress, get_environment_config(env).combinatorial_module
+                    ),
                     legs=list(canonical_legs),
                 ),
                 merge_v2_call(
-                    router=cast(EvmAddress, env.protocol_v2_router),
+                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=resolved_amount,
                 ),
@@ -2630,7 +2647,7 @@ class AsyncSecureClient:
         resolved_amount = resolve_merge_amount_from_balances(context.condition_id, balances, amount)
         call = merge_positions_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
             amount=resolved_amount,
         )
@@ -2683,7 +2700,7 @@ class AsyncSecureClient:
                 seen_conditions.add(condition_key)
                 token_ids = derive_combo_outcome_position_ids(decoded.condition_id)
                 balance_call = erc1155_balance_of_batch_call(
-                    token_address=cast(EvmAddress, env.position_manager),
+                    token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                     owners=[self._ctx.wallet, self._ctx.wallet],
                     token_ids=list(token_ids),
                 )
@@ -2695,7 +2712,7 @@ class AsyncSecureClient:
                 )
                 calls.append(
                     merge_v2_call(
-                        router=cast(EvmAddress, env.protocol_v2_router),
+                        router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                         condition_id=decoded.condition_id,
                         amount=resolved_amount,
                     )
@@ -2724,7 +2741,7 @@ class AsyncSecureClient:
             calls.append(
                 merge_positions_call(
                     target=context.adapter_address,
-                    collateral=cast(EvmAddress, env.collateral_token),
+                    collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
                     condition_id=context.condition_id,
                     amount=resolved_amount,
                 )
@@ -2773,7 +2790,7 @@ class AsyncSecureClient:
         if position_id is not None:
             decoded = decode_combo_outcome_position_id(position_id)
             balance_call = erc1155_balance_of_call(
-                token_address=cast(EvmAddress, env.position_manager),
+                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                 owner=self._ctx.wallet,
                 token_id=position_id,
             )
@@ -2783,7 +2800,7 @@ class AsyncSecureClient:
             if balance == 0:
                 raise UserInputError("Combo position has no balance to redeem")
             call = redeem_v2_call(
-                router=cast(EvmAddress, env.protocol_v2_router),
+                router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                 condition_id=decoded.condition_id,
                 outcome_index=decoded.outcome_index,
                 amount=balance,
@@ -2799,7 +2816,7 @@ class AsyncSecureClient:
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
         )
         resolved_metadata = (
@@ -2893,10 +2910,12 @@ class AsyncSecureClient:
         return normalize_market_position_context(
             markets[0],
             context=context,
-            collateral_adapter=cast(EvmAddress, env.collateral_adapter),
-            neg_risk_collateral_adapter=cast(EvmAddress, env.neg_risk_collateral_adapter),
-            conditional_tokens=cast(EvmAddress, env.conditional_tokens),
-            neg_risk_adapter=cast(EvmAddress, env.neg_risk_adapter),
+            collateral_adapter=cast(EvmAddress, get_environment_config(env).collateral_adapter),
+            neg_risk_collateral_adapter=cast(
+                EvmAddress, get_environment_config(env).neg_risk_collateral_adapter
+            ),
+            conditional_tokens=cast(EvmAddress, get_environment_config(env).conditional_tokens),
+            neg_risk_adapter=cast(EvmAddress, get_environment_config(env).neg_risk_adapter),
         )
 
     async def post_order(self, signed_order: SignedOrder) -> OrderResponse:
@@ -3283,7 +3302,10 @@ async def _bootstrap_credentials(
         return provided
 
     signature = sign_api_key_auth(
-        signer, chain_id=environment.chain_id, timestamp=int(time.time()), nonce=nonce
+        signer,
+        chain_id=get_environment_config(environment).chain_id,
+        timestamp=int(time.time()),
+        nonce=nonce,
     )
     return await _auth_actions.create_or_derive_api_key(clob, signature)
 
@@ -3298,9 +3320,11 @@ async def _resolve_requested_wallet(
     if wallet is not None:
         return wallet
     legacy_deposit_wallet = derive_uups_deposit_wallet_address(
-        signer.address, environment.wallet_derivation
+        signer.address, get_environment_config(environment).wallet_derivation
     )
-    relayer = AsyncTransport(base_url=environment.relayer_url, logger=logger)
+    relayer = AsyncTransport(
+        base_url=get_environment_config(environment).relayer_url, logger=logger
+    )
     try:
         if await fetch_deployed(
             relayer,
@@ -3308,7 +3332,9 @@ async def _resolve_requested_wallet(
             type=RelayerTransactionType.WALLET,
         ):
             return legacy_deposit_wallet
-        return derive_beacon_deposit_wallet_address(signer.address, environment.wallet_derivation)
+        return derive_beacon_deposit_wallet_address(
+            signer.address, get_environment_config(environment).wallet_derivation
+        )
     finally:
         await relayer.close()
 
@@ -3333,7 +3359,7 @@ async def _credentials_are_active(
     logger: logging.Logger | None,
 ) -> bool:
     probe = AsyncTransport(
-        base_url=environment.clob_url,
+        base_url=get_environment_config(environment).clob_url,
         logger=logger,
         header_resolver=_make_l2_header_resolver(signer, credentials),
     )

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -44,6 +44,7 @@ from polymarket._internal.dispatch import (
     sync_paginate_offset,
     sync_paginate_page_based,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import SyncTransport
 from polymarket.environments import PRODUCTION, Environment
 from polymarket.errors import RequestRejectedError
@@ -110,10 +111,16 @@ class PublicClient:
     ) -> None:
         self._ctx = SyncClientContext(
             environment=environment,
-            gamma=SyncTransport(base_url=environment.gamma_url, logger=logger),
-            data=SyncTransport(base_url=environment.data_url, logger=logger),
-            rfq=SyncTransport(base_url=environment.rfq_url, logger=logger),
-            clob=SyncTransport(base_url=environment.clob_url, logger=logger),
+            gamma=SyncTransport(
+                base_url=get_environment_config(environment).gamma_url, logger=logger
+            ),
+            data=SyncTransport(
+                base_url=get_environment_config(environment).data_url, logger=logger
+            ),
+            rfq=SyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger),
+            clob=SyncTransport(
+                base_url=get_environment_config(environment).clob_url, logger=logger
+            ),
         )
 
     @property

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -109,18 +109,14 @@ class PublicClient:
         *,
         logger: logging.Logger | None = None,
     ) -> None:
+        config = get_environment_config(environment)
         self._ctx = SyncClientContext(
             environment=environment,
-            gamma=SyncTransport(
-                base_url=get_environment_config(environment).gamma_url, logger=logger
-            ),
-            data=SyncTransport(
-                base_url=get_environment_config(environment).data_url, logger=logger
-            ),
-            rfq=SyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger),
-            clob=SyncTransport(
-                base_url=get_environment_config(environment).clob_url, logger=logger
-            ),
+            _resolved_environment_config=config,
+            gamma=SyncTransport(base_url=config.gamma_url, logger=logger),
+            data=SyncTransport(base_url=config.data_url, logger=logger),
+            rfq=SyncTransport(base_url=config.rfq_url, logger=logger),
+            clob=SyncTransport(base_url=config.clob_url, logger=logger),
         )
 
     @property

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -114,6 +114,7 @@ from polymarket._internal.dispatch import (
     sync_paginate_offset,
     sync_paginate_page_based,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.eoa.broadcast import broadcast_eoa_call_sync
 from polymarket._internal.eoa.rpc import SyncJsonRpcClient
 from polymarket._internal.hmac import build_hmac_signature
@@ -325,7 +326,9 @@ class SecureClient:
             logger=logger,
         )
 
-        bootstrap_clob = SyncTransport(base_url=environment.clob_url, logger=logger)
+        bootstrap_clob = SyncTransport(
+            base_url=get_environment_config(environment).clob_url, logger=logger
+        )
         try:
             resolved_credentials = _bootstrap_credentials_sync(
                 environment=environment,
@@ -366,34 +369,36 @@ class SecureClient:
         wallet_type = classify_wallet_type(
             signer=signer.address,
             wallet=wallet_checksum,
-            config=environment.wallet_derivation,
+            config=get_environment_config(environment).wallet_derivation,
         )
         branded_wallet = cast(EvmAddress, wallet_checksum)
 
-        gamma = SyncTransport(base_url=environment.gamma_url, logger=logger)
-        data = SyncTransport(base_url=environment.data_url, logger=logger)
-        rfq = SyncTransport(base_url=environment.rfq_url, logger=logger)
-        clob = SyncTransport(base_url=environment.clob_url, logger=logger)
+        gamma = SyncTransport(base_url=get_environment_config(environment).gamma_url, logger=logger)
+        data = SyncTransport(base_url=get_environment_config(environment).data_url, logger=logger)
+        rfq = SyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger)
+        clob = SyncTransport(base_url=get_environment_config(environment).clob_url, logger=logger)
         relayer_resolver = (
             make_relayer_header_resolver_sync(api_key) if api_key is not None else None
         )
         relayer = SyncTransport(
-            base_url=environment.relayer_url,
+            base_url=get_environment_config(environment).relayer_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         combos = SyncTransport(
-            base_url=environment.collateral_return_url,
+            base_url=get_environment_config(environment).collateral_return_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         try:
             secure_clob = SyncTransport(
-                base_url=environment.clob_url,
+                base_url=get_environment_config(environment).clob_url,
                 logger=logger,
                 header_resolver=_make_l2_header_resolver_sync(signer, credentials),
             )
-            rpc_transport = SyncTransport(base_url=environment.rpc_url, logger=logger)
+            rpc_transport = SyncTransport(
+                base_url=get_environment_config(environment).rpc_url, logger=logger
+            )
             rpc = SyncJsonRpcClient(rpc_transport)
         except BaseException:
             gamma.close()
@@ -2246,11 +2251,13 @@ class SecureClient:
             combo = derive_combo_position_context(canonical_legs)
             calls = [
                 combinatorial_prepare_condition_call(
-                    combinatorial_module=cast(EvmAddress, env.combinatorial_module),
+                    combinatorial_module=cast(
+                        EvmAddress, get_environment_config(env).combinatorial_module
+                    ),
                     legs=list(canonical_legs),
                 ),
                 split_v2_call(
-                    router=cast(EvmAddress, env.protocol_v2_router),
+                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=amount,
                 ),
@@ -2265,7 +2272,7 @@ class SecureClient:
         context = self._resolve_market_position_context(condition_id=condition_id)
         call = split_position_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
             amount=amount,
         )
@@ -2303,7 +2310,7 @@ class SecureClient:
             canonical_legs = canonicalize_combo_legs(legs)
             combo = derive_combo_position_context(canonical_legs)
             balance_call = erc1155_balance_of_batch_call(
-                token_address=cast(EvmAddress, env.position_manager),
+                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                 owners=[self._ctx.wallet, self._ctx.wallet],
                 token_ids=list(combo.position_ids),
             )
@@ -2315,11 +2322,13 @@ class SecureClient:
             )
             calls = [
                 combinatorial_prepare_condition_call(
-                    combinatorial_module=cast(EvmAddress, env.combinatorial_module),
+                    combinatorial_module=cast(
+                        EvmAddress, get_environment_config(env).combinatorial_module
+                    ),
                     legs=list(canonical_legs),
                 ),
                 merge_v2_call(
-                    router=cast(EvmAddress, env.protocol_v2_router),
+                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=resolved_amount,
                 ),
@@ -2343,7 +2352,7 @@ class SecureClient:
         resolved_amount = resolve_merge_amount_from_balances(context.condition_id, balances, amount)
         call = merge_positions_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
             amount=resolved_amount,
         )
@@ -2396,7 +2405,7 @@ class SecureClient:
                 seen_conditions.add(condition_key)
                 token_ids = derive_combo_outcome_position_ids(decoded.condition_id)
                 balance_call = erc1155_balance_of_batch_call(
-                    token_address=cast(EvmAddress, env.position_manager),
+                    token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                     owners=[self._ctx.wallet, self._ctx.wallet],
                     token_ids=list(token_ids),
                 )
@@ -2408,7 +2417,7 @@ class SecureClient:
                 )
                 calls.append(
                     merge_v2_call(
-                        router=cast(EvmAddress, env.protocol_v2_router),
+                        router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                         condition_id=decoded.condition_id,
                         amount=resolved_amount,
                     )
@@ -2437,7 +2446,7 @@ class SecureClient:
             calls.append(
                 merge_positions_call(
                     target=context.adapter_address,
-                    collateral=cast(EvmAddress, env.collateral_token),
+                    collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
                     condition_id=context.condition_id,
                     amount=resolved_amount,
                 )
@@ -2486,7 +2495,7 @@ class SecureClient:
         if position_id is not None:
             decoded = decode_combo_outcome_position_id(position_id)
             balance_call = erc1155_balance_of_call(
-                token_address=cast(EvmAddress, env.position_manager),
+                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
                 owner=self._ctx.wallet,
                 token_id=position_id,
             )
@@ -2496,7 +2505,7 @@ class SecureClient:
             if balance == 0:
                 raise UserInputError("Combo position has no balance to redeem")
             call = redeem_v2_call(
-                router=cast(EvmAddress, env.protocol_v2_router),
+                router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
                 condition_id=decoded.condition_id,
                 outcome_index=decoded.outcome_index,
                 amount=balance,
@@ -2512,7 +2521,7 @@ class SecureClient:
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
-            collateral=cast(EvmAddress, env.collateral_token),
+            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
             condition_id=context.condition_id,
         )
         resolved_metadata = (
@@ -2573,9 +2582,9 @@ class SecureClient:
             rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
-            chain_id=env.chain_id,
-            max_polls=env.relayer_max_polls,
-            poll_delay_s=env.relayer_poll_frequency_ms / 1000,
+            chain_id=get_environment_config(env).chain_id,
+            max_polls=get_environment_config(env).relayer_max_polls,
+            poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
         )
 
     def _dispatch_single_call(
@@ -2618,7 +2627,7 @@ class SecureClient:
     def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
         current_deposit_wallet = derive_beacon_deposit_wallet_address(
-            ctx.signer.address, ctx.environment.wallet_derivation
+            ctx.signer.address, get_environment_config(ctx.environment).wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2663,10 +2672,12 @@ class SecureClient:
         return normalize_market_position_context(
             markets[0],
             context=context,
-            collateral_adapter=cast(EvmAddress, env.collateral_adapter),
-            neg_risk_collateral_adapter=cast(EvmAddress, env.neg_risk_collateral_adapter),
-            conditional_tokens=cast(EvmAddress, env.conditional_tokens),
-            neg_risk_adapter=cast(EvmAddress, env.neg_risk_adapter),
+            collateral_adapter=cast(EvmAddress, get_environment_config(env).collateral_adapter),
+            neg_risk_collateral_adapter=cast(
+                EvmAddress, get_environment_config(env).neg_risk_collateral_adapter
+            ),
+            conditional_tokens=cast(EvmAddress, get_environment_config(env).conditional_tokens),
+            neg_risk_adapter=cast(EvmAddress, get_environment_config(env).neg_risk_adapter),
         )
 
 
@@ -2692,7 +2703,10 @@ def _bootstrap_credentials_sync(
         return provided
 
     signature = sign_api_key_auth(
-        signer, chain_id=environment.chain_id, timestamp=int(time.time()), nonce=nonce
+        signer,
+        chain_id=get_environment_config(environment).chain_id,
+        timestamp=int(time.time()),
+        nonce=nonce,
     )
     return _auth_actions.create_or_derive_api_key_sync(clob, signature)
 
@@ -2707,9 +2721,9 @@ def _resolve_requested_wallet_sync(
     if wallet is not None:
         return wallet
     legacy_deposit_wallet = derive_uups_deposit_wallet_address(
-        signer.address, environment.wallet_derivation
+        signer.address, get_environment_config(environment).wallet_derivation
     )
-    relayer = SyncTransport(base_url=environment.relayer_url, logger=logger)
+    relayer = SyncTransport(base_url=get_environment_config(environment).relayer_url, logger=logger)
     try:
         if fetch_deployed_sync(
             relayer,
@@ -2717,7 +2731,9 @@ def _resolve_requested_wallet_sync(
             type=RelayerTransactionType.WALLET,
         ):
             return legacy_deposit_wallet
-        return derive_beacon_deposit_wallet_address(signer.address, environment.wallet_derivation)
+        return derive_beacon_deposit_wallet_address(
+            signer.address, get_environment_config(environment).wallet_derivation
+        )
     finally:
         relayer.close()
 
@@ -2742,7 +2758,7 @@ def _credentials_are_active_sync(
     logger: logging.Logger | None,
 ) -> bool:
     probe = SyncTransport(
-        base_url=environment.clob_url,
+        base_url=get_environment_config(environment).clob_url,
         logger=logger,
         header_resolver=_make_l2_header_resolver_sync(signer, credentials),
     )

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -114,7 +114,7 @@ from polymarket._internal.dispatch import (
     sync_paginate_offset,
     sync_paginate_page_based,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import EnvironmentConfig, get_environment_config
 from polymarket._internal.eoa.broadcast import broadcast_eoa_call_sync
 from polymarket._internal.eoa.rpc import SyncJsonRpcClient
 from polymarket._internal.hmac import build_hmac_signature
@@ -314,6 +314,7 @@ class SecureClient:
         _validate_nonce(nonce)
         if credentials is not None and nonce != 0:
             raise UserInputError("nonce cannot be combined with credentials.")
+        config = get_environment_config(environment)
         try:
             signer = cast(LocalAccount, Account.from_key(private_key))
         except (ValueError, TypeError) as error:
@@ -322,16 +323,14 @@ class SecureClient:
         resolved_wallet = _resolve_requested_wallet_sync(
             signer=signer,
             wallet=wallet,
-            environment=environment,
+            config=config,
             logger=logger,
         )
 
-        bootstrap_clob = SyncTransport(
-            base_url=get_environment_config(environment).clob_url, logger=logger
-        )
+        bootstrap_clob = SyncTransport(base_url=config.clob_url, logger=logger)
         try:
             resolved_credentials = _bootstrap_credentials_sync(
-                environment=environment,
+                config=config,
                 signer=signer,
                 clob=bootstrap_clob,
                 provided=credentials,
@@ -346,6 +345,7 @@ class SecureClient:
             signer=signer,
             wallet=resolved_wallet,
             environment=environment,
+            config=config,
             credentials=resolved_credentials,
             api_key=api_key,
             logger=logger,
@@ -358,6 +358,7 @@ class SecureClient:
         signer: LocalAccount,
         wallet: str,
         environment: Environment,
+        config: EnvironmentConfig,
         credentials: ApiKeyCreds,
         api_key: ApiKey | None,
         logger: logging.Logger | None,
@@ -369,36 +370,34 @@ class SecureClient:
         wallet_type = classify_wallet_type(
             signer=signer.address,
             wallet=wallet_checksum,
-            config=get_environment_config(environment).wallet_derivation,
+            config=config.wallet_derivation,
         )
         branded_wallet = cast(EvmAddress, wallet_checksum)
 
-        gamma = SyncTransport(base_url=get_environment_config(environment).gamma_url, logger=logger)
-        data = SyncTransport(base_url=get_environment_config(environment).data_url, logger=logger)
-        rfq = SyncTransport(base_url=get_environment_config(environment).rfq_url, logger=logger)
-        clob = SyncTransport(base_url=get_environment_config(environment).clob_url, logger=logger)
+        gamma = SyncTransport(base_url=config.gamma_url, logger=logger)
+        data = SyncTransport(base_url=config.data_url, logger=logger)
+        rfq = SyncTransport(base_url=config.rfq_url, logger=logger)
+        clob = SyncTransport(base_url=config.clob_url, logger=logger)
         relayer_resolver = (
             make_relayer_header_resolver_sync(api_key) if api_key is not None else None
         )
         relayer = SyncTransport(
-            base_url=get_environment_config(environment).relayer_url,
+            base_url=config.relayer_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         combos = SyncTransport(
-            base_url=get_environment_config(environment).collateral_return_url,
+            base_url=config.collateral_return_url,
             logger=logger,
             header_resolver=relayer_resolver,
         )
         try:
             secure_clob = SyncTransport(
-                base_url=get_environment_config(environment).clob_url,
+                base_url=config.clob_url,
                 logger=logger,
                 header_resolver=_make_l2_header_resolver_sync(signer, credentials),
             )
-            rpc_transport = SyncTransport(
-                base_url=get_environment_config(environment).rpc_url, logger=logger
-            )
+            rpc_transport = SyncTransport(base_url=config.rpc_url, logger=logger)
             rpc = SyncJsonRpcClient(rpc_transport)
         except BaseException:
             gamma.close()
@@ -411,6 +410,7 @@ class SecureClient:
 
         ctx = SyncSecureClientContext(
             environment=environment,
+            _resolved_environment_config=config,
             gamma=gamma,
             data=data,
             rfq=rfq,
@@ -2174,7 +2174,7 @@ class SecureClient:
         calls = resolve_missing_trading_approval_calls_sync(
             self._ctx.rpc,
             wallet=self._ctx.wallet,
-            environment=self._ctx.environment,
+            config=self._ctx.environment_config,
         )
         if not calls:
             return SyncDeprecatedTransactionHandle()
@@ -2243,7 +2243,6 @@ class SecureClient:
         """
         if (condition_id is None) == (legs is None):
             raise UserInputError("Provide exactly one of condition_id or legs")
-        env = self._ctx.environment
         if legs is not None:
             if amount <= 0:
                 raise UserInputError("Split amount must be positive for combo positions")
@@ -2252,12 +2251,12 @@ class SecureClient:
             calls = [
                 combinatorial_prepare_condition_call(
                     combinatorial_module=cast(
-                        EvmAddress, get_environment_config(env).combinatorial_module
+                        EvmAddress, self._ctx.environment_config.combinatorial_module
                     ),
                     legs=list(canonical_legs),
                 ),
                 split_v2_call(
-                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                    router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=amount,
                 ),
@@ -2272,7 +2271,7 @@ class SecureClient:
         context = self._resolve_market_position_context(condition_id=condition_id)
         call = split_position_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
             amount=amount,
         )
@@ -2305,12 +2304,11 @@ class SecureClient:
         """
         if (condition_id is None) == (legs is None):
             raise UserInputError("Provide exactly one of condition_id or legs")
-        env = self._ctx.environment
         if legs is not None:
             canonical_legs = canonicalize_combo_legs(legs)
             combo = derive_combo_position_context(canonical_legs)
             balance_call = erc1155_balance_of_batch_call(
-                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                 owners=[self._ctx.wallet, self._ctx.wallet],
                 token_ids=list(combo.position_ids),
             )
@@ -2323,12 +2321,12 @@ class SecureClient:
             calls = [
                 combinatorial_prepare_condition_call(
                     combinatorial_module=cast(
-                        EvmAddress, get_environment_config(env).combinatorial_module
+                        EvmAddress, self._ctx.environment_config.combinatorial_module
                     ),
                     legs=list(canonical_legs),
                 ),
                 merge_v2_call(
-                    router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                    router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                     condition_id=combo.condition_id,
                     amount=resolved_amount,
                 ),
@@ -2352,7 +2350,7 @@ class SecureClient:
         resolved_amount = resolve_merge_amount_from_balances(context.condition_id, balances, amount)
         call = merge_positions_call(
             target=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
             amount=resolved_amount,
         )
@@ -2384,7 +2382,6 @@ class SecureClient:
         if not positions:
             raise UserInputError("positions must include at least one merge request")
 
-        env = self._ctx.environment
         normalized = [
             normalize_batch_merge_position_request(cast(Mapping[str, object], position))
             for position in positions
@@ -2405,7 +2402,7 @@ class SecureClient:
                 seen_conditions.add(condition_key)
                 token_ids = derive_combo_outcome_position_ids(decoded.condition_id)
                 balance_call = erc1155_balance_of_batch_call(
-                    token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                    token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                     owners=[self._ctx.wallet, self._ctx.wallet],
                     token_ids=list(token_ids),
                 )
@@ -2417,7 +2414,7 @@ class SecureClient:
                 )
                 calls.append(
                     merge_v2_call(
-                        router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                        router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                         condition_id=decoded.condition_id,
                         amount=resolved_amount,
                     )
@@ -2446,7 +2443,7 @@ class SecureClient:
             calls.append(
                 merge_positions_call(
                     target=context.adapter_address,
-                    collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+                    collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
                     condition_id=context.condition_id,
                     amount=resolved_amount,
                 )
@@ -2491,11 +2488,10 @@ class SecureClient:
         """
         if sum(value is not None for value in (condition_id, market_id, position_id)) != 1:
             raise UserInputError("Provide exactly one of condition_id, market_id, or position_id")
-        env = self._ctx.environment
         if position_id is not None:
             decoded = decode_combo_outcome_position_id(position_id)
             balance_call = erc1155_balance_of_call(
-                token_address=cast(EvmAddress, get_environment_config(env).position_manager),
+                token_address=cast(EvmAddress, self._ctx.environment_config.position_manager),
                 owner=self._ctx.wallet,
                 token_id=position_id,
             )
@@ -2505,7 +2501,7 @@ class SecureClient:
             if balance == 0:
                 raise UserInputError("Combo position has no balance to redeem")
             call = redeem_v2_call(
-                router=cast(EvmAddress, get_environment_config(env).protocol_v2_router),
+                router=cast(EvmAddress, self._ctx.environment_config.protocol_v2_router),
                 condition_id=decoded.condition_id,
                 outcome_index=decoded.outcome_index,
                 amount=balance,
@@ -2521,7 +2517,7 @@ class SecureClient:
         )
         call = ctf_redeem_positions_call(
             ctf=context.adapter_address,
-            collateral=cast(EvmAddress, get_environment_config(env).collateral_token),
+            collateral=cast(EvmAddress, self._ctx.environment_config.collateral_token),
             condition_id=context.condition_id,
         )
         resolved_metadata = (
@@ -2577,14 +2573,13 @@ class SecureClient:
         return _combos_actions.execute_collateral_return_plan_sync(self._ctx, plan=plan)
 
     def _broadcast_eoa_call(self, call: TransactionCall) -> SyncEoaTransactionHandle:
-        env = self._ctx.environment
         return broadcast_eoa_call_sync(
             rpc=self._ctx.rpc,
             signer=self._ctx.signer,
             call=call,
-            chain_id=get_environment_config(env).chain_id,
-            max_polls=get_environment_config(env).relayer_max_polls,
-            poll_delay_s=get_environment_config(env).relayer_poll_frequency_ms / 1000,
+            chain_id=self._ctx.environment_config.chain_id,
+            max_polls=self._ctx.environment_config.relayer_max_polls,
+            poll_delay_s=self._ctx.environment_config.relayer_poll_frequency_ms / 1000,
         )
 
     def _dispatch_single_call(
@@ -2627,7 +2622,7 @@ class SecureClient:
     def _deploy_default_deposit_wallet(self) -> None:
         ctx = self._ctx
         current_deposit_wallet = derive_beacon_deposit_wallet_address(
-            ctx.signer.address, get_environment_config(ctx.environment).wallet_derivation
+            ctx.signer.address, ctx.environment_config.wallet_derivation
         )
         if str(ctx.wallet).lower() != current_deposit_wallet.lower():
             raise UserInputError(
@@ -2646,7 +2641,6 @@ class SecureClient:
     ) -> MarketPositionContext:
         if (condition_id is None) == (market_id is None):
             raise UserInputError("Provide exactly one of condition_id or market_id")
-        env = self._ctx.environment
         if condition_id is not None:
             context = f"condition {condition_id}"
             if closed is None:
@@ -2672,18 +2666,18 @@ class SecureClient:
         return normalize_market_position_context(
             markets[0],
             context=context,
-            collateral_adapter=cast(EvmAddress, get_environment_config(env).collateral_adapter),
+            collateral_adapter=cast(EvmAddress, self._ctx.environment_config.collateral_adapter),
             neg_risk_collateral_adapter=cast(
-                EvmAddress, get_environment_config(env).neg_risk_collateral_adapter
+                EvmAddress, self._ctx.environment_config.neg_risk_collateral_adapter
             ),
-            conditional_tokens=cast(EvmAddress, get_environment_config(env).conditional_tokens),
-            neg_risk_adapter=cast(EvmAddress, get_environment_config(env).neg_risk_adapter),
+            conditional_tokens=cast(EvmAddress, self._ctx.environment_config.conditional_tokens),
+            neg_risk_adapter=cast(EvmAddress, self._ctx.environment_config.neg_risk_adapter),
         )
 
 
 def _bootstrap_credentials_sync(
     *,
-    environment: Environment,
+    config: EnvironmentConfig,
     signer: LocalAccount,
     clob: SyncTransport,
     provided: ApiKeyCreds | None,
@@ -2694,7 +2688,7 @@ def _bootstrap_credentials_sync(
     if provided is not None and (
         not validate
         or _credentials_are_active_sync(
-            environment=environment,
+            config=config,
             signer=signer,
             credentials=provided,
             logger=logger,
@@ -2704,7 +2698,7 @@ def _bootstrap_credentials_sync(
 
     signature = sign_api_key_auth(
         signer,
-        chain_id=get_environment_config(environment).chain_id,
+        chain_id=config.chain_id,
         timestamp=int(time.time()),
         nonce=nonce,
     )
@@ -2715,15 +2709,15 @@ def _resolve_requested_wallet_sync(
     *,
     signer: LocalAccount,
     wallet: str | None,
-    environment: Environment,
+    config: EnvironmentConfig,
     logger: logging.Logger | None,
 ) -> str:
     if wallet is not None:
         return wallet
     legacy_deposit_wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(environment).wallet_derivation
+        signer.address, config.wallet_derivation
     )
-    relayer = SyncTransport(base_url=get_environment_config(environment).relayer_url, logger=logger)
+    relayer = SyncTransport(base_url=config.relayer_url, logger=logger)
     try:
         if fetch_deployed_sync(
             relayer,
@@ -2731,9 +2725,7 @@ def _resolve_requested_wallet_sync(
             type=RelayerTransactionType.WALLET,
         ):
             return legacy_deposit_wallet
-        return derive_beacon_deposit_wallet_address(
-            signer.address, get_environment_config(environment).wallet_derivation
-        )
+        return derive_beacon_deposit_wallet_address(signer.address, config.wallet_derivation)
     finally:
         relayer.close()
 
@@ -2752,13 +2744,13 @@ def _relayer_transaction_type_for_wallet(
 
 def _credentials_are_active_sync(
     *,
-    environment: Environment,
+    config: EnvironmentConfig,
     signer: LocalAccount,
     credentials: ApiKeyCreds,
     logger: logging.Logger | None,
 ) -> bool:
     probe = SyncTransport(
-        base_url=get_environment_config(environment).clob_url,
+        base_url=config.clob_url,
         logger=logger,
         header_resolver=_make_l2_header_resolver_sync(signer, credentials),
     )

--- a/src/polymarket/environments.py
+++ b/src/polymarket/environments.py
@@ -1,10 +1,10 @@
 """Polymarket environment configuration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class WalletDerivation:
+class _WalletDerivation:
     proxy_factory: str
     proxy_implementation: str
     safe_factory: str
@@ -15,10 +15,9 @@ class WalletDerivation:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class Environment:
-    name: str
+class _EnvironmentConfig:
     chain_id: int
-    wallet_derivation: WalletDerivation
+    wallet_derivation: _WalletDerivation
     collateral_token: str
     conditional_tokens: str
     neg_risk_adapter: str
@@ -53,38 +52,58 @@ class Environment:
     relayer_poll_frequency_ms: int = 2000
 
 
-PRODUCTION = Environment(
+@dataclass(frozen=True, slots=True, init=False)
+class Environment:
+    """An SDK environment identified by its public name."""
+
+    name: str
+    _config: _EnvironmentConfig = field(repr=False)
+
+    def __init__(self) -> None:
+        raise TypeError("Environment instances are provided by the SDK")
+
+
+def _create_environment(*, name: str, config: _EnvironmentConfig) -> Environment:
+    environment = object.__new__(Environment)
+    object.__setattr__(environment, "name", name)
+    object.__setattr__(environment, "_config", config)
+    return environment
+
+
+PRODUCTION = _create_environment(
     name="production",
-    chain_id=137,
-    wallet_derivation=WalletDerivation(
-        proxy_factory="0xaB45c5A4B0c941a2F231C04C3f49182e1A254052",
-        proxy_implementation="0x44e999d5c2F66Ef0861317f9A4805AC2e90aEB4f",
-        safe_factory="0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b",
-        safe_init_code_hash="0x2bce2127ff07fb632d16c8347c4ebf501f4841168bed00d9e6ef715ddb6fcecf",
-        deposit_wallet_factory="0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
-        deposit_wallet_implementation="0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB",
-        deposit_wallet_beacon="0x7A18EDfe055488A3128f01F563e5B479D92ffc3a",
+    config=_EnvironmentConfig(
+        chain_id=137,
+        wallet_derivation=_WalletDerivation(
+            proxy_factory="0xaB45c5A4B0c941a2F231C04C3f49182e1A254052",
+            proxy_implementation="0x44e999d5c2F66Ef0861317f9A4805AC2e90aEB4f",
+            safe_factory="0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b",
+            safe_init_code_hash="0x2bce2127ff07fb632d16c8347c4ebf501f4841168bed00d9e6ef715ddb6fcecf",
+            deposit_wallet_factory="0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
+            deposit_wallet_implementation="0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB",
+            deposit_wallet_beacon="0x7A18EDfe055488A3128f01F563e5B479D92ffc3a",
+        ),
+        collateral_token="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
+        conditional_tokens="0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
+        neg_risk_adapter="0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
+        collateral_adapter="0xAdA100Db00Ca00073811820692005400218FcE1f",
+        neg_risk_collateral_adapter="0xadA2005600Dec949baf300f4C6120000bDB6eAab",
+        standard_exchange="0xE111180000d2663C0091e4f400237545B87B996B",
+        neg_risk_exchange="0xe2222d279d744050d28e00520010520000310F59",
+        auto_redeem_operator="0xa1200000d0002264C9a1698e001292D00E1b00af",
+        safe_multisend="0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+        relay_hub="0xD216153c06E857cD7f72665E0aF1d7D82172F494",
+        clob_url="https://clob.polymarket.com",
+        clob_market_ws_url="wss://ws-subscriptions-clob.polymarket.com/ws/market",
+        clob_user_ws_url="wss://ws-subscriptions-clob.polymarket.com/ws/user",
+        relayer_url="https://relayer-v2.polymarket.com",
+        gamma_url="https://gamma-api.polymarket.com",
+        data_url="https://data-api.polymarket.com",
+        rfq_url="https://combos-rfq-api.polymarket.com",
+        rtds_ws_url="wss://ws-live-data.polymarket.com",
+        sports_ws_url="wss://sports-api.polymarket.com/ws",
+        rpc_url="https://polygon.drpc.org",
     ),
-    collateral_token="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
-    conditional_tokens="0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
-    neg_risk_adapter="0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
-    collateral_adapter="0xAdA100Db00Ca00073811820692005400218FcE1f",
-    neg_risk_collateral_adapter="0xadA2005600Dec949baf300f4C6120000bDB6eAab",
-    standard_exchange="0xE111180000d2663C0091e4f400237545B87B996B",
-    neg_risk_exchange="0xe2222d279d744050d28e00520010520000310F59",
-    auto_redeem_operator="0xa1200000d0002264C9a1698e001292D00E1b00af",
-    safe_multisend="0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
-    relay_hub="0xD216153c06E857cD7f72665E0aF1d7D82172F494",
-    clob_url="https://clob.polymarket.com",
-    clob_market_ws_url="wss://ws-subscriptions-clob.polymarket.com/ws/market",
-    clob_user_ws_url="wss://ws-subscriptions-clob.polymarket.com/ws/user",
-    relayer_url="https://relayer-v2.polymarket.com",
-    gamma_url="https://gamma-api.polymarket.com",
-    data_url="https://data-api.polymarket.com",
-    rfq_url="https://combos-rfq-api.polymarket.com",
-    rtds_ws_url="wss://ws-live-data.polymarket.com",
-    sports_ws_url="wss://sports-api.polymarket.com/ws",
-    rpc_url="https://polygon.drpc.org",
 )
 
-__all__ = ["Environment", "PRODUCTION", "WalletDerivation"]
+__all__ = ["Environment", "PRODUCTION"]

--- a/tests/integration/test_collateral_return_live.py
+++ b/tests/integration/test_collateral_return_live.py
@@ -28,6 +28,7 @@ from polymarket import (
     TransactionHandle,
     UserInputError,
 )
+from polymarket._internal.environment import get_environment_config
 
 pytestmark = pytest.mark.anyio
 
@@ -86,9 +87,12 @@ async def test_plan_collateral_return_live(deposit_wallet_client: AsyncSecureCli
 
     assert plan.wallet.lower() == str(deposit_wallet_client.wallet).lower()
     _assert_plan_hash(plan)
-    assert plan.chain_id == environment.chain_id
+    assert plan.chain_id == get_environment_config(environment).chain_id
     assert plan.block_number > 0
-    assert plan.router_call.to.lower() == environment.protocol_v2_router.lower()
+    assert (
+        plan.router_call.to.lower()
+        == get_environment_config(environment).protocol_v2_router.lower()
+    )
     assert plan.router_call.data.startswith("0x")
 
 

--- a/tests/integration/test_perps.py
+++ b/tests/integration/test_perps.py
@@ -29,6 +29,7 @@ from polymarket import (
     PerpsTpSlTrigger,
     RequestRejectedError,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket.errors import UnexpectedResponseError
 from polymarket.perps import PerpsSession
 from polymarket.streams import PerpsBookSpec
@@ -134,8 +135,8 @@ async def test_deposits_and_withdraws_the_same_perps_amount(
     client = relayer_enabled_deposit_wallet_client
     approval = await client.approve_erc20(
         amount="max",
-        spender_address=client.environment.perps_deposit_contract,
-        token_address=client.environment.collateral_token,
+        spender_address=get_environment_config(client.environment).perps_deposit_contract,
+        token_address=get_environment_config(client.environment).collateral_token,
     )
     await approval.wait()
 

--- a/tests/integration/test_relayer_approve_live.py
+++ b/tests/integration/test_relayer_approve_live.py
@@ -7,8 +7,7 @@ from contextlib import asynccontextmanager
 import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey, GaslessTransaction
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 
 
 def _builder_auth(require_env: Callable[[str], str]) -> BuilderApiKey:
@@ -102,8 +101,8 @@ def test_approve_erc20_live_against_relayer(
     async def run() -> GaslessTransaction:
         async with _secure_client(require_env) as client:
             handle = await client.approve_erc20(
-                token_address=get_environment_config(PRODUCTION).collateral_token,
-                spender_address=get_environment_config(PRODUCTION).standard_exchange,
+                token_address=PRODUCTION_CONFIG.collateral_token,
+                spender_address=PRODUCTION_CONFIG.standard_exchange,
                 amount=1,
                 metadata="py-sdk integration test: approve_erc20",
             )
@@ -122,8 +121,8 @@ def test_approve_erc1155_for_all_live(require_env: Callable[[str], str]) -> None
     async def run() -> None:
         async with _secure_client(require_env) as client:
             handle = await client.approve_erc1155_for_all(
-                token_address=get_environment_config(PRODUCTION).conditional_tokens,
-                operator_address=get_environment_config(PRODUCTION).standard_exchange,
+                token_address=PRODUCTION_CONFIG.conditional_tokens,
+                operator_address=PRODUCTION_CONFIG.standard_exchange,
                 metadata="py-sdk integration test: approve_erc1155_for_all",
             )
             await handle.wait()
@@ -159,7 +158,7 @@ def test_transfer_erc20_live(require_env: Callable[[str], str]) -> None:
     async def run() -> None:
         async with _secure_client(require_env) as client:
             handle = await client.transfer_erc20(
-                token_address=get_environment_config(PRODUCTION).collateral_token,
+                token_address=PRODUCTION_CONFIG.collateral_token,
                 recipient_address=str(client.wallet),
                 amount=1,
                 metadata="py-sdk integration test: self-transfer",

--- a/tests/integration/test_relayer_approve_live.py
+++ b/tests/integration/test_relayer_approve_live.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey, GaslessTransaction
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 
 
@@ -101,8 +102,8 @@ def test_approve_erc20_live_against_relayer(
     async def run() -> GaslessTransaction:
         async with _secure_client(require_env) as client:
             handle = await client.approve_erc20(
-                token_address=PRODUCTION.collateral_token,
-                spender_address=PRODUCTION.standard_exchange,
+                token_address=get_environment_config(PRODUCTION).collateral_token,
+                spender_address=get_environment_config(PRODUCTION).standard_exchange,
                 amount=1,
                 metadata="py-sdk integration test: approve_erc20",
             )
@@ -121,8 +122,8 @@ def test_approve_erc1155_for_all_live(require_env: Callable[[str], str]) -> None
     async def run() -> None:
         async with _secure_client(require_env) as client:
             handle = await client.approve_erc1155_for_all(
-                token_address=PRODUCTION.conditional_tokens,
-                operator_address=PRODUCTION.standard_exchange,
+                token_address=get_environment_config(PRODUCTION).conditional_tokens,
+                operator_address=get_environment_config(PRODUCTION).standard_exchange,
                 metadata="py-sdk integration test: approve_erc1155_for_all",
             )
             await handle.wait()
@@ -158,7 +159,7 @@ def test_transfer_erc20_live(require_env: Callable[[str], str]) -> None:
     async def run() -> None:
         async with _secure_client(require_env) as client:
             handle = await client.transfer_erc20(
-                token_address=PRODUCTION.collateral_token,
+                token_address=get_environment_config(PRODUCTION).collateral_token,
                 recipient_address=str(client.wallet),
                 amount=1,
                 metadata="py-sdk integration test: self-transfer",

--- a/tests/integration/test_relayer_gasless_live.py
+++ b/tests/integration/test_relayer_gasless_live.py
@@ -1,6 +1,7 @@
 import pytest
 
 from polymarket import AsyncSecureClient, BuilderApiKey, SecureClient
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 
 pytestmark = pytest.mark.anyio
@@ -22,8 +23,8 @@ async def test_async_secure_client_executes_gasless_transaction_for_proxy_wallet
     async with client:
         assert client.wallet_type == "POLY_PROXY"
         handle = await client.approve_erc20(
-            token_address=PRODUCTION.collateral_token,
-            spender_address=PRODUCTION.standard_exchange,
+            token_address=get_environment_config(PRODUCTION).collateral_token,
+            spender_address=get_environment_config(PRODUCTION).standard_exchange,
             amount=1,
             metadata="Test legacy Proxy wallet gasless execution",
         )
@@ -46,8 +47,8 @@ async def test_async_secure_client_executes_gasless_transaction_for_safe_wallet(
     async with client:
         assert client.wallet_type == "GNOSIS_SAFE"
         handle = await client.approve_erc20(
-            token_address=PRODUCTION.collateral_token,
-            spender_address=PRODUCTION.standard_exchange,
+            token_address=get_environment_config(PRODUCTION).collateral_token,
+            spender_address=get_environment_config(PRODUCTION).standard_exchange,
             amount=1,
             metadata="Test legacy Safe wallet gasless execution",
         )
@@ -69,8 +70,8 @@ def test_sync_secure_client_executes_gasless_transaction_for_proxy_wallet(
     ) as client:
         assert client.wallet_type == "POLY_PROXY"
         handle = client.approve_erc20(
-            token_address=PRODUCTION.collateral_token,
-            spender_address=PRODUCTION.standard_exchange,
+            token_address=get_environment_config(PRODUCTION).collateral_token,
+            spender_address=get_environment_config(PRODUCTION).standard_exchange,
             amount=1,
             metadata="Test legacy Proxy wallet sync gasless execution",
         )
@@ -92,8 +93,8 @@ def test_sync_secure_client_executes_gasless_transaction_for_safe_wallet(
     ) as client:
         assert client.wallet_type == "GNOSIS_SAFE"
         handle = client.approve_erc20(
-            token_address=PRODUCTION.collateral_token,
-            spender_address=PRODUCTION.standard_exchange,
+            token_address=get_environment_config(PRODUCTION).collateral_token,
+            spender_address=get_environment_config(PRODUCTION).standard_exchange,
             amount=1,
             metadata="Test legacy Safe wallet sync gasless execution",
         )

--- a/tests/integration/test_relayer_gasless_live.py
+++ b/tests/integration/test_relayer_gasless_live.py
@@ -1,8 +1,7 @@
 import pytest
 
 from polymarket import AsyncSecureClient, BuilderApiKey, SecureClient
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 
 pytestmark = pytest.mark.anyio
 
@@ -23,8 +22,8 @@ async def test_async_secure_client_executes_gasless_transaction_for_proxy_wallet
     async with client:
         assert client.wallet_type == "POLY_PROXY"
         handle = await client.approve_erc20(
-            token_address=get_environment_config(PRODUCTION).collateral_token,
-            spender_address=get_environment_config(PRODUCTION).standard_exchange,
+            token_address=PRODUCTION_CONFIG.collateral_token,
+            spender_address=PRODUCTION_CONFIG.standard_exchange,
             amount=1,
             metadata="Test legacy Proxy wallet gasless execution",
         )
@@ -47,8 +46,8 @@ async def test_async_secure_client_executes_gasless_transaction_for_safe_wallet(
     async with client:
         assert client.wallet_type == "GNOSIS_SAFE"
         handle = await client.approve_erc20(
-            token_address=get_environment_config(PRODUCTION).collateral_token,
-            spender_address=get_environment_config(PRODUCTION).standard_exchange,
+            token_address=PRODUCTION_CONFIG.collateral_token,
+            spender_address=PRODUCTION_CONFIG.standard_exchange,
             amount=1,
             metadata="Test legacy Safe wallet gasless execution",
         )
@@ -70,8 +69,8 @@ def test_sync_secure_client_executes_gasless_transaction_for_proxy_wallet(
     ) as client:
         assert client.wallet_type == "POLY_PROXY"
         handle = client.approve_erc20(
-            token_address=get_environment_config(PRODUCTION).collateral_token,
-            spender_address=get_environment_config(PRODUCTION).standard_exchange,
+            token_address=PRODUCTION_CONFIG.collateral_token,
+            spender_address=PRODUCTION_CONFIG.standard_exchange,
             amount=1,
             metadata="Test legacy Proxy wallet sync gasless execution",
         )
@@ -93,8 +92,8 @@ def test_sync_secure_client_executes_gasless_transaction_for_safe_wallet(
     ) as client:
         assert client.wallet_type == "GNOSIS_SAFE"
         handle = client.approve_erc20(
-            token_address=get_environment_config(PRODUCTION).collateral_token,
-            spender_address=get_environment_config(PRODUCTION).standard_exchange,
+            token_address=PRODUCTION_CONFIG.collateral_token,
+            spender_address=PRODUCTION_CONFIG.standard_exchange,
             amount=1,
             metadata="Test legacy Safe wallet sync gasless execution",
         )

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -11,6 +11,7 @@ import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket import PRODUCTION, ApiKeyCreds, AsyncSecureClient
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.errors import ConnectionLostError, TransportError
 from polymarket.rfq import (
     RfqConfirmationRequestEvent,
@@ -66,7 +67,10 @@ async def _rfq_client(
         private_key=require_env("POLYMARKET_PRIVATE_KEY"),
         wallet=require_env("POLYMARKET_DEPOSIT_WALLET"),
         credentials=_existing_credentials(),
-        environment=replace(PRODUCTION, rfq_quoter_ws_url=ws_url),
+        environment=with_environment_config(
+            PRODUCTION,
+            config=replace(get_environment_config(PRODUCTION), rfq_quoter_ws_url=ws_url),
+        ),
     )
     try:
         yield client

--- a/tests/integration/test_rfq.py
+++ b/tests/integration/test_rfq.py
@@ -11,7 +11,10 @@ import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket import PRODUCTION, ApiKeyCreds, AsyncSecureClient
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket.errors import ConnectionLostError, TransportError
 from polymarket.rfq import (
     RfqConfirmationRequestEvent,
@@ -69,7 +72,7 @@ async def _rfq_client(
         credentials=_existing_credentials(),
         environment=with_environment_config(
             PRODUCTION,
-            config=replace(get_environment_config(PRODUCTION), rfq_quoter_ws_url=ws_url),
+            config=replace(PRODUCTION_CONFIG, rfq_quoter_ws_url=ws_url),
         ),
     )
     try:

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -11,6 +11,7 @@ import httpx
 from eth_utils.crypto import keccak
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey, SecureClient
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.clients._transport import AsyncTransport
 
 PK_DEPLOY_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -31,7 +32,9 @@ async def make_deposit_client() -> AsyncSecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -48,7 +51,9 @@ async def make_proxy_client() -> AsyncSecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_PROXY_WALLET)
-    wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_proxy_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return await AsyncSecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
@@ -79,7 +84,10 @@ async def make_eoa_client_with_rpc(
     from polymarket._internal.eoa.rpc import JsonRpcClient
     from polymarket.environments import PRODUCTION
 
-    env = dataclasses.replace(PRODUCTION, rpc_url="https://rpc.test")
+    env = with_environment_config(
+        PRODUCTION,
+        config=dataclasses.replace(get_environment_config(PRODUCTION), rpc_url="https://rpc.test"),
+    )
     signer = Account.from_key(PK_DEPLOY_WALLET)
     client = await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
@@ -266,7 +274,9 @@ async def make_safe_client() -> AsyncSecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_SAFE_WALLET)
-    wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_safe_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return await AsyncSecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
@@ -386,7 +396,9 @@ def make_sync_deposit_client() -> SecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return SecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -403,7 +415,9 @@ def make_sync_proxy_client() -> SecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_PROXY_WALLET)
-    wallet = derive_proxy_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_proxy_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return SecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
@@ -420,7 +434,9 @@ def make_sync_safe_client() -> SecureClient:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_SAFE_WALLET)
-    wallet = derive_safe_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_safe_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return SecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,

--- a/tests/unit/_relayer_helpers.py
+++ b/tests/unit/_relayer_helpers.py
@@ -11,7 +11,10 @@ import httpx
 from eth_utils.crypto import keccak
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, BuilderApiKey, SecureClient
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket.clients._transport import AsyncTransport
 
 PK_DEPLOY_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -29,12 +32,9 @@ async def make_deposit_client() -> AsyncSecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return await AsyncSecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -48,12 +48,9 @@ async def make_proxy_client() -> AsyncSecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_proxy_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_PROXY_WALLET)
-    wallet = derive_proxy_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_proxy_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return await AsyncSecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
@@ -86,7 +83,7 @@ async def make_eoa_client_with_rpc(
 
     env = with_environment_config(
         PRODUCTION,
-        config=dataclasses.replace(get_environment_config(PRODUCTION), rpc_url="https://rpc.test"),
+        config=dataclasses.replace(PRODUCTION_CONFIG, rpc_url="https://rpc.test"),
     )
     signer = Account.from_key(PK_DEPLOY_WALLET)
     client = await AsyncSecureClient._create(
@@ -271,12 +268,9 @@ async def make_safe_client() -> AsyncSecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_safe_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_SAFE_WALLET)
-    wallet = derive_safe_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_safe_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return await AsyncSecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,
@@ -393,12 +387,9 @@ def make_sync_deposit_client() -> SecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_DEPLOY_WALLET)
-    wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return SecureClient._create(
         private_key=PK_DEPLOY_WALLET,
         wallet=wallet,
@@ -412,12 +403,9 @@ def make_sync_proxy_client() -> SecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_proxy_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_PROXY_WALLET)
-    wallet = derive_proxy_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_proxy_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return SecureClient._create(
         private_key=PK_PROXY_WALLET,
         wallet=wallet,
@@ -431,12 +419,9 @@ def make_sync_safe_client() -> SecureClient:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_safe_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PK_SAFE_WALLET)
-    wallet = derive_safe_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_safe_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return SecureClient._create(
         private_key=PK_SAFE_WALLET,
         wallet=wallet,

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -9,7 +9,7 @@ import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient
 from polymarket._internal.actions.account import END_CURSOR
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import UserInputError
 
@@ -398,11 +398,10 @@ def test_secure_client_defaults_wallet_to_current_deposit_wallet() -> None:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     async def run() -> str:

--- a/tests/unit/test_account_transport.py
+++ b/tests/unit/test_account_transport.py
@@ -9,6 +9,7 @@ import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient
 from polymarket._internal.actions.account import END_CURSOR
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import UserInputError
 
@@ -400,7 +401,9 @@ def test_secure_client_defaults_wallet_to_current_deposit_wallet() -> None:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PRIVATE_KEY)
-    expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     async def run() -> str:
         client = await AsyncSecureClient._create(

--- a/tests/unit/test_bootstrap_credentials.py
+++ b/tests/unit/test_bootstrap_credentials.py
@@ -7,10 +7,10 @@ from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
 from polymarket import ApiKeyCreds
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket._internal.l1_auth import ApiKeyAuthSignature
 from polymarket.clients import async_secure as _module
 from polymarket.clients._transport import AsyncTransport
-from polymarket.environments import PRODUCTION
 from polymarket.errors import RequestRejectedError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -29,7 +29,7 @@ def _clob() -> AsyncTransport:
 def test_bootstrap_returns_provided_credentials_when_validation_disabled() -> None:
     async def run() -> ApiKeyCreds:
         return await _module._bootstrap_credentials(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             clob=_clob(),
             provided=PROVIDED,
@@ -55,7 +55,7 @@ def test_bootstrap_returns_provided_when_validation_confirms_active(
 
     async def run() -> ApiKeyCreds:
         return await _module._bootstrap_credentials(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             clob=_clob(),
             provided=PROVIDED,
@@ -81,7 +81,7 @@ def test_bootstrap_falls_back_to_l1_when_provided_creds_are_inactive(
 
     async def run() -> ApiKeyCreds:
         return await _module._bootstrap_credentials(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             clob=_clob(),
             provided=PROVIDED,
@@ -110,7 +110,7 @@ def test_bootstrap_does_fresh_l1_when_no_credentials_provided(
 
     async def run() -> ApiKeyCreds:
         return await _module._bootstrap_credentials(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             clob=_clob(),
             provided=None,
@@ -136,7 +136,7 @@ def test_credentials_are_active_returns_false_on_401(
 
     async def run() -> bool:
         return await _module._credentials_are_active(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             credentials=PROVIDED,
             logger=None,
@@ -155,7 +155,7 @@ def test_credentials_are_active_returns_false_when_key_not_listed(
 
     async def run() -> bool:
         return await _module._credentials_are_active(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             credentials=PROVIDED,
             logger=None,
@@ -174,7 +174,7 @@ def test_credentials_are_active_propagates_non_401_errors(
 
     async def run() -> bool:
         return await _module._credentials_are_active(
-            environment=PRODUCTION,
+            config=PRODUCTION_CONFIG,
             signer=_signer(),
             credentials=PROVIDED,
             logger=None,

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -15,6 +15,7 @@ from polymarket._internal.actions.builders import (
     build_list_builder_trades_request,
     parse_builder_trades_page,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
@@ -279,8 +280,10 @@ class TestPublicClientListBuilderTrades:
                 data=client._ctx.data,
                 rfq=client._ctx.rfq,
                 clob=SyncTransport(
-                    base_url=PRODUCTION.clob_url,
-                    client=httpx.Client(base_url=PRODUCTION.clob_url, transport=handler),
+                    base_url=get_environment_config(PRODUCTION).clob_url,
+                    client=httpx.Client(
+                        base_url=get_environment_config(PRODUCTION).clob_url, transport=handler
+                    ),
                 ),
             )
 
@@ -329,9 +332,10 @@ class TestAsyncPublicClientListBuilderTrades:
                     data=client._ctx.data,
                     rfq=client._ctx.rfq,
                     clob=AsyncTransport(
-                        base_url=PRODUCTION.clob_url,
+                        base_url=get_environment_config(PRODUCTION).clob_url,
                         client=httpx.AsyncClient(
-                            base_url=PRODUCTION.clob_url, transport=httpx.MockTransport(handler)
+                            base_url=get_environment_config(PRODUCTION).clob_url,
+                            transport=httpx.MockTransport(handler),
                         ),
                     ),
                     perps=client._ctx.perps,
@@ -377,9 +381,10 @@ class TestAsyncSecureClientListBuilderTrades:
                 client._ctx = dataclasses.replace(
                     client._ctx,
                     clob=AsyncTransport(
-                        base_url=PRODUCTION.clob_url,
+                        base_url=get_environment_config(PRODUCTION).clob_url,
                         client=httpx.AsyncClient(
-                            base_url=PRODUCTION.clob_url, transport=httpx.MockTransport(handler)
+                            base_url=get_environment_config(PRODUCTION).clob_url,
+                            transport=httpx.MockTransport(handler),
                         ),
                     ),
                 )

--- a/tests/unit/test_builder_trades.py
+++ b/tests/unit/test_builder_trades.py
@@ -15,9 +15,8 @@ from polymarket._internal.actions.builders import (
     build_list_builder_trades_request,
     parse_builder_trades_page,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.clients._transport import AsyncTransport, SyncTransport
-from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.models.clob.builder import BuilderTrade
 
@@ -280,10 +279,8 @@ class TestPublicClientListBuilderTrades:
                 data=client._ctx.data,
                 rfq=client._ctx.rfq,
                 clob=SyncTransport(
-                    base_url=get_environment_config(PRODUCTION).clob_url,
-                    client=httpx.Client(
-                        base_url=get_environment_config(PRODUCTION).clob_url, transport=handler
-                    ),
+                    base_url=PRODUCTION_CONFIG.clob_url,
+                    client=httpx.Client(base_url=PRODUCTION_CONFIG.clob_url, transport=handler),
                 ),
             )
 
@@ -332,9 +329,9 @@ class TestAsyncPublicClientListBuilderTrades:
                     data=client._ctx.data,
                     rfq=client._ctx.rfq,
                     clob=AsyncTransport(
-                        base_url=get_environment_config(PRODUCTION).clob_url,
+                        base_url=PRODUCTION_CONFIG.clob_url,
                         client=httpx.AsyncClient(
-                            base_url=get_environment_config(PRODUCTION).clob_url,
+                            base_url=PRODUCTION_CONFIG.clob_url,
                             transport=httpx.MockTransport(handler),
                         ),
                     ),
@@ -381,9 +378,9 @@ class TestAsyncSecureClientListBuilderTrades:
                 client._ctx = dataclasses.replace(
                     client._ctx,
                     clob=AsyncTransport(
-                        base_url=get_environment_config(PRODUCTION).clob_url,
+                        base_url=PRODUCTION_CONFIG.clob_url,
                         client=httpx.AsyncClient(
-                            base_url=get_environment_config(PRODUCTION).clob_url,
+                            base_url=PRODUCTION_CONFIG.clob_url,
                             transport=httpx.MockTransport(handler),
                         ),
                     ),

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,6 +13,7 @@ from polymarket import (
     SecureClient,
 )
 from polymarket._internal.context import AsyncSecureClientContext
+from polymarket._internal.environment import get_environment_config
 from polymarket.errors import UserInputError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -161,8 +162,12 @@ def test_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitted(
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
-    legacy_wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    expected = derive_beacon_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    legacy_wallet = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
+    expected = derive_beacon_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     def fake_fetch_deployed_sync(
         *args: object, address: str, type: RelayerTransactionType | None
@@ -193,7 +198,9 @@ def test_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_when_om
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
-    expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     def fake_fetch_deployed_sync(
         *args: object, address: str, type: RelayerTransactionType | None
@@ -235,8 +242,12 @@ def test_async_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitt
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
-    legacy_wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
-    expected = derive_beacon_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    legacy_wallet = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
+    expected = derive_beacon_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     async def fake_fetch_deployed(
         *args: object, address: str, type: RelayerTransactionType | None
@@ -273,7 +284,9 @@ def test_async_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_w
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
-    expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     async def fake_fetch_deployed(
         *args: object, address: str, type: RelayerTransactionType | None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,7 +13,7 @@ from polymarket import (
     SecureClient,
 )
 from polymarket._internal.context import AsyncSecureClientContext
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.errors import UserInputError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -158,15 +158,14 @@ def test_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitted(
         derive_beacon_deposit_wallet_address,
         derive_uups_deposit_wallet_address,
     )
-    from polymarket.environments import PRODUCTION
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     legacy_wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
     expected = derive_beacon_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     def fake_fetch_deployed_sync(
@@ -194,12 +193,11 @@ def test_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_when_om
 
     import polymarket.clients.secure as secure_module
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     def fake_fetch_deployed_sync(
@@ -238,15 +236,14 @@ def test_async_secure_client_wallet_defaults_to_beacon_deposit_wallet_when_omitt
         derive_beacon_deposit_wallet_address,
         derive_uups_deposit_wallet_address,
     )
-    from polymarket.environments import PRODUCTION
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     legacy_wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
     expected = derive_beacon_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     async def fake_fetch_deployed(
@@ -280,12 +277,11 @@ def test_async_secure_client_wallet_defaults_to_existing_legacy_deposit_wallet_w
 
     import polymarket.clients.async_secure as async_secure_module
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
     from polymarket.models.clob.relayer import RelayerTransactionType
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     async def fake_fetch_deployed(

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -22,7 +22,10 @@ from _relayer_helpers import (
 )
 
 from polymarket import CollateralReturnOperationKind, CollateralReturnPlanResponse
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket.environments import PRODUCTION
 from polymarket.errors import (
     RequestRejectedError,
@@ -73,7 +76,7 @@ def _plan_payload(*, wallet: str, **overrides: object) -> dict[str, object]:
         },
         "candidate_position_ids": ["42"],
         "router_call": {
-            "to": get_environment_config(PRODUCTION).protocol_v2_router,
+            "to": PRODUCTION_CONFIG.protocol_v2_router,
             "data": _ROUTER_DATA,
         },
     }
@@ -223,7 +226,7 @@ def test_execute_submits_router_call_for_deposit_wallet() -> None:
     assert body["envelope"]["type"] == "WALLET"
     assert body["envelope"]["depositWalletParams"]["calls"] == [
         {
-            "target": get_environment_config(PRODUCTION).protocol_v2_router,
+            "target": PRODUCTION_CONFIG.protocol_v2_router,
             "value": "0",
             "data": _ROUTER_DATA,
         }
@@ -335,9 +338,7 @@ def test_execute_resubmits_with_fresh_nonce_on_transient_wallet_busy() -> None:
             client._ctx,
             environment=with_environment_config(
                 PRODUCTION,
-                config=dataclasses.replace(
-                    get_environment_config(PRODUCTION), relayer_poll_frequency_ms=0
-                ),
+                config=dataclasses.replace(PRODUCTION_CONFIG, relayer_poll_frequency_ms=0),
             ),
         )
         install_relayer_routes(client, relayer_captured, _nonce_route(client, nonce="5"))

--- a/tests/unit/test_collateral_return.py
+++ b/tests/unit/test_collateral_return.py
@@ -22,6 +22,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import CollateralReturnOperationKind, CollateralReturnPlanResponse
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.environments import PRODUCTION
 from polymarket.errors import (
     RequestRejectedError,
@@ -71,7 +72,10 @@ def _plan_payload(*, wallet: str, **overrides: object) -> dict[str, object]:
             "created": [],
         },
         "candidate_position_ids": ["42"],
-        "router_call": {"to": PRODUCTION.protocol_v2_router, "data": _ROUTER_DATA},
+        "router_call": {
+            "to": get_environment_config(PRODUCTION).protocol_v2_router,
+            "data": _ROUTER_DATA,
+        },
     }
     payload.update(overrides)
     return payload
@@ -218,7 +222,11 @@ def test_execute_submits_router_call_for_deposit_wallet() -> None:
     assert body["plan_hash"] == _PLAN_HASH
     assert body["envelope"]["type"] == "WALLET"
     assert body["envelope"]["depositWalletParams"]["calls"] == [
-        {"target": PRODUCTION.protocol_v2_router, "value": "0", "data": _ROUTER_DATA}
+        {
+            "target": get_environment_config(PRODUCTION).protocol_v2_router,
+            "value": "0",
+            "data": _ROUTER_DATA,
+        }
     ]
 
 
@@ -325,7 +333,12 @@ def test_execute_resubmits_with_fresh_nonce_on_transient_wallet_busy() -> None:
         client = await make_deposit_client()
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(PRODUCTION, relayer_poll_frequency_ms=0),
+            environment=with_environment_config(
+                PRODUCTION,
+                config=dataclasses.replace(
+                    get_environment_config(PRODUCTION), relayer_poll_frequency_ms=0
+                ),
+            ),
         )
         install_relayer_routes(client, relayer_captured, _nonce_route(client, nonce="5"))
         install_combos_handler(client, handler)

--- a/tests/unit/test_environments.py
+++ b/tests/unit/test_environments.py
@@ -1,0 +1,14 @@
+import pytest
+
+from polymarket import PRODUCTION, Environment
+
+
+def test_environment_only_exposes_its_name() -> None:
+    assert PRODUCTION.name == "production"
+    assert {name for name in dir(PRODUCTION) if not name.startswith("_")} == {"name"}
+    assert repr(PRODUCTION) == "Environment(name='production')"
+
+
+def test_environment_cannot_be_constructed_directly() -> None:
+    with pytest.raises(TypeError, match="provided by the SDK"):
+        Environment()

--- a/tests/unit/test_environments.py
+++ b/tests/unit/test_environments.py
@@ -1,6 +1,12 @@
+# pyright: reportPrivateUsage=false
+
+from typing import NoReturn
+
 import pytest
 
-from polymarket import PRODUCTION, Environment
+from polymarket import PRODUCTION, Environment, PublicClient
+from polymarket._internal import context as context_module
+from polymarket._internal.environment import PRODUCTION_CONFIG
 
 
 def test_environment_only_exposes_its_name() -> None:
@@ -12,3 +18,15 @@ def test_environment_only_exposes_its_name() -> None:
 def test_environment_cannot_be_constructed_directly() -> None:
     with pytest.raises(TypeError, match="provided by the SDK"):
         Environment()
+
+
+def test_client_context_reuses_ingested_environment_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_lookup(_environment: Environment) -> NoReturn:
+        raise AssertionError("context should reuse the config resolved by the client")
+
+    monkeypatch.setattr(context_module, "get_environment_config", unexpected_lookup)
+
+    with PublicClient() as client:
+        assert client._ctx.environment_config is PRODUCTION_CONFIG

--- a/tests/unit/test_eoa_broadcast.py
+++ b/tests/unit/test_eoa_broadcast.py
@@ -11,6 +11,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import TransactionCall
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.errors import TimeoutError, TransactionFailedError, UserInputError
 from polymarket.transactions import DeprecatedTransactionHandle, EoaTransactionHandle
 from polymarket.types import EvmAddress
@@ -52,7 +53,12 @@ def test_eoa_wait_returns_outcome_on_success_receipt() -> None:
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             handle = await client.approve_erc20(
@@ -75,7 +81,12 @@ def test_eoa_wait_raises_on_reverted_receipt() -> None:
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             handle = await client.approve_erc20(
@@ -99,10 +110,13 @@ def test_eoa_wait_times_out_when_receipt_never_appears() -> None:
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(
+            environment=with_environment_config(
                 client._ctx.environment,
-                relayer_poll_frequency_ms=1,
-                relayer_max_polls=3,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment),
+                    relayer_poll_frequency_ms=1,
+                    relayer_max_polls=3,
+                ),
             ),
         )
         try:
@@ -195,7 +209,12 @@ def test_eoa_setup_trading_approvals_submits_and_waits_for_required_calls_sequen
         client = await make_eoa_client_with_rpc(rpc_handler=handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             return await client.setup_trading_approvals()

--- a/tests/unit/test_eoa_broadcast.py
+++ b/tests/unit/test_eoa_broadcast.py
@@ -11,7 +11,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import TransactionCall
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import with_environment_config
 from polymarket.errors import TimeoutError, TransactionFailedError, UserInputError
 from polymarket.transactions import DeprecatedTransactionHandle, EoaTransactionHandle
 from polymarket.types import EvmAddress
@@ -56,7 +56,7 @@ def test_eoa_wait_returns_outcome_on_success_receipt() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -84,7 +84,7 @@ def test_eoa_wait_raises_on_reverted_receipt() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -113,7 +113,7 @@ def test_eoa_wait_times_out_when_receipt_never_appears() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment),
+                    client._ctx.environment_config,
                     relayer_poll_frequency_ms=1,
                     relayer_max_polls=3,
                 ),
@@ -212,7 +212,7 @@ def test_eoa_setup_trading_approvals_submits_and_waits_for_required_calls_sequen
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )

--- a/tests/unit/test_factory_beacon_detection.py
+++ b/tests/unit/test_factory_beacon_detection.py
@@ -5,7 +5,7 @@ import json
 import httpx
 import pytest
 
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket._internal.eoa.rpc import JsonRpcCallError, JsonRpcClient
 from polymarket._internal.wallet import (
     derive_beacon_deposit_wallet_address,
@@ -15,10 +15,9 @@ from polymarket._internal.wallet import (
     is_beacon_deposit_wallet_factory,
 )
 from polymarket.clients._transport import AsyncTransport
-from polymarket.environments import PRODUCTION
 
-_FACTORY = get_environment_config(PRODUCTION).wallet_derivation.deposit_wallet_factory
-_BEACON = get_environment_config(PRODUCTION).wallet_derivation.deposit_wallet_beacon
+_FACTORY = PRODUCTION_CONFIG.wallet_derivation.deposit_wallet_factory
+_BEACON = PRODUCTION_CONFIG.wallet_derivation.deposit_wallet_beacon
 _SIGNER = "0x0000000000000000000000000000000000000001"
 _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _FACTORY_BEACON_SELECTOR = "0x49493a4d"
@@ -159,7 +158,7 @@ def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
         rpc = _rpc(handler)
         try:
             return await derive_current_deposit_wallet_address(
-                rpc, _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+                rpc, _SIGNER, PRODUCTION_CONFIG.wallet_derivation
             )
         finally:
             await rpc.close()
@@ -168,7 +167,7 @@ def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
     assert (
         result.lower()
         == derive_beacon_deposit_wallet_address(
-            _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+            _SIGNER, PRODUCTION_CONFIG.wallet_derivation
         ).lower()
     )
 
@@ -180,7 +179,7 @@ def test_derive_current_picks_uups_when_factory_reverts() -> None:
         rpc = _rpc(handler)
         try:
             return await derive_current_deposit_wallet_address(
-                rpc, _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+                rpc, _SIGNER, PRODUCTION_CONFIG.wallet_derivation
             )
         finally:
             await rpc.close()
@@ -188,7 +187,5 @@ def test_derive_current_picks_uups_when_factory_reverts() -> None:
     result = asyncio.run(run())
     assert (
         result.lower()
-        == derive_uups_deposit_wallet_address(
-            _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
-        ).lower()
+        == derive_uups_deposit_wallet_address(_SIGNER, PRODUCTION_CONFIG.wallet_derivation).lower()
     )

--- a/tests/unit/test_factory_beacon_detection.py
+++ b/tests/unit/test_factory_beacon_detection.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import pytest
 
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.eoa.rpc import JsonRpcCallError, JsonRpcClient
 from polymarket._internal.wallet import (
     derive_beacon_deposit_wallet_address,
@@ -16,8 +17,8 @@ from polymarket._internal.wallet import (
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION
 
-_FACTORY = PRODUCTION.wallet_derivation.deposit_wallet_factory
-_BEACON = PRODUCTION.wallet_derivation.deposit_wallet_beacon
+_FACTORY = get_environment_config(PRODUCTION).wallet_derivation.deposit_wallet_factory
+_BEACON = get_environment_config(PRODUCTION).wallet_derivation.deposit_wallet_beacon
 _SIGNER = "0x0000000000000000000000000000000000000001"
 _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _FACTORY_BEACON_SELECTOR = "0x49493a4d"
@@ -158,7 +159,7 @@ def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
         rpc = _rpc(handler)
         try:
             return await derive_current_deposit_wallet_address(
-                rpc, _SIGNER, PRODUCTION.wallet_derivation
+                rpc, _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
             )
         finally:
             await rpc.close()
@@ -166,7 +167,9 @@ def test_derive_current_picks_beacon_when_factory_exposes_beacon() -> None:
     result = asyncio.run(run())
     assert (
         result.lower()
-        == derive_beacon_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+        == derive_beacon_deposit_wallet_address(
+            _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+        ).lower()
     )
 
 
@@ -177,7 +180,7 @@ def test_derive_current_picks_uups_when_factory_reverts() -> None:
         rpc = _rpc(handler)
         try:
             return await derive_current_deposit_wallet_address(
-                rpc, _SIGNER, PRODUCTION.wallet_derivation
+                rpc, _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
             )
         finally:
             await rpc.close()
@@ -185,5 +188,7 @@ def test_derive_current_picks_uups_when_factory_reverts() -> None:
     result = asyncio.run(run())
     assert (
         result.lower()
-        == derive_uups_deposit_wallet_address(_SIGNER, PRODUCTION.wallet_derivation).lower()
+        == derive_uups_deposit_wallet_address(
+            _SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+        ).lower()
     )

--- a/tests/unit/test_order_context.py
+++ b/tests/unit/test_order_context.py
@@ -8,8 +8,7 @@ from polymarket._internal.actions.orders.context import (
     validate_price_on_tick_grid,
 )
 from polymarket._internal.actions.orders.math import decimal_places
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.errors import UnexpectedResponseError, UserInputError
 
 
@@ -35,15 +34,15 @@ def test_resolve_rounding_config_rejects_unsupported_tick_size() -> None:
 
 def test_resolve_exchange_address_selects_neg_risk_when_true() -> None:
     assert (
-        resolve_exchange_address(PRODUCTION, neg_risk=True)
-        == get_environment_config(PRODUCTION).neg_risk_exchange
+        resolve_exchange_address(PRODUCTION_CONFIG, neg_risk=True)
+        == PRODUCTION_CONFIG.neg_risk_exchange
     )
 
 
 def test_resolve_exchange_address_selects_standard_when_false() -> None:
     assert (
-        resolve_exchange_address(PRODUCTION, neg_risk=False)
-        == get_environment_config(PRODUCTION).standard_exchange
+        resolve_exchange_address(PRODUCTION_CONFIG, neg_risk=False)
+        == PRODUCTION_CONFIG.standard_exchange
     )
 
 

--- a/tests/unit/test_order_context.py
+++ b/tests/unit/test_order_context.py
@@ -8,6 +8,7 @@ from polymarket._internal.actions.orders.context import (
     validate_price_on_tick_grid,
 )
 from polymarket._internal.actions.orders.math import decimal_places
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 
@@ -33,11 +34,17 @@ def test_resolve_rounding_config_rejects_unsupported_tick_size() -> None:
 
 
 def test_resolve_exchange_address_selects_neg_risk_when_true() -> None:
-    assert resolve_exchange_address(PRODUCTION, neg_risk=True) == PRODUCTION.neg_risk_exchange
+    assert (
+        resolve_exchange_address(PRODUCTION, neg_risk=True)
+        == get_environment_config(PRODUCTION).neg_risk_exchange
+    )
 
 
 def test_resolve_exchange_address_selects_standard_when_false() -> None:
-    assert resolve_exchange_address(PRODUCTION, neg_risk=False) == PRODUCTION.standard_exchange
+    assert (
+        resolve_exchange_address(PRODUCTION, neg_risk=False)
+        == get_environment_config(PRODUCTION).standard_exchange
+    )
 
 
 # Prices are generated as integer numerators over the tick's scale, which

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -13,9 +13,8 @@ from polymarket._internal.actions.orders.limit import (
     prepare_limit_order_draft,
     validate_limit_order_params,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.clients._transport import AsyncTransport
-from polymarket.environments import PRODUCTION
 from polymarket.errors import UserInputError
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -243,7 +242,7 @@ def test_prepare_limit_order_draft_buy_computes_offered_requested() -> None:
     assert offered == 5_000_000  # 10 * 0.5 USDC base units
     assert requested == 10_000_000  # 10 shares base units
     assert order_type == "GTC"
-    assert exchange == get_environment_config(PRODUCTION).standard_exchange
+    assert exchange == PRODUCTION_CONFIG.standard_exchange
 
 
 def test_prepare_limit_order_draft_sell_swaps_amounts() -> None:
@@ -264,7 +263,7 @@ def test_prepare_limit_order_draft_sell_swaps_amounts() -> None:
     offered, requested, exchange = asyncio.run(run())
     assert offered == 10_000_000  # 10 shares
     assert requested == 5_000_000  # 5 USDC
-    assert exchange == get_environment_config(PRODUCTION).neg_risk_exchange
+    assert exchange == PRODUCTION_CONFIG.neg_risk_exchange
 
 
 def test_prepare_limit_order_draft_sets_gtd_when_expiration_given() -> None:

--- a/tests/unit/test_order_limit.py
+++ b/tests/unit/test_order_limit.py
@@ -13,6 +13,7 @@ from polymarket._internal.actions.orders.limit import (
     prepare_limit_order_draft,
     validate_limit_order_params,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UserInputError
@@ -242,7 +243,7 @@ def test_prepare_limit_order_draft_buy_computes_offered_requested() -> None:
     assert offered == 5_000_000  # 10 * 0.5 USDC base units
     assert requested == 10_000_000  # 10 shares base units
     assert order_type == "GTC"
-    assert exchange == PRODUCTION.standard_exchange
+    assert exchange == get_environment_config(PRODUCTION).standard_exchange
 
 
 def test_prepare_limit_order_draft_sell_swaps_amounts() -> None:
@@ -263,7 +264,7 @@ def test_prepare_limit_order_draft_sell_swaps_amounts() -> None:
     offered, requested, exchange = asyncio.run(run())
     assert offered == 10_000_000  # 10 shares
     assert requested == 5_000_000  # 5 USDC
-    assert exchange == PRODUCTION.neg_risk_exchange
+    assert exchange == get_environment_config(PRODUCTION).neg_risk_exchange
 
 
 def test_prepare_limit_order_draft_sets_gtd_when_expiration_given() -> None:

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -12,6 +12,7 @@ from polymarket._internal.actions.orders.place import (
     is_balance_or_allowance_rejection,
     post_order_with_allowance_recovery,
 )
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket._internal.wallet import derive_uups_deposit_wallet_address
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION
@@ -19,7 +20,7 @@ from polymarket.errors import RequestRejectedError
 
 _PRIVATE_KEY = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 _CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
-_STANDARD_EXCHANGE = PRODUCTION.standard_exchange
+_STANDARD_EXCHANGE = get_environment_config(PRODUCTION).standard_exchange
 _CONDITION_ID = "0x5c19f205507ce03ff5f3be08a8090a5969ea6870cc07b902a4ca2e61dfe48fdd"
 
 
@@ -33,7 +34,9 @@ async def _make_deposit_client() -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(_PRIVATE_KEY)
-    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    wallet = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
     return await AsyncSecureClient._create(
         private_key=_PRIVATE_KEY,
         wallet=wallet,
@@ -276,7 +279,12 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
         client = await _make_deposit_client()
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             _install_clob(client, _public_handler(public_captured))
@@ -307,7 +315,7 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
 
     body = _json.loads(approve_submit.content.decode("utf-8"))
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_token.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_token.lower()
 
 
 def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retries() -> None:
@@ -369,7 +377,12 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
         client = await _make_deposit_client()
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             _install_clob(client, _public_handler(public_captured))
@@ -402,7 +415,7 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
     body = _json.loads(approve_submit.content.decode("utf-8"))
     inner = body["depositWalletParams"]["calls"][0]
     set_approval_selector = "0xa22cb465"  # setApprovalForAll(address,bool)
-    assert inner["target"].lower() == PRODUCTION.conditional_tokens.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).conditional_tokens.lower()
     assert inner["data"].startswith(set_approval_selector)
 
 
@@ -465,7 +478,12 @@ def test_place_limit_order_retry_failure_surfaces_directly() -> None:
         client = await _make_deposit_client()
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             _install_clob(client, _public_handler(public_captured))

--- a/tests/unit/test_place_order_recovery.py
+++ b/tests/unit/test_place_order_recovery.py
@@ -12,15 +12,17 @@ from polymarket._internal.actions.orders.place import (
     is_balance_or_allowance_rejection,
     post_order_with_allowance_recovery,
 )
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket._internal.wallet import derive_uups_deposit_wallet_address
 from polymarket.clients._transport import AsyncTransport
-from polymarket.environments import PRODUCTION
 from polymarket.errors import RequestRejectedError
 
 _PRIVATE_KEY = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 _CREDS = ApiKeyCreds(key="k", passphrase="p", secret="dGVzdA==")
-_STANDARD_EXCHANGE = get_environment_config(PRODUCTION).standard_exchange
+_STANDARD_EXCHANGE = PRODUCTION_CONFIG.standard_exchange
 _CONDITION_ID = "0x5c19f205507ce03ff5f3be08a8090a5969ea6870cc07b902a4ca2e61dfe48fdd"
 
 
@@ -34,9 +36,7 @@ async def _make_deposit_client() -> AsyncSecureClient:
     from eth_account import Account
 
     signer = Account.from_key(_PRIVATE_KEY)
-    wallet = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION_CONFIG.wallet_derivation)
     return await AsyncSecureClient._create(
         private_key=_PRIVATE_KEY,
         wallet=wallet,
@@ -282,7 +282,7 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -315,7 +315,7 @@ def test_place_limit_order_recovers_buy_with_approve_max_then_retries() -> None:
 
     body = _json.loads(approve_submit.content.decode("utf-8"))
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_token.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_token.lower()
 
 
 def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retries() -> None:
@@ -380,7 +380,7 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -415,7 +415,7 @@ def test_place_limit_order_recovers_sell_with_erc1155_approve_for_all_then_retri
     body = _json.loads(approve_submit.content.decode("utf-8"))
     inner = body["depositWalletParams"]["calls"][0]
     set_approval_selector = "0xa22cb465"  # setApprovalForAll(address,bool)
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).conditional_tokens.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.conditional_tokens.lower()
     assert inner["data"].startswith(set_approval_selector)
 
 
@@ -481,7 +481,7 @@ def test_place_limit_order_retry_failure_surfaces_directly() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -22,6 +22,7 @@ from _relayer_helpers import (
 )
 
 from polymarket import AsyncSecureClient
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.errors import UserInputError
 from polymarket.transactions import TransactionHandle
 
@@ -34,7 +35,9 @@ def test_approve_erc20_rejects_when_no_api_key() -> None:
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(
+            signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        )
         client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,
@@ -338,7 +341,12 @@ def test_approve_erc20_retries_with_fresh_nonce_on_nonce_mismatch() -> None:
         install_relayer_handler(client, handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         try:
             await client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
@@ -451,7 +459,12 @@ def test_wait_polls_until_confirmed() -> None:
         install_relayer_handler(client, handler)
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=10),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=10
+                ),
+            ),
         )
         try:
             handle = await client.approve_erc20(
@@ -477,7 +490,9 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
-        wallet = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+        wallet = derive_uups_deposit_wallet_address(
+            signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        )
         client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,
             wallet=wallet,

--- a/tests/unit/test_relayer_approve_erc20.py
+++ b/tests/unit/test_relayer_approve_erc20.py
@@ -22,7 +22,10 @@ from _relayer_helpers import (
 )
 
 from polymarket import AsyncSecureClient
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket.errors import UserInputError
 from polymarket.transactions import TransactionHandle
 
@@ -31,12 +34,11 @@ def test_approve_erc20_rejects_when_no_api_key() -> None:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(
-            signer.address, get_environment_config(PRODUCTION).wallet_derivation
+            signer.address, PRODUCTION_CONFIG.wallet_derivation
         )
         client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,
@@ -344,7 +346,7 @@ def test_approve_erc20_retries_with_fresh_nonce_on_nonce_mismatch() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -462,7 +464,7 @@ def test_wait_polls_until_confirmed() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=10
+                    client._ctx.environment_config, relayer_poll_frequency_ms=10
                 ),
             ),
         )
@@ -484,14 +486,13 @@ def test_approve_erc20_works_with_relayer_api_key() -> None:
 
     from polymarket import RelayerApiKey
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     captured: list[httpx.Request] = []
 
     async def run() -> None:
         signer = Account.from_key(PK_DEPLOY_WALLET)
         wallet = derive_uups_deposit_wallet_address(
-            signer.address, get_environment_config(PRODUCTION).wallet_derivation
+            signer.address, PRODUCTION_CONFIG.wallet_derivation
         )
         client = await AsyncSecureClient._create(
             private_key=PK_DEPLOY_WALLET,

--- a/tests/unit/test_relayer_merge_positions.py
+++ b/tests/unit/test_relayer_merge_positions.py
@@ -16,8 +16,7 @@ from _relayer_helpers import (
 )
 from eth_abi.abi import encode as abi_encode
 
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
 
@@ -73,12 +72,9 @@ def test_merge_positions_resolves_max_to_min_of_yes_no() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_adapter.lower()
     assert "Merge 60000000 positions" in body["metadata"]
-    assert (
-        rpc_calls[0]["params"][0]["to"].lower()
-        == get_environment_config(PRODUCTION).conditional_tokens.lower()
-    )
+    assert rpc_calls[0]["params"][0]["to"].lower() == PRODUCTION_CONFIG.conditional_tokens.lower()
 
 
 def test_merge_positions_rejects_amount_above_max() -> None:
@@ -121,14 +117,8 @@ def test_merge_positions_neg_risk_uses_neg_risk_collateral_adapter_target() -> N
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert (
-        inner["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
-    assert (
-        rpc_calls[0]["params"][0]["to"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_adapter.lower()
-    )
+    assert inner["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
+    assert rpc_calls[0]["params"][0]["to"].lower() == PRODUCTION_CONFIG.neg_risk_adapter.lower()
 
 
 def test_merge_positions_rejects_when_no_complementary_balance() -> None:

--- a/tests/unit/test_relayer_merge_positions.py
+++ b/tests/unit/test_relayer_merge_positions.py
@@ -16,6 +16,7 @@ from _relayer_helpers import (
 )
 from eth_abi.abi import encode as abi_encode
 
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
@@ -72,9 +73,12 @@ def test_merge_positions_resolves_max_to_min_of_yes_no() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
     assert "Merge 60000000 positions" in body["metadata"]
-    assert rpc_calls[0]["params"][0]["to"].lower() == PRODUCTION.conditional_tokens.lower()
+    assert (
+        rpc_calls[0]["params"][0]["to"].lower()
+        == get_environment_config(PRODUCTION).conditional_tokens.lower()
+    )
 
 
 def test_merge_positions_rejects_amount_above_max() -> None:
@@ -117,8 +121,14 @@ def test_merge_positions_neg_risk_uses_neg_risk_collateral_adapter_target() -> N
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
-    assert rpc_calls[0]["params"][0]["to"].lower() == PRODUCTION.neg_risk_adapter.lower()
+    assert (
+        inner["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
+    assert (
+        rpc_calls[0]["params"][0]["to"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_adapter.lower()
+    )
 
 
 def test_merge_positions_rejects_when_no_complementary_balance() -> None:

--- a/tests/unit/test_relayer_position_workflows.py
+++ b/tests/unit/test_relayer_position_workflows.py
@@ -19,9 +19,8 @@ from eth_abi.abi import encode as abi_encode
 from eth_utils.crypto import keccak
 
 from polymarket import AsyncSecureClient
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.calls import merge_v2_call
-from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.transactions import GaslessTransactionHandle
 from polymarket.types import EvmAddress
@@ -44,13 +43,8 @@ def test_split_position_with_combo_legs_bundles_prepare_and_split() -> None:
     asyncio.run(run())
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
-    assert (
-        calls[0]["target"].lower()
-        == get_environment_config(PRODUCTION).combinatorial_module.lower()
-    )
-    assert (
-        calls[1]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
-    )
+    assert calls[0]["target"].lower() == PRODUCTION_CONFIG.combinatorial_module.lower()
+    assert calls[1]["target"].lower() == PRODUCTION_CONFIG.protocol_v2_router.lower()
     assert calls[0]["data"].startswith("0x" + keccak(b"prepareCondition(uint256[])")[:4].hex())
     assert calls[1]["data"].startswith("0x" + keccak(b"split(bytes31,uint256)")[:4].hex())
     assert body["metadata"] == f"Split 5 combo positions for condition {_COMBO_CONDITION_ID}"
@@ -74,13 +68,8 @@ def test_merge_positions_with_combo_legs_uses_onchain_balances() -> None:
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
     assert len(calls) == 2
-    assert (
-        calls[0]["target"].lower()
-        == get_environment_config(PRODUCTION).combinatorial_module.lower()
-    )
-    assert (
-        calls[1]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
-    )
+    assert calls[0]["target"].lower() == PRODUCTION_CONFIG.combinatorial_module.lower()
+    assert calls[1]["target"].lower() == PRODUCTION_CONFIG.protocol_v2_router.lower()
     assert calls[1]["data"].startswith("0x" + keccak(b"merge(bytes31,uint256)")[:4].hex())
     assert body["metadata"] == f"Merge 60 combo positions for condition {_COMBO_CONDITION_ID}"
 
@@ -102,16 +91,14 @@ def test_redeem_positions_with_combo_position_id_uses_onchain_balance() -> None:
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
     assert len(calls) == 1
-    assert (
-        calls[0]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
-    )
+    assert calls[0]["target"].lower() == PRODUCTION_CONFIG.protocol_v2_router.lower()
     assert calls[0]["data"].startswith("0x" + keccak(b"redeem(bytes31,uint256,uint256)")[:4].hex())
     assert body["metadata"] == f"Redeem combo position {position_id}"
 
 
 def test_execute_transaction_async_batches_custom_calls() -> None:
     captured: list[httpx.Request] = []
-    router = EvmAddress(get_environment_config(PRODUCTION).protocol_v2_router)
+    router = EvmAddress(PRODUCTION_CONFIG.protocol_v2_router)
 
     async def run() -> object:
         client = await make_deposit_client()
@@ -165,7 +152,7 @@ def test_merge_multiple_positions_async_batches_combo_merges() -> None:
     assert len(calls) == 3
     assert body["metadata"] == "Merge selected combo positions"
     assert {call["target"].lower() for call in calls} == {
-        get_environment_config(PRODUCTION).protocol_v2_router.lower()
+        PRODUCTION_CONFIG.protocol_v2_router.lower()
     }
     assert [call["data"][-64:] for call in calls] == [
         f"{1:064x}",
@@ -219,7 +206,7 @@ def test_merge_multiple_positions_async_batches_market_merges() -> None:
     assert len(calls) == 2
     assert body["metadata"] == "Merge selected market positions"
     assert {call["target"].lower() for call in calls} == {
-        get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+        PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
     }
     assert [_decode_merge_positions_amount(call["data"]) for call in calls] == [
         1_000_000,
@@ -265,10 +252,7 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
     assert market_calls == [{"ids": [123], "closed": True, "page_size": 1}]
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
-    assert (
-        calls[0]["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
+    assert calls[0]["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
 
 
 def test_redeem_positions_market_id_rejects_non_integer() -> None:

--- a/tests/unit/test_relayer_position_workflows.py
+++ b/tests/unit/test_relayer_position_workflows.py
@@ -19,6 +19,7 @@ from eth_abi.abi import encode as abi_encode
 from eth_utils.crypto import keccak
 
 from polymarket import AsyncSecureClient
+from polymarket._internal.environment import get_environment_config
 from polymarket.calls import merge_v2_call
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
@@ -43,8 +44,13 @@ def test_split_position_with_combo_legs_bundles_prepare_and_split() -> None:
     asyncio.run(run())
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
-    assert calls[0]["target"].lower() == PRODUCTION.combinatorial_module.lower()
-    assert calls[1]["target"].lower() == PRODUCTION.protocol_v2_router.lower()
+    assert (
+        calls[0]["target"].lower()
+        == get_environment_config(PRODUCTION).combinatorial_module.lower()
+    )
+    assert (
+        calls[1]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
+    )
     assert calls[0]["data"].startswith("0x" + keccak(b"prepareCondition(uint256[])")[:4].hex())
     assert calls[1]["data"].startswith("0x" + keccak(b"split(bytes31,uint256)")[:4].hex())
     assert body["metadata"] == f"Split 5 combo positions for condition {_COMBO_CONDITION_ID}"
@@ -68,8 +74,13 @@ def test_merge_positions_with_combo_legs_uses_onchain_balances() -> None:
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
     assert len(calls) == 2
-    assert calls[0]["target"].lower() == PRODUCTION.combinatorial_module.lower()
-    assert calls[1]["target"].lower() == PRODUCTION.protocol_v2_router.lower()
+    assert (
+        calls[0]["target"].lower()
+        == get_environment_config(PRODUCTION).combinatorial_module.lower()
+    )
+    assert (
+        calls[1]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
+    )
     assert calls[1]["data"].startswith("0x" + keccak(b"merge(bytes31,uint256)")[:4].hex())
     assert body["metadata"] == f"Merge 60 combo positions for condition {_COMBO_CONDITION_ID}"
 
@@ -91,14 +102,16 @@ def test_redeem_positions_with_combo_position_id_uses_onchain_balance() -> None:
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
     assert len(calls) == 1
-    assert calls[0]["target"].lower() == PRODUCTION.protocol_v2_router.lower()
+    assert (
+        calls[0]["target"].lower() == get_environment_config(PRODUCTION).protocol_v2_router.lower()
+    )
     assert calls[0]["data"].startswith("0x" + keccak(b"redeem(bytes31,uint256,uint256)")[:4].hex())
     assert body["metadata"] == f"Redeem combo position {position_id}"
 
 
 def test_execute_transaction_async_batches_custom_calls() -> None:
     captured: list[httpx.Request] = []
-    router = EvmAddress(PRODUCTION.protocol_v2_router)
+    router = EvmAddress(get_environment_config(PRODUCTION).protocol_v2_router)
 
     async def run() -> object:
         client = await make_deposit_client()
@@ -151,7 +164,9 @@ def test_merge_multiple_positions_async_batches_combo_merges() -> None:
     calls = _deposit_wallet_calls(body)
     assert len(calls) == 3
     assert body["metadata"] == "Merge selected combo positions"
-    assert {call["target"].lower() for call in calls} == {PRODUCTION.protocol_v2_router.lower()}
+    assert {call["target"].lower() for call in calls} == {
+        get_environment_config(PRODUCTION).protocol_v2_router.lower()
+    }
     assert [call["data"][-64:] for call in calls] == [
         f"{1:064x}",
         f"{60:064x}",
@@ -204,7 +219,7 @@ def test_merge_multiple_positions_async_batches_market_merges() -> None:
     assert len(calls) == 2
     assert body["metadata"] == "Merge selected market positions"
     assert {call["target"].lower() for call in calls} == {
-        PRODUCTION.neg_risk_collateral_adapter.lower()
+        get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
     }
     assert [_decode_merge_positions_amount(call["data"]) for call in calls] == [
         1_000_000,
@@ -250,7 +265,10 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
     assert market_calls == [{"ids": [123], "closed": True, "page_size": 1}]
     body = _submit_body(captured)
     calls = _deposit_wallet_calls(body)
-    assert calls[0]["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+    assert (
+        calls[0]["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
 
 
 def test_redeem_positions_market_id_rejects_non_integer() -> None:

--- a/tests/unit/test_relayer_proxy_contract.py
+++ b/tests/unit/test_relayer_proxy_contract.py
@@ -18,6 +18,7 @@ from _relayer_helpers import (
 from polymarket._internal.actions.relayer.signing.proxy import (
     build_proxy_transaction_hash,
 )
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.eoa.rpc import JsonRpcClient
 from polymarket.clients._transport import AsyncTransport
 from polymarket.environments import PRODUCTION
@@ -207,7 +208,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit=body["signatureParams"]["gasLimit"],
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, PRODUCTION.relay_hub),
+        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
         relay=cast(EvmAddress, body["signatureParams"]["relay"]),
     )
     with_zero_relay = build_proxy_transaction_hash(
@@ -218,7 +219,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit=body["signatureParams"]["gasLimit"],
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, PRODUCTION.relay_hub),
+        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
         relay=cast(EvmAddress, "0x" + "00" * 20),
     )
     with_legacy_gas = build_proxy_transaction_hash(
@@ -229,7 +230,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit="10000000",
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, PRODUCTION.relay_hub),
+        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
         relay=cast(EvmAddress, body["signatureParams"]["relay"]),
     )
 

--- a/tests/unit/test_relayer_proxy_contract.py
+++ b/tests/unit/test_relayer_proxy_contract.py
@@ -18,10 +18,9 @@ from _relayer_helpers import (
 from polymarket._internal.actions.relayer.signing.proxy import (
     build_proxy_transaction_hash,
 )
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket._internal.eoa.rpc import JsonRpcClient
 from polymarket.clients._transport import AsyncTransport
-from polymarket.environments import PRODUCTION
 from polymarket.types import EvmAddress, HexString
 
 RELAYER_ADDRESS = "0xe679d14b2fe0bdee4a54f25bcec2978e372de566"
@@ -208,7 +207,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit=body["signatureParams"]["gasLimit"],
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
+        relay_hub=cast(EvmAddress, PRODUCTION_CONFIG.relay_hub),
         relay=cast(EvmAddress, body["signatureParams"]["relay"]),
     )
     with_zero_relay = build_proxy_transaction_hash(
@@ -219,7 +218,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit=body["signatureParams"]["gasLimit"],
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
+        relay_hub=cast(EvmAddress, PRODUCTION_CONFIG.relay_hub),
         relay=cast(EvmAddress, "0x" + "00" * 20),
     )
     with_legacy_gas = build_proxy_transaction_hash(
@@ -230,7 +229,7 @@ def test_proxy_signed_hash_binds_relay_and_gas_limit() -> None:
         gas_price=body["signatureParams"]["gasPrice"],
         gas_limit="10000000",
         nonce=body["nonce"],
-        relay_hub=cast(EvmAddress, get_environment_config(PRODUCTION).relay_hub),
+        relay_hub=cast(EvmAddress, PRODUCTION_CONFIG.relay_hub),
         relay=cast(EvmAddress, body["signatureParams"]["relay"]),
     )
 

--- a/tests/unit/test_relayer_redeem_positions.py
+++ b/tests/unit/test_relayer_redeem_positions.py
@@ -13,6 +13,7 @@ from _relayer_helpers import (
 )
 from eth_utils.crypto import keccak
 
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
@@ -65,7 +66,7 @@ def test_redeem_positions_uses_collateral_adapter_when_neg_risk_false() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
     ctf_selector = "0x" + keccak(b"redeemPositions(address,bytes32,bytes32,uint256[])")[:4].hex()
     assert inner["data"].startswith(ctf_selector)
 
@@ -93,7 +94,10 @@ def test_redeem_positions_uses_neg_risk_collateral_adapter_when_neg_risk_true() 
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+    assert (
+        inner["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
     ctf_selector = "0x" + keccak(b"redeemPositions(address,bytes32,bytes32,uint256[])")[:4].hex()
     assert inner["data"].startswith(ctf_selector)
 

--- a/tests/unit/test_relayer_redeem_positions.py
+++ b/tests/unit/test_relayer_redeem_positions.py
@@ -13,8 +13,7 @@ from _relayer_helpers import (
 )
 from eth_utils.crypto import keccak
 
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
 
@@ -66,7 +65,7 @@ def test_redeem_positions_uses_collateral_adapter_when_neg_risk_false() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_adapter.lower()
     ctf_selector = "0x" + keccak(b"redeemPositions(address,bytes32,bytes32,uint256[])")[:4].hex()
     assert inner["data"].startswith(ctf_selector)
 
@@ -94,10 +93,7 @@ def test_redeem_positions_uses_neg_risk_collateral_adapter_when_neg_risk_true() 
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert (
-        inner["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
+    assert inner["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
     ctf_selector = "0x" + keccak(b"redeemPositions(address,bytes32,bytes32,uint256[])")[:4].hex()
     assert inner["data"].startswith(ctf_selector)
 

--- a/tests/unit/test_relayer_setup_trading_approvals.py
+++ b/tests/unit/test_relayer_setup_trading_approvals.py
@@ -13,6 +13,7 @@ from _relayer_helpers import (
 )
 from eth_utils.crypto import keccak
 
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 
 
@@ -65,44 +66,53 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
     # neg_risk_collateral_adapter, protocol_v2_router, exchange_v3, perps_deposit_contract
     for index, spender in enumerate(
         [
-            PRODUCTION.standard_exchange,
-            PRODUCTION.neg_risk_exchange,
-            PRODUCTION.collateral_adapter,
-            PRODUCTION.neg_risk_collateral_adapter,
-            PRODUCTION.protocol_v2_router,
-            PRODUCTION.exchange_v3,
-            PRODUCTION.perps_deposit_contract,
+            get_environment_config(PRODUCTION).standard_exchange,
+            get_environment_config(PRODUCTION).neg_risk_exchange,
+            get_environment_config(PRODUCTION).collateral_adapter,
+            get_environment_config(PRODUCTION).neg_risk_collateral_adapter,
+            get_environment_config(PRODUCTION).protocol_v2_router,
+            get_environment_config(PRODUCTION).exchange_v3,
+            get_environment_config(PRODUCTION).perps_deposit_contract,
         ]
     ):
-        assert inner[index]["target"].lower() == PRODUCTION.collateral_token.lower()
+        assert (
+            inner[index]["target"].lower()
+            == get_environment_config(PRODUCTION).collateral_token.lower()
+        )
         assert inner[index]["data"].startswith(erc20_sel)
         assert spender[2:].lower() in inner[index]["data"].lower()
     # ERC1155 conditional-token approvals: standard_exchange, neg_risk_exchange,
     # collateral_adapter, neg_risk_collateral_adapter, auto_redeem_operator
     for offset, operator in enumerate(
         [
-            PRODUCTION.standard_exchange,
-            PRODUCTION.neg_risk_exchange,
-            PRODUCTION.collateral_adapter,
-            PRODUCTION.neg_risk_collateral_adapter,
-            PRODUCTION.auto_redeem_operator,
+            get_environment_config(PRODUCTION).standard_exchange,
+            get_environment_config(PRODUCTION).neg_risk_exchange,
+            get_environment_config(PRODUCTION).collateral_adapter,
+            get_environment_config(PRODUCTION).neg_risk_collateral_adapter,
+            get_environment_config(PRODUCTION).auto_redeem_operator,
         ]
     ):
         index = 7 + offset
-        assert inner[index]["target"].lower() == PRODUCTION.conditional_tokens.lower()
+        assert (
+            inner[index]["target"].lower()
+            == get_environment_config(PRODUCTION).conditional_tokens.lower()
+        )
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()
 
     # ERC1155 position-manager approvals: protocol_v2_router, exchange_v3, auto_redeem_operator
     for offset, operator in enumerate(
         [
-            PRODUCTION.protocol_v2_router,
-            PRODUCTION.exchange_v3,
-            PRODUCTION.auto_redeem_operator,
+            get_environment_config(PRODUCTION).protocol_v2_router,
+            get_environment_config(PRODUCTION).exchange_v3,
+            get_environment_config(PRODUCTION).auto_redeem_operator,
         ]
     ):
         index = 12 + offset
-        assert inner[index]["target"].lower() == PRODUCTION.position_manager.lower()
+        assert (
+            inner[index]["target"].lower()
+            == get_environment_config(PRODUCTION).position_manager.lower()
+        )
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()
     assert body["metadata"] == "Trading setup approvals"
@@ -164,6 +174,6 @@ def test_setup_trading_approvals_uses_safe_multisend_for_safe() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     assert body["type"] == "SAFE"
-    assert body["to"].lower() == PRODUCTION.safe_multisend.lower()
+    assert body["to"].lower() == get_environment_config(PRODUCTION).safe_multisend.lower()
     assert body["signatureParams"]["operation"] == "1"
     assert body["data"].startswith("0x8d80ff0a")

--- a/tests/unit/test_relayer_setup_trading_approvals.py
+++ b/tests/unit/test_relayer_setup_trading_approvals.py
@@ -13,8 +13,7 @@ from _relayer_helpers import (
 )
 from eth_utils.crypto import keccak
 
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 
 
 def _selector(sig: str) -> str:
@@ -66,53 +65,44 @@ def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> 
     # neg_risk_collateral_adapter, protocol_v2_router, exchange_v3, perps_deposit_contract
     for index, spender in enumerate(
         [
-            get_environment_config(PRODUCTION).standard_exchange,
-            get_environment_config(PRODUCTION).neg_risk_exchange,
-            get_environment_config(PRODUCTION).collateral_adapter,
-            get_environment_config(PRODUCTION).neg_risk_collateral_adapter,
-            get_environment_config(PRODUCTION).protocol_v2_router,
-            get_environment_config(PRODUCTION).exchange_v3,
-            get_environment_config(PRODUCTION).perps_deposit_contract,
+            PRODUCTION_CONFIG.standard_exchange,
+            PRODUCTION_CONFIG.neg_risk_exchange,
+            PRODUCTION_CONFIG.collateral_adapter,
+            PRODUCTION_CONFIG.neg_risk_collateral_adapter,
+            PRODUCTION_CONFIG.protocol_v2_router,
+            PRODUCTION_CONFIG.exchange_v3,
+            PRODUCTION_CONFIG.perps_deposit_contract,
         ]
     ):
-        assert (
-            inner[index]["target"].lower()
-            == get_environment_config(PRODUCTION).collateral_token.lower()
-        )
+        assert inner[index]["target"].lower() == PRODUCTION_CONFIG.collateral_token.lower()
         assert inner[index]["data"].startswith(erc20_sel)
         assert spender[2:].lower() in inner[index]["data"].lower()
     # ERC1155 conditional-token approvals: standard_exchange, neg_risk_exchange,
     # collateral_adapter, neg_risk_collateral_adapter, auto_redeem_operator
     for offset, operator in enumerate(
         [
-            get_environment_config(PRODUCTION).standard_exchange,
-            get_environment_config(PRODUCTION).neg_risk_exchange,
-            get_environment_config(PRODUCTION).collateral_adapter,
-            get_environment_config(PRODUCTION).neg_risk_collateral_adapter,
-            get_environment_config(PRODUCTION).auto_redeem_operator,
+            PRODUCTION_CONFIG.standard_exchange,
+            PRODUCTION_CONFIG.neg_risk_exchange,
+            PRODUCTION_CONFIG.collateral_adapter,
+            PRODUCTION_CONFIG.neg_risk_collateral_adapter,
+            PRODUCTION_CONFIG.auto_redeem_operator,
         ]
     ):
         index = 7 + offset
-        assert (
-            inner[index]["target"].lower()
-            == get_environment_config(PRODUCTION).conditional_tokens.lower()
-        )
+        assert inner[index]["target"].lower() == PRODUCTION_CONFIG.conditional_tokens.lower()
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()
 
     # ERC1155 position-manager approvals: protocol_v2_router, exchange_v3, auto_redeem_operator
     for offset, operator in enumerate(
         [
-            get_environment_config(PRODUCTION).protocol_v2_router,
-            get_environment_config(PRODUCTION).exchange_v3,
-            get_environment_config(PRODUCTION).auto_redeem_operator,
+            PRODUCTION_CONFIG.protocol_v2_router,
+            PRODUCTION_CONFIG.exchange_v3,
+            PRODUCTION_CONFIG.auto_redeem_operator,
         ]
     ):
         index = 12 + offset
-        assert (
-            inner[index]["target"].lower()
-            == get_environment_config(PRODUCTION).position_manager.lower()
-        )
+        assert inner[index]["target"].lower() == PRODUCTION_CONFIG.position_manager.lower()
         assert inner[index]["data"].startswith(erc1155_sel)
         assert operator[2:].lower() in inner[index]["data"].lower()
     assert body["metadata"] == "Trading setup approvals"
@@ -174,6 +164,6 @@ def test_setup_trading_approvals_uses_safe_multisend_for_safe() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     assert body["type"] == "SAFE"
-    assert body["to"].lower() == get_environment_config(PRODUCTION).safe_multisend.lower()
+    assert body["to"].lower() == PRODUCTION_CONFIG.safe_multisend.lower()
     assert body["signatureParams"]["operation"] == "1"
     assert body["data"].startswith("0x8d80ff0a")

--- a/tests/unit/test_relayer_split_position.py
+++ b/tests/unit/test_relayer_split_position.py
@@ -12,6 +12,7 @@ from _relayer_helpers import (
     request_json,
 )
 
+from polymarket._internal.environment import get_environment_config
 from polymarket.environments import PRODUCTION
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
@@ -71,7 +72,7 @@ def test_split_position_uses_collateral_adapter_when_neg_risk_false() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
     assert body["metadata"] == f"Split 1000000 positions for condition {_CONDITION_ID}"
 
 
@@ -107,7 +108,10 @@ def test_split_position_uses_neg_risk_collateral_adapter_when_neg_risk_true() ->
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+    assert (
+        inner["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
 
 
 def test_split_position_rejects_when_market_lookup_finds_nothing() -> None:

--- a/tests/unit/test_relayer_split_position.py
+++ b/tests/unit/test_relayer_split_position.py
@@ -12,8 +12,7 @@ from _relayer_helpers import (
     request_json,
 )
 
-from polymarket._internal.environment import get_environment_config
-from polymarket.environments import PRODUCTION
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.errors import UnexpectedResponseError, UserInputError
 from polymarket.pagination import Page
 
@@ -72,7 +71,7 @@ def test_split_position_uses_collateral_adapter_when_neg_risk_false() -> None:
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_adapter.lower()
     assert body["metadata"] == f"Split 1000000 positions for condition {_CONDITION_ID}"
 
 
@@ -108,10 +107,7 @@ def test_split_position_uses_neg_risk_collateral_adapter_when_neg_risk_true() ->
     submit_calls = [r for r in captured if urlparse(str(r.url)).path == "/submit"]
     body = request_json(submit_calls[0])
     inner = body["depositWalletParams"]["calls"][0]
-    assert (
-        inner["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
+    assert inner["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
 
 
 def test_split_position_rejects_when_market_lookup_finds_nothing() -> None:

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from polymarket import ApiKeyCreds, SecureClient
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.clients._transport import SyncTransport
 from polymarket.clients.secure import _make_l2_header_resolver_sync
 from polymarket.errors import RequestRejectedError, UserInputError
@@ -174,11 +174,10 @@ def test_create_defaults_wallet_to_current_deposit_wallet() -> None:
     from eth_account import Account
 
     from polymarket._internal.wallet import derive_uups_deposit_wallet_address
-    from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PRIVATE_KEY)
     expected = derive_uups_deposit_wallet_address(
-        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+        signer.address, PRODUCTION_CONFIG.wallet_derivation
     )
 
     with SecureClient._create(

--- a/tests/unit/test_secure_auth_sync.py
+++ b/tests/unit/test_secure_auth_sync.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from polymarket import ApiKeyCreds, SecureClient
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import SyncTransport
 from polymarket.clients.secure import _make_l2_header_resolver_sync
 from polymarket.errors import RequestRejectedError, UserInputError
@@ -176,7 +177,9 @@ def test_create_defaults_wallet_to_current_deposit_wallet() -> None:
     from polymarket.environments import PRODUCTION
 
     signer = Account.from_key(PRIVATE_KEY)
-    expected = derive_uups_deposit_wallet_address(signer.address, PRODUCTION.wallet_derivation)
+    expected = derive_uups_deposit_wallet_address(
+        signer.address, get_environment_config(PRODUCTION).wallet_derivation
+    )
 
     with SecureClient._create(
         private_key=PRIVATE_KEY,

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, SecureClient
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -281,11 +281,8 @@ def test_async_secure_list_positions_respects_explicit_user() -> None:
 
 def test_async_secure_list_positions_defaults_to_wallet_when_proxy() -> None:
     from polymarket._internal.wallet import derive_proxy_wallet_address
-    from polymarket.environments import PRODUCTION
 
-    proxy_wallet = derive_proxy_wallet_address(
-        SIGNER_ADDRESS, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    proxy_wallet = derive_proxy_wallet_address(SIGNER_ADDRESS, PRODUCTION_CONFIG.wallet_derivation)
     captured: list[httpx.Request] = []
 
     async def run() -> None:

--- a/tests/unit/test_secure_signer_defaults.py
+++ b/tests/unit/test_secure_signer_defaults.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from polymarket import ApiKeyCreds, AsyncSecureClient, SecureClient
+from polymarket._internal.environment import get_environment_config
 from polymarket.clients._transport import AsyncTransport, SyncTransport
 
 PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -282,7 +283,9 @@ def test_async_secure_list_positions_defaults_to_wallet_when_proxy() -> None:
     from polymarket._internal.wallet import derive_proxy_wallet_address
     from polymarket.environments import PRODUCTION
 
-    proxy_wallet = derive_proxy_wallet_address(SIGNER_ADDRESS, PRODUCTION.wallet_derivation)
+    proxy_wallet = derive_proxy_wallet_address(
+        SIGNER_ADDRESS, get_environment_config(PRODUCTION).wallet_derivation
+    )
     captured: list[httpx.Request] = []
 
     async def run() -> None:

--- a/tests/unit/test_streams_subscribe_router.py
+++ b/tests/unit/test_streams_subscribe_router.py
@@ -9,8 +9,11 @@ import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket import AsyncPublicClient
-from polymarket._internal.environment import create_environment, get_environment_config
-from polymarket.environments import PRODUCTION, Environment
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    create_environment,
+)
+from polymarket.environments import Environment
 from polymarket.errors import UserInputError
 from polymarket.models.clob.market_events import MarketBookEvent
 from polymarket.streams import MarketSpec
@@ -55,15 +58,15 @@ def _env_with_perps_ws(url: str) -> Environment:
 
 def _env_with(
     *,
-    clob_market_ws_url: str = get_environment_config(PRODUCTION).clob_market_ws_url,
-    sports_ws_url: str = get_environment_config(PRODUCTION).sports_ws_url,
-    rtds_ws_url: str = get_environment_config(PRODUCTION).rtds_ws_url,
-    perps_ws_url: str = get_environment_config(PRODUCTION).perps_ws_url,
+    clob_market_ws_url: str = PRODUCTION_CONFIG.clob_market_ws_url,
+    sports_ws_url: str = PRODUCTION_CONFIG.sports_ws_url,
+    rtds_ws_url: str = PRODUCTION_CONFIG.rtds_ws_url,
+    perps_ws_url: str = PRODUCTION_CONFIG.perps_ws_url,
 ) -> Environment:
     return create_environment(
         name="test",
         config=replace(
-            get_environment_config(PRODUCTION),
+            PRODUCTION_CONFIG,
             clob_market_ws_url=clob_market_ws_url,
             sports_ws_url=sports_ws_url,
             rtds_ws_url=rtds_ws_url,

--- a/tests/unit/test_streams_subscribe_router.py
+++ b/tests/unit/test_streams_subscribe_router.py
@@ -2,13 +2,15 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from typing import Any
 
 import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from polymarket import AsyncPublicClient
-from polymarket.environments import PRODUCTION, Environment, WalletDerivation
+from polymarket._internal.environment import create_environment, get_environment_config
+from polymarket.environments import PRODUCTION, Environment
 from polymarket.errors import UserInputError
 from polymarket.models.clob.market_events import MarketBookEvent
 from polymarket.streams import MarketSpec
@@ -53,44 +55,20 @@ def _env_with_perps_ws(url: str) -> Environment:
 
 def _env_with(
     *,
-    clob_market_ws_url: str = PRODUCTION.clob_market_ws_url,
-    sports_ws_url: str = PRODUCTION.sports_ws_url,
-    rtds_ws_url: str = PRODUCTION.rtds_ws_url,
-    perps_ws_url: str = PRODUCTION.perps_ws_url,
+    clob_market_ws_url: str = get_environment_config(PRODUCTION).clob_market_ws_url,
+    sports_ws_url: str = get_environment_config(PRODUCTION).sports_ws_url,
+    rtds_ws_url: str = get_environment_config(PRODUCTION).rtds_ws_url,
+    perps_ws_url: str = get_environment_config(PRODUCTION).perps_ws_url,
 ) -> Environment:
-    return Environment(
+    return create_environment(
         name="test",
-        chain_id=PRODUCTION.chain_id,
-        wallet_derivation=WalletDerivation(
-            proxy_factory=PRODUCTION.wallet_derivation.proxy_factory,
-            proxy_implementation=PRODUCTION.wallet_derivation.proxy_implementation,
-            safe_factory=PRODUCTION.wallet_derivation.safe_factory,
-            safe_init_code_hash=PRODUCTION.wallet_derivation.safe_init_code_hash,
-            deposit_wallet_factory=PRODUCTION.wallet_derivation.deposit_wallet_factory,
-            deposit_wallet_implementation=PRODUCTION.wallet_derivation.deposit_wallet_implementation,
-            deposit_wallet_beacon=PRODUCTION.wallet_derivation.deposit_wallet_beacon,
+        config=replace(
+            get_environment_config(PRODUCTION),
+            clob_market_ws_url=clob_market_ws_url,
+            sports_ws_url=sports_ws_url,
+            rtds_ws_url=rtds_ws_url,
+            perps_ws_url=perps_ws_url,
         ),
-        collateral_token=PRODUCTION.collateral_token,
-        conditional_tokens=PRODUCTION.conditional_tokens,
-        neg_risk_adapter=PRODUCTION.neg_risk_adapter,
-        collateral_adapter=PRODUCTION.collateral_adapter,
-        neg_risk_collateral_adapter=PRODUCTION.neg_risk_collateral_adapter,
-        standard_exchange=PRODUCTION.standard_exchange,
-        neg_risk_exchange=PRODUCTION.neg_risk_exchange,
-        auto_redeem_operator=PRODUCTION.auto_redeem_operator,
-        safe_multisend=PRODUCTION.safe_multisend,
-        relay_hub=PRODUCTION.relay_hub,
-        clob_url=PRODUCTION.clob_url,
-        clob_market_ws_url=clob_market_ws_url,
-        clob_user_ws_url=PRODUCTION.clob_user_ws_url,
-        relayer_url=PRODUCTION.relayer_url,
-        gamma_url=PRODUCTION.gamma_url,
-        data_url=PRODUCTION.data_url,
-        rfq_url=PRODUCTION.rfq_url,
-        rtds_ws_url=rtds_ws_url,
-        sports_ws_url=sports_ws_url,
-        rpc_url=PRODUCTION.rpc_url,
-        perps_ws_url=perps_ws_url,
     )
 
 

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -22,6 +22,7 @@ from eth_abi.abi import decode as abi_decode
 from eth_abi.abi import encode as abi_encode
 
 from polymarket import SecureClient
+from polymarket._internal.environment import get_environment_config, with_environment_config
 from polymarket.calls import merge_v2_call
 from polymarket.environments import PRODUCTION
 from polymarket.errors import (
@@ -150,7 +151,7 @@ def test_split_position_routes_through_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
 
 
 def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> None:
@@ -328,12 +329,12 @@ def test_setup_trading_approvals_safe_uses_multisend_delegatecall() -> None:
     body = request_json(submit)
     assert body["type"] == "SAFE"
     assert body["signatureParams"]["operation"] == "1"
-    assert body["to"].lower() == PRODUCTION.safe_multisend.lower()
+    assert body["to"].lower() == get_environment_config(PRODUCTION).safe_multisend.lower()
 
 
 def test_execute_transaction_batches_custom_calls() -> None:
     captured: list[httpx.Request] = []
-    router = EvmAddress(PRODUCTION.protocol_v2_router)
+    router = EvmAddress(get_environment_config(PRODUCTION).protocol_v2_router)
 
     with make_sync_deposit_client() as client:
         install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
@@ -385,7 +386,7 @@ def test_merge_multiple_positions_batches_combo_merges() -> None:
     assert len(inner_calls) == 3
     assert body["metadata"] == "Merge selected combo positions"
     assert {call["target"].lower() for call in inner_calls} == {
-        PRODUCTION.protocol_v2_router.lower()
+        get_environment_config(PRODUCTION).protocol_v2_router.lower()
     }
     assert [call["data"][-64:] for call in inner_calls] == [
         f"{1:064x}",
@@ -433,7 +434,7 @@ def test_merge_multiple_positions_batches_market_merges() -> None:
     assert len(inner_calls) == 2
     assert body["metadata"] == "Merge selected market positions"
     assert {call["target"].lower() for call in inner_calls} == {
-        PRODUCTION.collateral_adapter.lower()
+        get_environment_config(PRODUCTION).collateral_adapter.lower()
     }
     assert [_decode_merge_positions_amount(call["data"]) for call in inner_calls] == [
         1_000_000,
@@ -548,7 +549,7 @@ def test_merge_positions_routes_through_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.collateral_adapter.lower()
+    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
 
 
 def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
@@ -570,7 +571,10 @@ def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+    assert (
+        inner["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
 
 
 def test_redeem_positions_market_id_resolves_condition_before_fetching_positions() -> None:
@@ -591,7 +595,10 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == PRODUCTION.neg_risk_collateral_adapter.lower()
+    assert (
+        inner["target"].lower()
+        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
+    )
 
 
 def test_redeem_positions_market_id_rejects_non_integer() -> None:
@@ -691,7 +698,12 @@ def test_gasless_wait_returns_outcome_on_terminal_success() -> None:
     with make_sync_deposit_client() as client:
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         install_sync_relayer_handler(client, _wait_relayer_handler("STATE_CONFIRMED"))
         handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)
@@ -705,7 +717,12 @@ def test_gasless_wait_raises_transaction_failed_on_terminal_failure() -> None:
     with make_sync_deposit_client() as client:
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         install_sync_relayer_handler(
             client, _wait_relayer_handler("STATE_FAILED", error_msg="reverted on chain")
@@ -719,10 +736,13 @@ def test_gasless_wait_times_out_when_terminal_state_never_reached() -> None:
     with make_sync_deposit_client() as client:
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(
+            environment=with_environment_config(
                 client._ctx.environment,
-                relayer_poll_frequency_ms=1,
-                relayer_max_polls=3,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment),
+                    relayer_poll_frequency_ms=1,
+                    relayer_max_polls=3,
+                ),
             ),
         )
         install_sync_relayer_handler(client, _wait_relayer_handler("STATE_NEW"))
@@ -762,7 +782,12 @@ def test_gasless_submit_retries_on_retryable_400_then_succeeds() -> None:
     with make_sync_deposit_client() as client:
         client._ctx = dataclasses.replace(
             client._ctx,
-            environment=dataclasses.replace(client._ctx.environment, relayer_poll_frequency_ms=1),
+            environment=with_environment_config(
+                client._ctx.environment,
+                config=dataclasses.replace(
+                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                ),
+            ),
         )
         install_sync_relayer_handler(client, handler)
         handle = client.approve_erc20(token_address=TOKEN, spender_address=SPENDER, amount=1)

--- a/tests/unit/test_sync_relayer_workflows.py
+++ b/tests/unit/test_sync_relayer_workflows.py
@@ -22,9 +22,11 @@ from eth_abi.abi import decode as abi_decode
 from eth_abi.abi import encode as abi_encode
 
 from polymarket import SecureClient
-from polymarket._internal.environment import get_environment_config, with_environment_config
+from polymarket._internal.environment import (
+    PRODUCTION_CONFIG,
+    with_environment_config,
+)
 from polymarket.calls import merge_v2_call
-from polymarket.environments import PRODUCTION
 from polymarket.errors import (
     TimeoutError as PolyTimeoutError,
 )
@@ -151,7 +153,7 @@ def test_split_position_routes_through_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_adapter.lower()
 
 
 def test_setup_trading_approvals_bundles_required_calls_for_deposit_wallet() -> None:
@@ -329,12 +331,12 @@ def test_setup_trading_approvals_safe_uses_multisend_delegatecall() -> None:
     body = request_json(submit)
     assert body["type"] == "SAFE"
     assert body["signatureParams"]["operation"] == "1"
-    assert body["to"].lower() == get_environment_config(PRODUCTION).safe_multisend.lower()
+    assert body["to"].lower() == PRODUCTION_CONFIG.safe_multisend.lower()
 
 
 def test_execute_transaction_batches_custom_calls() -> None:
     captured: list[httpx.Request] = []
-    router = EvmAddress(get_environment_config(PRODUCTION).protocol_v2_router)
+    router = EvmAddress(PRODUCTION_CONFIG.protocol_v2_router)
 
     with make_sync_deposit_client() as client:
         install_sync_relayer_handler(client, _deposit_relayer_handler(captured))
@@ -386,7 +388,7 @@ def test_merge_multiple_positions_batches_combo_merges() -> None:
     assert len(inner_calls) == 3
     assert body["metadata"] == "Merge selected combo positions"
     assert {call["target"].lower() for call in inner_calls} == {
-        get_environment_config(PRODUCTION).protocol_v2_router.lower()
+        PRODUCTION_CONFIG.protocol_v2_router.lower()
     }
     assert [call["data"][-64:] for call in inner_calls] == [
         f"{1:064x}",
@@ -434,7 +436,7 @@ def test_merge_multiple_positions_batches_market_merges() -> None:
     assert len(inner_calls) == 2
     assert body["metadata"] == "Merge selected market positions"
     assert {call["target"].lower() for call in inner_calls} == {
-        get_environment_config(PRODUCTION).collateral_adapter.lower()
+        PRODUCTION_CONFIG.collateral_adapter.lower()
     }
     assert [_decode_merge_positions_amount(call["data"]) for call in inner_calls] == [
         1_000_000,
@@ -549,7 +551,7 @@ def test_merge_positions_routes_through_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert inner["target"].lower() == get_environment_config(PRODUCTION).collateral_adapter.lower()
+    assert inner["target"].lower() == PRODUCTION_CONFIG.collateral_adapter.lower()
 
 
 def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
@@ -571,10 +573,7 @@ def test_redeem_positions_routes_through_neg_risk_collateral_adapter() -> None:
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert (
-        inner["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
+    assert inner["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
 
 
 def test_redeem_positions_market_id_resolves_condition_before_fetching_positions() -> None:
@@ -595,10 +594,7 @@ def test_redeem_positions_market_id_resolves_condition_before_fetching_positions
     submit = [r for r in captured if urlparse(str(r.url)).path == "/submit"][0]
     body = request_json(submit)
     inner = body["depositWalletParams"]["calls"][0]
-    assert (
-        inner["target"].lower()
-        == get_environment_config(PRODUCTION).neg_risk_collateral_adapter.lower()
-    )
+    assert inner["target"].lower() == PRODUCTION_CONFIG.neg_risk_collateral_adapter.lower()
 
 
 def test_redeem_positions_market_id_rejects_non_integer() -> None:
@@ -701,7 +697,7 @@ def test_gasless_wait_returns_outcome_on_terminal_success() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -720,7 +716,7 @@ def test_gasless_wait_raises_transaction_failed_on_terminal_failure() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )
@@ -739,7 +735,7 @@ def test_gasless_wait_times_out_when_terminal_state_never_reached() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment),
+                    client._ctx.environment_config,
                     relayer_poll_frequency_ms=1,
                     relayer_max_polls=3,
                 ),
@@ -785,7 +781,7 @@ def test_gasless_submit_retries_on_retryable_400_then_succeeds() -> None:
             environment=with_environment_config(
                 client._ctx.environment,
                 config=dataclasses.replace(
-                    get_environment_config(client._ctx.environment), relayer_poll_frequency_ms=1
+                    client._ctx.environment_config, relayer_poll_frequency_ms=1
                 ),
             ),
         )

--- a/tests/unit/test_wallet_derivations.py
+++ b/tests/unit/test_wallet_derivations.py
@@ -1,5 +1,6 @@
 import pytest
 
+from polymarket._internal.environment import get_environment_config
 from polymarket._internal.wallet import (
     classify_wallet_type,
     derive_beacon_deposit_wallet_address,
@@ -20,22 +21,30 @@ EXPECTED_SAFE = "0x766b6851a199bf91ae3fa13b1cfac5187355118f"
 
 
 def test_derive_uups_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_uups_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    derived = derive_uups_deposit_wallet_address(
+        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert derived.lower() == EXPECTED_UUPS_DEPOSIT
 
 
 def test_derive_beacon_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_beacon_deposit_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    derived = derive_beacon_deposit_wallet_address(
+        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert derived.lower() == EXPECTED_BEACON_DEPOSIT
 
 
 def test_derive_proxy_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_proxy_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    derived = derive_proxy_wallet_address(
+        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert derived.lower() == EXPECTED_PROXY
 
 
 def test_derive_safe_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_safe_wallet_address(SIGNER, PRODUCTION.wallet_derivation)
+    derived = derive_safe_wallet_address(
+        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert derived.lower() == EXPECTED_SAFE
 
 
@@ -47,41 +56,53 @@ def test_signature_type_for_each_wallet_type() -> None:
 
 
 def test_classify_wallet_type_returns_eoa_when_wallet_equals_signer() -> None:
-    result = classify_wallet_type(signer=SIGNER, wallet=SIGNER, config=PRODUCTION.wallet_derivation)
+    result = classify_wallet_type(
+        signer=SIGNER, wallet=SIGNER, config=get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert result == "EOA"
 
 
 def test_classify_wallet_type_returns_deposit_wallet_for_uups_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_UUPS_DEPOSIT, config=PRODUCTION.wallet_derivation
+        signer=SIGNER,
+        wallet=EXPECTED_UUPS_DEPOSIT,
+        config=get_environment_config(PRODUCTION).wallet_derivation,
     )
     assert result == "DEPOSIT_WALLET"
 
 
 def test_classify_wallet_type_returns_deposit_wallet_for_beacon_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_BEACON_DEPOSIT, config=PRODUCTION.wallet_derivation
+        signer=SIGNER,
+        wallet=EXPECTED_BEACON_DEPOSIT,
+        config=get_environment_config(PRODUCTION).wallet_derivation,
     )
     assert result == "DEPOSIT_WALLET"
 
 
 def test_classify_wallet_type_returns_poly_proxy_for_derived_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_PROXY, config=PRODUCTION.wallet_derivation
+        signer=SIGNER,
+        wallet=EXPECTED_PROXY,
+        config=get_environment_config(PRODUCTION).wallet_derivation,
     )
     assert result == "POLY_PROXY"
 
 
 def test_classify_wallet_type_returns_gnosis_safe_for_derived_address() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=EXPECTED_SAFE, config=PRODUCTION.wallet_derivation
+        signer=SIGNER,
+        wallet=EXPECTED_SAFE,
+        config=get_environment_config(PRODUCTION).wallet_derivation,
     )
     assert result == "GNOSIS_SAFE"
 
 
 def test_classify_wallet_type_is_case_insensitive() -> None:
     upper = EXPECTED_UUPS_DEPOSIT.upper().replace("0X", "0x")
-    result = classify_wallet_type(signer=SIGNER, wallet=upper, config=PRODUCTION.wallet_derivation)
+    result = classify_wallet_type(
+        signer=SIGNER, wallet=upper, config=get_environment_config(PRODUCTION).wallet_derivation
+    )
     assert result == "DEPOSIT_WALLET"
 
 
@@ -90,5 +111,5 @@ def test_classify_wallet_type_rejects_unrelated_wallet() -> None:
         classify_wallet_type(
             signer=SIGNER,
             wallet="0x0000000000000000000000000000000000000002",
-            config=PRODUCTION.wallet_derivation,
+            config=get_environment_config(PRODUCTION).wallet_derivation,
         )

--- a/tests/unit/test_wallet_derivations.py
+++ b/tests/unit/test_wallet_derivations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from polymarket._internal.environment import get_environment_config
+from polymarket._internal.environment import PRODUCTION_CONFIG
 from polymarket._internal.wallet import (
     classify_wallet_type,
     derive_beacon_deposit_wallet_address,
@@ -9,7 +9,6 @@ from polymarket._internal.wallet import (
     derive_uups_deposit_wallet_address,
     signature_type_for,
 )
-from polymarket.environments import PRODUCTION
 from polymarket.errors import UserInputError
 
 SIGNER = "0x0000000000000000000000000000000000000001"
@@ -21,30 +20,22 @@ EXPECTED_SAFE = "0x766b6851a199bf91ae3fa13b1cfac5187355118f"
 
 
 def test_derive_uups_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_uups_deposit_wallet_address(
-        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    derived = derive_uups_deposit_wallet_address(SIGNER, PRODUCTION_CONFIG.wallet_derivation)
     assert derived.lower() == EXPECTED_UUPS_DEPOSIT
 
 
 def test_derive_beacon_deposit_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_beacon_deposit_wallet_address(
-        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    derived = derive_beacon_deposit_wallet_address(SIGNER, PRODUCTION_CONFIG.wallet_derivation)
     assert derived.lower() == EXPECTED_BEACON_DEPOSIT
 
 
 def test_derive_proxy_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_proxy_wallet_address(
-        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    derived = derive_proxy_wallet_address(SIGNER, PRODUCTION_CONFIG.wallet_derivation)
     assert derived.lower() == EXPECTED_PROXY
 
 
 def test_derive_safe_wallet_address_matches_ts_golden_vector() -> None:
-    derived = derive_safe_wallet_address(
-        SIGNER, get_environment_config(PRODUCTION).wallet_derivation
-    )
+    derived = derive_safe_wallet_address(SIGNER, PRODUCTION_CONFIG.wallet_derivation)
     assert derived.lower() == EXPECTED_SAFE
 
 
@@ -57,7 +48,7 @@ def test_signature_type_for_each_wallet_type() -> None:
 
 def test_classify_wallet_type_returns_eoa_when_wallet_equals_signer() -> None:
     result = classify_wallet_type(
-        signer=SIGNER, wallet=SIGNER, config=get_environment_config(PRODUCTION).wallet_derivation
+        signer=SIGNER, wallet=SIGNER, config=PRODUCTION_CONFIG.wallet_derivation
     )
     assert result == "EOA"
 
@@ -66,7 +57,7 @@ def test_classify_wallet_type_returns_deposit_wallet_for_uups_address() -> None:
     result = classify_wallet_type(
         signer=SIGNER,
         wallet=EXPECTED_UUPS_DEPOSIT,
-        config=get_environment_config(PRODUCTION).wallet_derivation,
+        config=PRODUCTION_CONFIG.wallet_derivation,
     )
     assert result == "DEPOSIT_WALLET"
 
@@ -75,7 +66,7 @@ def test_classify_wallet_type_returns_deposit_wallet_for_beacon_address() -> Non
     result = classify_wallet_type(
         signer=SIGNER,
         wallet=EXPECTED_BEACON_DEPOSIT,
-        config=get_environment_config(PRODUCTION).wallet_derivation,
+        config=PRODUCTION_CONFIG.wallet_derivation,
     )
     assert result == "DEPOSIT_WALLET"
 
@@ -84,7 +75,7 @@ def test_classify_wallet_type_returns_poly_proxy_for_derived_address() -> None:
     result = classify_wallet_type(
         signer=SIGNER,
         wallet=EXPECTED_PROXY,
-        config=get_environment_config(PRODUCTION).wallet_derivation,
+        config=PRODUCTION_CONFIG.wallet_derivation,
     )
     assert result == "POLY_PROXY"
 
@@ -93,7 +84,7 @@ def test_classify_wallet_type_returns_gnosis_safe_for_derived_address() -> None:
     result = classify_wallet_type(
         signer=SIGNER,
         wallet=EXPECTED_SAFE,
-        config=get_environment_config(PRODUCTION).wallet_derivation,
+        config=PRODUCTION_CONFIG.wallet_derivation,
     )
     assert result == "GNOSIS_SAFE"
 
@@ -101,7 +92,7 @@ def test_classify_wallet_type_returns_gnosis_safe_for_derived_address() -> None:
 def test_classify_wallet_type_is_case_insensitive() -> None:
     upper = EXPECTED_UUPS_DEPOSIT.upper().replace("0X", "0x")
     result = classify_wallet_type(
-        signer=SIGNER, wallet=upper, config=get_environment_config(PRODUCTION).wallet_derivation
+        signer=SIGNER, wallet=upper, config=PRODUCTION_CONFIG.wallet_derivation
     )
     assert result == "DEPOSIT_WALLET"
 
@@ -111,5 +102,5 @@ def test_classify_wallet_type_rejects_unrelated_wallet() -> None:
         classify_wallet_type(
             signer=SIGNER,
             wallet="0x0000000000000000000000000000000000000002",
-            config=get_environment_config(PRODUCTION).wallet_derivation,
+            config=PRODUCTION_CONFIG.wallet_derivation,
         )


### PR DESCRIPTION
## Summary

- keep `Environment.name` as the only public environment member
- move endpoints, addresses, wallet derivation, and polling settings behind SDK-internal configuration
- resolve configuration once at each client entrypoint and pass it through bootstrap, transports, and internal client contexts
- make `Environment` instances SDK-owned and remove the public `WalletDerivation` configuration type
- remove the README example that depended on the internal protocol router address

This intentionally removes direct environment configuration access and custom `Environment` construction from the public API while keeping configuration straightforward to consume inside the SDK.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `make test` (2,229 passed)
- `make api-reference`
- `uv build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any code that read `environment.*` config fields or built custom environments; runtime paths are wide but should be behavior-preserving if only `PRODUCTION` is used.
> 
> **Overview**
> **Refactors the public `Environment` API** so callers only see `name` (e.g. `PRODUCTION`); URLs, chain IDs, contract addresses, wallet derivation, and relayer polling settings move to SDK-internal `EnvironmentConfig` resolved via `get_environment_config` and cached on client context as `environment_config`.
> 
> **SDK-owned environments:** direct `Environment()` construction is blocked; production is built with `_create_environment`. Tests and integrations that need overrides use internal `with_environment_config` / `PRODUCTION_CONFIG` instead of `dataclasses.replace(PRODUCTION, ...)`.
> 
> **Behavior wiring** (orders, relayer, wallet derivation, transports, perps, collateral return) is updated to read from `ctx.environment_config` rather than attributes on `Environment`. The README drops the custom `execute_transaction` / `merge_v2_call` example that depended on public router addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e036f7114b056341773c8df022cbfaa36e7e0069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->