### PR TITLE
fix(perps): prevent order update race

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 ## Platform Invariants
 
 - A market's minimum tick size may become finer, such as `0.01` to `0.001`, but it cannot become coarser, such as `0.001` to `0.01`. SDK caching and recovery logic may rely on this monotonic behavior and should not add defensive handling for tick-size coarsening.
+- When a Perps order is submitted with a client order ID, every corresponding private order update echoes that same client order ID. SDK order-placement workflows may rely on this invariant for pre-acknowledgement correlation.
 
 ## Client Sync/Async Design
 

--- a/src/polymarket/_internal/actions/perps/trading.py
+++ b/src/polymarket/_internal/actions/perps/trading.py
@@ -1,14 +1,21 @@
-"""Perps trading command construction.
+"""Perps trading workflows and command construction.
 
 Signed commands are positional tuples (the signed form); the WebSocket frame
 body carries an equivalent keyed form. Both are produced here so the session
 can sign one and send the other.
 """
 
-from collections.abc import Sequence
-from typing import Any
+from __future__ import annotations
 
-from polymarket.errors import UserInputError
+import secrets
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from polymarket.errors import RequestRejectedError, UserInputError
+from polymarket.models.perps.events import PerpsOrderEvent, PerpsSessionEvent
+from polymarket.models.perps.orders import PerpsOrder, PerpsPostOrderAck
 from polymarket.models.perps.requests import (
     DecimalInput,
     PerpsOrderRequest,
@@ -17,11 +24,208 @@ from polymarket.models.perps.requests import (
     to_decimal_string,
     validate_client_order_id,
 )
-from polymarket.models.perps.types import PerpsTpSlKind, PerpsTpSlScope
+from polymarket.models.perps.results import (
+    PerpsOrderPlacement,
+    PerpsPlacedTpSlOrder,
+    PerpsPlacedTpSlOrders,
+)
+from polymarket.models.perps.types import PerpsOrderId, PerpsTpSlKind, PerpsTpSlScope
+
+if TYPE_CHECKING:
+    from polymarket._internal.perps_session import PerpsSession
+
+# Purposefully generous: backend order updates are expected in the ~100ms range.
+_ORDER_PLACEMENT_UPDATE_TIMEOUT_S = 2.0
 
 RawPerpsOrder = list[Any]
 """Positional order row: [iid, buy, price?, qty, tif?, post_only, reduce_only?,
 client_order_id?, trigger?]. ``None`` holes are compacted before signing."""
+
+
+async def place_order(
+    session: PerpsSession,
+    request: PerpsOrderRequest,
+    *,
+    take_profit: PerpsTpSlTrigger | None,
+    stop_loss: PerpsTpSlTrigger | None,
+    expires_at: datetime | int | None,
+) -> PerpsOrderPlacement:
+    if request.client_order_id is None:
+        request = replace(request, client_order_id=secrets.token_hex(16))
+    client_order_id = request.client_order_id
+    assert client_order_id is not None
+
+    if take_profit is None and stop_loss is None:
+        _, order = await _place_orders_and_wait_for_update(
+            session,
+            [to_raw_order(request)],
+            client_order_id=client_order_id,
+            group=None,
+            expires_at=expires_at,
+        )
+        return PerpsOrderPlacement(order=order)
+
+    rows: list[RawPerpsOrder] = [to_raw_order(request)]
+    exit_buy = request.side == "SELL"
+    quantity_string = to_decimal_string("quantity", request.quantity)
+    if take_profit is not None:
+        rows.append(
+            to_raw_tp_sl_order(
+                buy=exit_buy,
+                instrument_id=request.instrument_id,
+                kind="tp",
+                quantity=quantity_string,
+                trigger=take_profit,
+            )
+        )
+    if stop_loss is not None:
+        rows.append(
+            to_raw_tp_sl_order(
+                buy=exit_buy,
+                instrument_id=request.instrument_id,
+                kind="sl",
+                quantity=quantity_string,
+                trigger=stop_loss,
+            )
+        )
+    placed, order = await _place_orders_and_wait_for_update(
+        session,
+        rows,
+        client_order_id=client_order_id,
+        group="order",
+        expires_at=expires_at,
+    )
+    trigger_index = 1
+    take_profit_order = None
+    stop_loss_order = None
+    if take_profit is not None:
+        take_profit_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
+        trigger_index += 1
+    if stop_loss is not None:
+        stop_loss_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
+    return PerpsOrderPlacement(
+        order=order,
+        tp_sl=PerpsPlacedTpSlOrders(
+            take_profit=take_profit_order,
+            stop_loss=stop_loss_order,
+        ),
+    )
+
+
+async def post_orders(
+    session: PerpsSession,
+    orders: Sequence[PerpsOrderRequest],
+    *,
+    expires_at: datetime | int | None,
+) -> tuple[PerpsPostOrderAck, ...]:
+    if not orders:
+        raise UserInputError("orders must be non-empty")
+    acks = await session._send_create_orders(  # pyright: ignore[reportPrivateUsage]
+        [to_raw_order(order) for order in orders],
+        group=None,
+        expires_at=expires_at,
+    )
+    return tuple(acks)
+
+
+async def place_position_tp_sl(
+    session: PerpsSession,
+    *,
+    instrument_id: int,
+    take_profit: PerpsPositionTpSlTrigger | None,
+    stop_loss: PerpsPositionTpSlTrigger | None,
+    expires_at: datetime | int | None,
+) -> PerpsPlacedTpSlOrders:
+    if take_profit is None and stop_loss is None:
+        raise UserInputError("Provide take_profit, stop_loss, or both")
+    exit_buy = await _position_exit_buy(session, instrument_id)
+    rows: list[RawPerpsOrder] = []
+    if take_profit is not None:
+        rows.append(
+            to_raw_tp_sl_order(
+                buy=exit_buy,
+                instrument_id=instrument_id,
+                kind="tp",
+                quantity="0",
+                trigger=take_profit,
+            )
+        )
+    if stop_loss is not None:
+        rows.append(
+            to_raw_tp_sl_order(
+                buy=exit_buy,
+                instrument_id=instrument_id,
+                kind="sl",
+                quantity="0",
+                trigger=stop_loss,
+            )
+        )
+    acks = await session._send_create_orders(  # pyright: ignore[reportPrivateUsage]
+        rows,
+        group="position",
+        expires_at=expires_at,
+    )
+    placed = [_expect_ok_ack(ack) for ack in acks]
+    trigger_index = 0
+    take_profit_order = None
+    stop_loss_order = None
+    if take_profit is not None:
+        take_profit_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
+        trigger_index += 1
+    if stop_loss is not None:
+        stop_loss_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
+    return PerpsPlacedTpSlOrders(
+        take_profit=take_profit_order,
+        stop_loss=stop_loss_order,
+    )
+
+
+async def _place_orders_and_wait_for_update(
+    session: PerpsSession,
+    rows: list[RawPerpsOrder],
+    *,
+    client_order_id: str,
+    group: PerpsTpSlScope | None,
+    expires_at: datetime | int | None,
+) -> tuple[list[PerpsOrderId], PerpsOrder]:
+    def matches(event: PerpsSessionEvent) -> bool:
+        return (
+            isinstance(event, PerpsOrderEvent) and event.payload.client_order_id == client_order_id
+        )
+
+    waiter = session._create_event_waiter(matches)  # pyright: ignore[reportPrivateUsage]
+    try:
+        acks = await session._send_create_orders(  # pyright: ignore[reportPrivateUsage]
+            rows,
+            group=group,
+            expires_at=expires_at,
+        )
+        placed = [_expect_ok_ack(ack) for ack in acks]
+        event = await session._wait_for_event(  # pyright: ignore[reportPrivateUsage]
+            waiter,
+            timeout_s=_ORDER_PLACEMENT_UPDATE_TIMEOUT_S,
+        )
+        assert isinstance(event, PerpsOrderEvent)
+        return placed, event.payload
+    finally:
+        session._remove_event_waiter(waiter)  # pyright: ignore[reportPrivateUsage]
+
+
+async def _position_exit_buy(session: PerpsSession, instrument_id: int) -> bool:
+    portfolio = await session.fetch_portfolio()
+    position = next(
+        (item for item in portfolio.positions if item.instrument_id == instrument_id),
+        None,
+    )
+    if position is None or position.size == 0:
+        raise UserInputError(f"No open Perps position for instrument {instrument_id}.")
+    return position.size < 0
+
+
+def _expect_ok_ack(ack: PerpsPostOrderAck) -> PerpsOrderId:
+    if ack.status == "err":
+        raise RequestRejectedError(ack.error or "Perps command was rejected.", status=200)
+    return cast(PerpsOrderId, ack.order_id)
 
 
 def to_raw_order(request: PerpsOrderRequest) -> RawPerpsOrder:
@@ -192,6 +396,9 @@ __all__ = [
     "cancel_orders_by_client_id_op",
     "cancel_orders_op",
     "create_orders_op",
+    "place_order",
+    "place_position_tp_sl",
+    "post_orders",
     "to_command_body_op",
     "to_raw_order",
     "to_raw_tp_sl_order",

--- a/src/polymarket/_internal/perps_session.py
+++ b/src/polymarket/_internal/perps_session.py
@@ -26,10 +26,17 @@ from polymarket._internal.actions.perps.trading import (
     cancel_orders_op,
     create_orders_op,
     to_command_body_op,
-    to_raw_order,
-    to_raw_tp_sl_order,
     update_leverage_op,
     update_margin_op,
+)
+from polymarket._internal.actions.perps.trading import (
+    place_order as place_perps_order,
+)
+from polymarket._internal.actions.perps.trading import (
+    place_position_tp_sl as place_perps_position_tp_sl,
+)
+from polymarket._internal.actions.perps.trading import (
+    post_orders as post_perps_orders,
 )
 from polymarket._internal.streams.perps.heartbeat import PerpsWebSocketHeartbeat
 from polymarket._internal.streams.reconnect import ReconnectScheduler
@@ -56,7 +63,6 @@ from polymarket.models.perps.account import (
 )
 from polymarket.models.perps.credentials import PerpsCredentials
 from polymarket.models.perps.events import (
-    PerpsOrderEvent,
     PerpsResyncEvent,
     PerpsSessionEvent,
     parse_perps_session_event,
@@ -80,16 +86,13 @@ from polymarket.models.perps.requests import (
     PerpsOrderRequest,
     PerpsPositionTpSlTrigger,
     PerpsTpSlTrigger,
-    to_decimal_string,
 )
 from polymarket.models.perps.results import (
     PerpsOrderPlacement,
-    PerpsPlacedTpSlOrder,
     PerpsPlacedTpSlOrders,
 )
 from polymarket.models.perps.types import (
     PerpsDepositStatus,
-    PerpsOrderId,
     PerpsPnlInterval,
     PerpsSortDirection,
     PerpsTimeInForce,
@@ -101,8 +104,6 @@ from polymarket.pagination import AsyncPaginator
 _AUTH_TIMEOUT_S = 30.0
 _ACK_TIMEOUT_S = 30.0
 _MIN_AUTO_CANCEL_BUFFER_MS = 5_000
-# Purposefully generous: backend order updates are expected in the ~100ms range.
-_ORDER_PLACEMENT_UPDATE_TIMEOUT_S = 2.0
 _QUEUE_SIZE = 1024
 
 _SESSION_CHANNELS = (
@@ -180,9 +181,6 @@ class PerpsSession:
         )
         self._pending: dict[int, _PendingRequest] = {}
         self._event_waiters: list[_EventWaiter] = []
-        # Order updates can arrive before the post acknowledgement resumes the
-        # caller; keep a bounded buffer so place_order never misses its update.
-        self._recent_orders: dict[PerpsOrderId, PerpsOrder] = {}
         self._sequences: dict[str, int] = {}
         self._next_request_id = 1
         self._closed = False
@@ -301,6 +299,8 @@ class PerpsSession:
         ``take_profit`` and/or ``stop_loss`` to place reduce-only trigger orders
         together with the entry order. ``expires_at`` is an optional command
         expiration timestamp, accepted as ``datetime`` or epoch milliseconds.
+        When ``client_order_id`` is omitted, the session generates one for
+        reliable private-order update correlation.
         """
         if time_in_force == "gtc":
             request = PerpsOrderRequest(
@@ -325,51 +325,12 @@ class PerpsSession:
                 reduce_only=reduce_only,
                 client_order_id=client_order_id,
             )
-        if take_profit is None and stop_loss is None:
-            acks = await self._send_create_orders(
-                [to_raw_order(request)], group=None, expires_at=expires_at
-            )
-            entry = self._expect_ok_ack(acks[0])
-            order = await self._wait_for_order_update(entry)
-            return PerpsOrderPlacement(order=order)
-
-        rows: list[RawPerpsOrder] = [to_raw_order(request)]
-        exit_buy = request.side == "SELL"
-        quantity_string = to_decimal_string("quantity", request.quantity)
-        if take_profit is not None:
-            rows.append(
-                to_raw_tp_sl_order(
-                    buy=exit_buy,
-                    instrument_id=request.instrument_id,
-                    kind="tp",
-                    quantity=quantity_string,
-                    trigger=take_profit,
-                )
-            )
-        if stop_loss is not None:
-            rows.append(
-                to_raw_tp_sl_order(
-                    buy=exit_buy,
-                    instrument_id=request.instrument_id,
-                    kind="sl",
-                    quantity=quantity_string,
-                    trigger=stop_loss,
-                )
-            )
-        acks = await self._send_create_orders(rows, group="order", expires_at=expires_at)
-        placed = [self._expect_ok_ack(ack) for ack in acks]
-        order = await self._wait_for_order_update(placed[0])
-        trigger_index = 1
-        take_profit_order = None
-        stop_loss_order = None
-        if take_profit is not None:
-            take_profit_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
-            trigger_index += 1
-        if stop_loss is not None:
-            stop_loss_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
-        return PerpsOrderPlacement(
-            order=order,
-            tp_sl=PerpsPlacedTpSlOrders(take_profit=take_profit_order, stop_loss=stop_loss_order),
+        return await place_perps_order(
+            self,
+            request,
+            take_profit=take_profit,
+            stop_loss=stop_loss,
+            expires_at=expires_at,
         )
 
     async def post_orders(
@@ -383,12 +344,7 @@ class PerpsSession:
         This is a low-level method; :meth:`place_order` is the common path when
         callers want to wait for the resulting order update.
         """
-        if not orders:
-            raise UserInputError("orders must be non-empty")
-        acks = await self._send_create_orders(
-            [to_raw_order(order) for order in orders], group=None, expires_at=expires_at
-        )
-        return tuple(acks)
+        return await post_perps_orders(self, orders, expires_at=expires_at)
 
     async def place_position_tp_sl(
         self,
@@ -404,41 +360,13 @@ class PerpsSession:
         raises :class:`~polymarket.errors.UserInputError`. Provide
         ``take_profit``, ``stop_loss``, or both.
         """
-        if take_profit is None and stop_loss is None:
-            raise UserInputError("Provide take_profit, stop_loss, or both")
-        exit_buy = await self._position_exit_buy(instrument_id)
-        rows: list[RawPerpsOrder] = []
-        if take_profit is not None:
-            rows.append(
-                to_raw_tp_sl_order(
-                    buy=exit_buy,
-                    instrument_id=instrument_id,
-                    kind="tp",
-                    quantity="0",
-                    trigger=take_profit,
-                )
-            )
-        if stop_loss is not None:
-            rows.append(
-                to_raw_tp_sl_order(
-                    buy=exit_buy,
-                    instrument_id=instrument_id,
-                    kind="sl",
-                    quantity="0",
-                    trigger=stop_loss,
-                )
-            )
-        acks = await self._send_create_orders(rows, group="position", expires_at=expires_at)
-        placed = [self._expect_ok_ack(ack) for ack in acks]
-        trigger_index = 0
-        take_profit_order = None
-        stop_loss_order = None
-        if take_profit is not None:
-            take_profit_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
-            trigger_index += 1
-        if stop_loss is not None:
-            stop_loss_order = PerpsPlacedTpSlOrder(order_id=placed[trigger_index])
-        return PerpsPlacedTpSlOrders(take_profit=take_profit_order, stop_loss=stop_loss_order)
+        return await place_perps_position_tp_sl(
+            self,
+            instrument_id=instrument_id,
+            take_profit=take_profit,
+            stop_loss=stop_loss,
+            expires_at=expires_at,
+        )
 
     @overload
     async def cancel_order(
@@ -946,49 +874,31 @@ class PerpsSession:
         self._next_request_id += 1
         return request_id
 
-    def _expect_ok_ack(self, ack: PerpsPostOrderAck) -> PerpsOrderId:
-        if ack.status == "err":
-            raise RequestRejectedError(ack.error or "Perps command was rejected.", status=200)
-        return cast(PerpsOrderId, ack.order_id)
-
-    async def _wait_for_order_update(self, order_id: PerpsOrderId) -> PerpsOrder:
-        buffered = self._recent_orders.get(order_id)
-        if buffered is not None:
-            return buffered
-
-        def matches(event: PerpsSessionEvent) -> bool:
-            return isinstance(event, PerpsOrderEvent) and event.payload.id == order_id
-
-        event = await self._wait_for_event(matches, timeout_s=_ORDER_PLACEMENT_UPDATE_TIMEOUT_S)
-        assert isinstance(event, PerpsOrderEvent)
-        return event.payload
-
-    async def _wait_for_event(
-        self,
-        predicate: Callable[[PerpsSessionEvent], bool],
-        *,
-        timeout_s: float,
-    ) -> PerpsSessionEvent:
+    def _create_event_waiter(self, predicate: Callable[[PerpsSessionEvent], bool]) -> _EventWaiter:
         future: asyncio.Future[PerpsSessionEvent] = asyncio.get_running_loop().create_future()
         waiter = _EventWaiter(future=future, predicate=predicate)
         self._event_waiters.append(waiter)
+        return waiter
+
+    async def _wait_for_event(
+        self,
+        waiter: _EventWaiter,
+        *,
+        timeout_s: float,
+    ) -> PerpsSessionEvent:
         try:
-            return await asyncio.wait_for(future, timeout=timeout_s)
+            return await asyncio.wait_for(waiter.future, timeout=timeout_s)
         except TimeoutError as error:
             raise SDKTimeoutError("Perps event wait timed out.") from error
-        finally:
-            with contextlib.suppress(ValueError):
-                self._event_waiters.remove(waiter)
 
-    async def _position_exit_buy(self, instrument_id: int) -> bool:
-        portfolio = await self.fetch_portfolio()
-        position = next(
-            (item for item in portfolio.positions if item.instrument_id == instrument_id),
-            None,
-        )
-        if position is None or position.size == 0:
-            raise UserInputError(f"No open Perps position for instrument {instrument_id}.")
-        return position.size < 0
+    def _remove_event_waiter(self, waiter: _EventWaiter) -> None:
+        with contextlib.suppress(ValueError):
+            self._event_waiters.remove(waiter)
+        if not waiter.future.done():
+            waiter.future.cancel()
+            return
+        with contextlib.suppress(asyncio.CancelledError):
+            waiter.future.exception()
 
     def _on_message(self, raw: object) -> None:
         if isinstance(raw, list):
@@ -1088,13 +998,7 @@ class PerpsSession:
             )
         )
 
-    _RECENT_ORDERS_LIMIT = 256
-
     def _emit_event(self, event: PerpsSessionEvent) -> None:
-        if isinstance(event, PerpsOrderEvent):
-            self._recent_orders[event.payload.id] = event.payload
-            while len(self._recent_orders) > self._RECENT_ORDERS_LIMIT:
-                self._recent_orders.pop(next(iter(self._recent_orders)))
         for waiter in tuple(self._event_waiters):
             try:
                 matched = waiter.predicate(event)

--- a/tests/unit/test_perps_session.py
+++ b/tests/unit/test_perps_session.py
@@ -22,6 +22,7 @@ from polymarket.errors import (
     TransportError,
     UserInputError,
 )
+from polymarket.errors import TimeoutError as SDKTimeoutError
 from polymarket.models.perps.credentials import PerpsCredentials
 from polymarket.models.perps.events import (
     PerpsFillEvent,
@@ -71,7 +72,11 @@ async def _handshake(ws: ServerConnection) -> list[dict[str, Any]]:
 
 
 def _order_update(
-    order_id: int, *, sequence: int = 1, reduce_only: bool | None = None
+    order_id: int,
+    *,
+    client_order_id: str | None = None,
+    sequence: int = 1,
+    reduce_only: bool | None = None,
 ) -> dict[str, Any]:
     update: dict[str, Any] = {
         "ch": "orders",
@@ -93,6 +98,8 @@ def _order_update(
             "uts": 1751500000001,
         },
     }
+    if client_order_id is not None:
+        update["data"]["coid"] = client_order_id
     return update
 
 
@@ -220,8 +227,17 @@ def test_place_order_signs_command_and_returns_order_update() -> None:
             if _is_ping(message):
                 continue
             commands.append(message)
+            client_order_id = message["op"]["args"][0]["c"]
+            await ws.send(
+                json.dumps(
+                    _order_update(
+                        77,
+                        client_order_id=client_order_id,
+                        reduce_only=True,
+                    )
+                )
+            )
             await ws.send(json.dumps({"id": message["id"], "data": [{"status": "ok", "oid": 77}]}))
-            await ws.send(json.dumps(_order_update(77, reduce_only=True)))
 
     async def run() -> None:
         async with ws_server(handler) as url, _open_session(url) as session:
@@ -234,12 +250,18 @@ def test_place_order_signs_command_and_returns_order_update() -> None:
                 time_in_force="gtc",
             )
             assert placement.order.id == 77
+            assert placement.order.client_order_id == commands[0]["op"]["args"][0]["c"]
             assert placement.order.reduce_only is True
             assert placement.order.status == "open"
             assert placement.tp_sl is None
+            assert session._event_waiters == []
 
     asyncio.run(asyncio.wait_for(run(), timeout=10.0))
     command = commands[0]
+    client_order_id = command["op"]["args"][0]["c"]
+    assert isinstance(client_order_id, str)
+    assert len(client_order_id) == 32
+    int(client_order_id, 16)
     assert command["op"]["type"] == "createOrders"
     assert command["op"]["args"] == [
         {
@@ -250,11 +272,111 @@ def test_place_order_signs_command_and_returns_order_update() -> None:
             "ro": True,
             "tif": "gtc",
             "p": "0.5",
+            "c": client_order_id,
         }
     ]
     assert isinstance(command["salt"], int)
     assert isinstance(command["ts"], int)
     assert command["sig"].startswith("0x") and len(command["sig"]) == 132
+
+
+def test_place_order_update_timeout_starts_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polymarket._internal.actions.perps import trading
+
+    monkeypatch.setattr(trading, "_ORDER_PLACEMENT_UPDATE_TIMEOUT_S", 0.5)
+
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        async for raw in ws:
+            message = json.loads(raw)
+            if _is_ping(message):
+                continue
+            client_order_id = message["op"]["args"][0]["c"]
+            await asyncio.sleep(0.6)
+            await ws.send(json.dumps({"id": message["id"], "data": [{"status": "ok", "oid": 77}]}))
+            await ws.send(
+                json.dumps(
+                    _order_update(
+                        77,
+                        client_order_id=client_order_id,
+                    )
+                )
+            )
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            placement = await session.place_order(
+                instrument_id=1,
+                side="BUY",
+                price="0.5",
+                quantity="10",
+                time_in_force="gtc",
+            )
+            assert placement.order.id == 77
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
+def test_place_order_ack_timeout_cleans_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polymarket._internal import perps_session
+
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        with contextlib.suppress(Exception):
+            async for _ in ws:
+                pass
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            monkeypatch.setattr(perps_session, "_ACK_TIMEOUT_S", 0.01)
+            with pytest.raises(
+                TransportError,
+                match="post order acknowledgement timed out",
+            ):
+                await session.place_order(
+                    instrument_id=1,
+                    side="BUY",
+                    price="0.5",
+                    quantity="10",
+                    time_in_force="gtc",
+                )
+            assert session._event_waiters == []
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
+def test_place_order_update_timeout_cleans_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polymarket._internal.actions.perps import trading
+
+    monkeypatch.setattr(trading, "_ORDER_PLACEMENT_UPDATE_TIMEOUT_S", 0.01)
+
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        async for raw in ws:
+            message = json.loads(raw)
+            if _is_ping(message):
+                continue
+            await ws.send(json.dumps({"id": message["id"], "data": [{"status": "ok", "oid": 77}]}))
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            with pytest.raises(SDKTimeoutError, match="event wait timed out"):
+                await session.place_order(
+                    instrument_id=1,
+                    side="BUY",
+                    price="0.5",
+                    quantity="10",
+                    time_in_force="gtc",
+                )
+            assert session._event_waiters == []
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
 
 
 def test_batched_session_updates_feed_queue_and_order_waiters() -> None:
@@ -264,8 +386,20 @@ def test_batched_session_updates_feed_queue_and_order_waiters() -> None:
             message = json.loads(raw)
             if _is_ping(message):
                 continue
+            client_order_id = message["op"]["args"][0]["c"]
             await ws.send(json.dumps({"id": message["id"], "data": [{"status": "ok", "oid": 77}]}))
-            await ws.send(json.dumps([_order_update(76), _order_update(77, sequence=2)]))
+            await ws.send(
+                json.dumps(
+                    [
+                        _order_update(76),
+                        _order_update(
+                            77,
+                            client_order_id=client_order_id,
+                            sequence=2,
+                        ),
+                    ]
+                )
+            )
 
     async def run() -> None:
         async with ws_server(handler) as url, _open_session(url) as session:
@@ -321,6 +455,15 @@ def test_place_order_with_tp_sl_groups_rows_and_returns_trigger_ids() -> None:
             if _is_ping(message):
                 continue
             commands.append(message)
+            client_order_id = message["op"]["args"][0]["c"]
+            await ws.send(
+                json.dumps(
+                    _order_update(
+                        100,
+                        client_order_id=client_order_id,
+                    )
+                )
+            )
             await ws.send(
                 json.dumps(
                     {
@@ -333,7 +476,6 @@ def test_place_order_with_tp_sl_groups_rows_and_returns_trigger_ids() -> None:
                     }
                 )
             )
-            await ws.send(json.dumps(_order_update(100)))
 
     async def run() -> None:
         async with ws_server(handler) as url, _open_session(url) as session:
@@ -347,6 +489,7 @@ def test_place_order_with_tp_sl_groups_rows_and_returns_trigger_ids() -> None:
                 stop_loss=PerpsTpSlTrigger(trigger_price="0.25"),
             )
             assert placement.order.id == 100
+            assert placement.order.client_order_id == commands[0]["op"]["args"][0]["c"]
             assert placement.tp_sl is not None
             assert placement.tp_sl.take_profit is not None
             assert placement.tp_sl.take_profit.order_id == 101
@@ -357,6 +500,9 @@ def test_place_order_with_tp_sl_groups_rows_and_returns_trigger_ids() -> None:
     op = commands[0]["op"]
     assert op["grp"] == "order"
     assert len(op["args"]) == 3
+    assert len(op["args"][0]["c"]) == 32
+    assert "c" not in op["args"][1]
+    assert "c" not in op["args"][2]
     assert op["args"][1]["tr"] == {"tpsl": "tp", "trp": "1", "market": True}
     assert op["args"][2]["tr"] == {"tpsl": "sl", "trp": "0.25", "market": True}
     # Trigger legs exit the position: entry BUY -> reduce-only SELL legs.
@@ -389,8 +535,64 @@ def test_place_order_rejection_raises_request_rejected() -> None:
                     quantity="10",
                     time_in_force="gtc",
                 )
+            assert session._event_waiters == []
 
     asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+
+
+def test_post_orders_preserves_low_level_client_ids_and_error_acks() -> None:
+    from polymarket.models.perps.requests import PerpsOrderRequest
+
+    commands: list[dict[str, Any]] = []
+    supplied_client_order_id = "aabbccddeeff00112233445566778899"
+
+    async def handler(ws: ServerConnection) -> None:
+        await _handshake(ws)
+        async for raw in ws:
+            message = json.loads(raw)
+            if _is_ping(message):
+                continue
+            commands.append(message)
+            await ws.send(
+                json.dumps(
+                    {
+                        "id": message["id"],
+                        "data": [
+                            {"status": "ok", "oid": 77},
+                            {"status": "err", "error": "insufficient margin"},
+                        ],
+                    }
+                )
+            )
+
+    async def run() -> None:
+        async with ws_server(handler) as url, _open_session(url) as session:
+            acks = await session.post_orders(
+                [
+                    PerpsOrderRequest(
+                        instrument_id=1,
+                        side="BUY",
+                        price="0.5",
+                        quantity="10",
+                        time_in_force="gtc",
+                    ),
+                    PerpsOrderRequest(
+                        instrument_id=1,
+                        side="SELL",
+                        price="0.6",
+                        quantity="5",
+                        time_in_force="gtc",
+                        client_order_id=supplied_client_order_id,
+                    ),
+                ]
+            )
+            assert [ack.status for ack in acks] == ["ok", "err"]
+            assert acks[1].error == "insufficient margin"
+
+    asyncio.run(asyncio.wait_for(run(), timeout=10.0))
+    args = commands[0]["op"]["args"]
+    assert "c" not in args[0]
+    assert args[1]["c"] == supplied_client_order_id
 
 
 def test_cancel_order_returns_result_without_raising_on_err_status() -> None:


### PR DESCRIPTION
## Summary

- port the DEV-398 update-before-ack fix from Polymarket/ts-sdk#274 using Python-native async primitives
- move Perps placement workflows into trading actions that receive the concrete session while the session retains signing, transport, and waiter lifecycle ownership
- generate client order IDs only for high-level placement, register correlation before sending, and remove the bounded recent-order replay cache
- preserve distinct acknowledgement and post-acknowledgement event deadlines, strict client-order-ID correlation, and low-level mixed acknowledgement behavior

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv build`
- `uv run pytest tests/unit/test_perps_session.py -q` (24 passed)
- `uv run pytest -m "not integration"` (2,230 passed, 184 deselected)

Metered live Perps placement was not run.

## Tracking

- [DEV-398](https://linear.app/polymarket/issue/DEV-398/fix-perps-placeorder-order-update-race)
- TypeScript counterpart: Polymarket/ts-sdk#274
