### PR TITLE
fix(ci): resolve release in explicit repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
             echo "Invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi
-          gh release view "$RELEASE_TAG" --json isDraft --jq 'select(.isDraft == false)' >/dev/null
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq 'select(.isDraft == false)' >/dev/null
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout


### PR DESCRIPTION
The guarded publish retry resolves the release before checkout, so GitHub CLI cannot infer a repository from .git. This passes GITHUB_REPOSITORY explicitly to gh release view. No package, tag, release, or publishing behavior changes. Validation: git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow change with no impact on packaging, tagging, or PyPI publish logic.
> 
> **Overview**
> Fixes the **Publish** workflow when it validates the release tag on **workflow_dispatch** retries (and any run where **Resolve release tag** runs before **Checkout**).
> 
> `gh release view` now includes `--repo "$GITHUB_REPOSITORY"` so the CLI does not depend on a checked-out `.git` context. Tag format checks and the non-draft release guard are unchanged; only release lookup is made reliable in that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1f2559e34fdffe54799d40147eacea2ce7a24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->