### PR TITLE
chore(ci): remove manual publish retry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,6 @@ name: Publish
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: Published polymarket-client release tag to retry
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -21,24 +15,10 @@ jobs:
     environment: release
 
     steps:
-      - name: Resolve release tag
-        id: release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
-        run: |
-          if [[ ! "$RELEASE_TAG" =~ ^polymarket-client-v[0-9] ]]; then
-            echo "Invalid release tag: $RELEASE_TAG" >&2
-            exit 1
-          fi
-          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq 'select(.isDraft == false)' >/dev/null
-          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ steps.release.outputs.tag }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2


### PR DESCRIPTION
## Summary

- remove the temporary workflow_dispatch recovery path from Publish
- restore release-published as the only trigger
- retain the PyPI publisher v1.14.2 compatibility fix

The guarded retry for polymarket-client-v0.6.0 completed successfully and PyPI now contains both distributions.

## Verification

- git diff --check
- confirmed v1.14.2 remains pinned in publish.yml and release-please.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only cleanup with no application or release-artifact logic changes beyond simplifying how publish is triggered.
> 
> **Overview**
> **Publish** no longer supports manual reruns: the `workflow_dispatch` trigger and `release_tag` input are removed, along with the **Resolve release tag** step that validated `polymarket-client-v*` tags and checked non-draft releases.
> 
> Checkout now uses the default ref from the `release: published` event instead of pinning checkout to a resolved tag. The rest of the job (uv build, `pypa/gh-action-pypi-publish` at v1.14.2) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b114372aa63654f5b15531d1d0f645954d1552d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->