### PR TITLE
feat(data): support multi-status filtering on combo positions

### DIFF
--- a/src/polymarket/_internal/actions/data.py
+++ b/src/polymarket/_internal/actions/data.py
@@ -275,7 +275,7 @@ def list_closed_positions_spec(
 def list_combo_positions_spec(
     *,
     user: str,
-    status: ComboPositionStatus | None = None,
+    status: ComboPositionStatus | Sequence[ComboPositionStatus] | None = None,
     sort: ComboPositionSort | None = None,
     condition_id: str | Sequence[str] | None = None,
     updated_after: int | None = None,
@@ -283,7 +283,8 @@ def list_combo_positions_spec(
 ) -> KeysetPaginatedSpec[ComboPosition]:
     if not user:
         raise UserInputError("user is required.")
-    _check_enum("status", status, _COMBO_POSITION_STATUS)
+    if status is not None:
+        status = _normalize_combo_status_filter(status)
     _check_enum("sort", sort, _COMBO_POSITION_SORT)
     if condition_id is not None:
         condition_id = _normalize_combo_condition_filter(condition_id)
@@ -516,6 +517,17 @@ def _check_enum(name: str, value: object, allowed: tuple[str, ...]) -> None:
 def _check_nonnegative_int(name: str, value: int | None) -> None:
     if value is not None and value < 0:
         raise UserInputError(f"{name} must be non-negative.")
+
+
+def _normalize_combo_status_filter(
+    value: ComboPositionStatus | Sequence[ComboPositionStatus],
+) -> ComboPositionStatus | tuple[ComboPositionStatus, ...]:
+    values = (value,) if isinstance(value, str) else tuple(value)
+    if not values:
+        raise UserInputError("status must be a non-empty sequence.")
+    for item in values:
+        _check_enum("status", item, _COMBO_POSITION_STATUS)
+    return value if isinstance(value, str) else values
 
 
 def _normalize_combo_condition_filter(value: str | Sequence[str]) -> str | tuple[str, ...]:

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -714,7 +714,7 @@ class AsyncPublicClient:
         self,
         *,
         user: str,
-        status: ComboPositionStatus | None = None,
+        status: ComboPositionStatus | Sequence[ComboPositionStatus] | None = None,
         sort: ComboPositionSort | None = None,
         condition_id: str | Sequence[str] | None = None,
         updated_after: int | None = None,
@@ -722,6 +722,10 @@ class AsyncPublicClient:
         page_size: int = 20,
     ) -> AsyncPaginator[ComboPosition]:
         """List combo positions for a user.
+
+        Args:
+            status: One status or a non-empty sequence of statuses. Multiple
+                statuses are matched as alternatives in the given order.
 
         Returns:
             An async paginator over matching combo positions.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -1342,7 +1342,7 @@ class AsyncSecureClient:
         self,
         *,
         user: str | None = None,
-        status: ComboPositionStatus | None = None,
+        status: ComboPositionStatus | Sequence[ComboPositionStatus] | None = None,
         sort: ComboPositionSort | None = None,
         condition_id: str | Sequence[str] | None = None,
         updated_after: int | None = None,
@@ -1350,6 +1350,10 @@ class AsyncSecureClient:
         page_size: int = 20,
     ) -> AsyncPaginator[ComboPosition]:
         """List combo positions for a user or the authenticated wallet.
+
+        Args:
+            status: One status or a non-empty sequence of statuses. Multiple
+                statuses are matched as alternatives in the given order.
 
         Returns:
             An async paginator over matching combo positions.

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -494,7 +494,7 @@ class PublicClient:
         self,
         *,
         user: str,
-        status: ComboPositionStatus | None = None,
+        status: ComboPositionStatus | Sequence[ComboPositionStatus] | None = None,
         sort: ComboPositionSort | None = None,
         condition_id: str | Sequence[str] | None = None,
         updated_after: int | None = None,
@@ -502,6 +502,10 @@ class PublicClient:
         page_size: int = 20,
     ) -> Paginator[ComboPosition]:
         """List combo positions for a user.
+
+        Args:
+            status: One status or a non-empty sequence of statuses. Multiple
+                statuses are matched as alternatives in the given order.
 
         Returns:
             A paginator over matching combo positions.

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -871,7 +871,7 @@ class SecureClient:
         self,
         *,
         user: str | None = None,
-        status: ComboPositionStatus | None = None,
+        status: ComboPositionStatus | Sequence[ComboPositionStatus] | None = None,
         sort: ComboPositionSort | None = None,
         condition_id: str | Sequence[str] | None = None,
         updated_after: int | None = None,
@@ -879,6 +879,10 @@ class SecureClient:
         page_size: int = 20,
     ) -> Paginator[ComboPosition]:
         """List combo positions for a user or the authenticated wallet.
+
+        Args:
+            status: One status or a non-empty sequence of statuses. Multiple
+                statuses are matched as alternatives in the given order.
 
         Returns:
             A paginator over matching combo positions.

--- a/tests/integration/test_data_paginated.py
+++ b/tests/integration/test_data_paginated.py
@@ -8,6 +8,7 @@ from polymarket import (
     ClosedPosition,
     ComboActivity,
     ComboPosition,
+    ComboPositionStatus,
     LeaderboardEntry,
     MetaMarketPosition,
     Position,
@@ -82,6 +83,30 @@ def test_list_combo_positions_filters_by_condition_id() -> None:
         ).first_page()
     assert filtered.items
     assert filtered.items[0].condition_id == condition_id
+
+
+@pytest.mark.integration
+def test_list_combo_positions_filters_by_multiple_statuses() -> None:
+    statuses: list[ComboPositionStatus] = ["RESOLVED_WIN", "RESOLVED_PARTIAL", "RESOLVED_LOSS"]
+    with PublicClient() as client:
+        paginator = client.list_combo_positions(user=COMBO_WALLET, status=statuses, page_size=1)
+        first = paginator.first_page()
+        pages = [first]
+        if first.next_cursor is not None:
+            pages.append(paginator.from_cursor(first.next_cursor).first_page())
+    assert first.items
+    assert all(position.status in statuses for page in pages for position in page.items)
+
+
+@pytest.mark.integration
+def test_list_combo_positions_filters_by_single_status() -> None:
+    status: ComboPositionStatus = "RESOLVED_WIN"
+    with PublicClient() as client:
+        page = client.list_combo_positions(
+            user=COMBO_WALLET, status=status, page_size=10
+        ).first_page()
+    assert page.items
+    assert all(p.status == status for p in page.items)
 
 
 @pytest.mark.integration

--- a/tests/unit/test_data_paginated_specs.py
+++ b/tests/unit/test_data_paginated_specs.py
@@ -70,6 +70,52 @@ def test_list_combo_positions_spec_validates_status() -> None:
         data_actions.list_combo_positions_spec(user="0xWALLET", status="CLOSED")  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    "statuses",
+    [
+        ["RESOLVED_WIN", "RESOLVED_PARTIAL", "RESOLVED_LOSS"],
+        ("RESOLVED_WIN", "RESOLVED_PARTIAL", "RESOLVED_LOSS"),
+    ],
+)
+def test_list_combo_positions_spec_builds_request_with_multiple_statuses(
+    statuses: list[str] | tuple[str, ...],
+) -> None:
+    spec = data_actions.list_combo_positions_spec(
+        user="0xWALLET",
+        status=statuses,  # type: ignore[arg-type]
+    )
+    assert spec.base_params == {
+        "user": "0xWALLET",
+        "status": "RESOLVED_WIN,RESOLVED_PARTIAL,RESOLVED_LOSS",
+    }
+
+
+def test_list_combo_positions_spec_validates_each_status_in_sequence() -> None:
+    with pytest.raises(UserInputError, match="status"):
+        data_actions.list_combo_positions_spec(user="0xWALLET", status=["OPEN", "CLOSED"])  # type: ignore[list-item]
+
+
+def test_list_combo_positions_spec_rejects_empty_status_sequence() -> None:
+    with pytest.raises(UserInputError, match="status"):
+        data_actions.list_combo_positions_spec(user="0xWALLET", status=[])
+
+
+def test_list_combo_positions_spec_rejects_non_string_status_member() -> None:
+    with pytest.raises(UserInputError, match="status"):
+        data_actions.list_combo_positions_spec(
+            user="0xWALLET",
+            status=["OPEN", 1],  # type: ignore[list-item]
+        )
+
+
+def test_list_combo_positions_spec_rejects_comma_separated_status_string() -> None:
+    with pytest.raises(UserInputError, match="status"):
+        data_actions.list_combo_positions_spec(
+            user="0xWALLET",
+            status="RESOLVED_WIN,RESOLVED_LOSS",  # type: ignore[arg-type]
+        )
+
+
 def test_list_combo_positions_spec_rejects_non_combo_condition_id() -> None:
     with pytest.raises(UserInputError, match="combo condition ID"):
         data_actions.list_combo_positions_spec(user="0xWALLET", condition_id=_CTF_CONDITION_ID)


### PR DESCRIPTION
[DEV-442](https://linear.app/polymarket/issue/DEV-442/combo-multi-status-filtering-in-py-sdk)/[DEV-429](https://linear.app/polymarket/issue/DEV-429/support-multi-status-filtering-on-combo-positions-in-ts-and-python): Supports multi-status combo position filters in Python.

Tests: lint/format, typecheck, build, unit PASS; public live PASS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API extension (single status unchanged) with input validation and test coverage; no auth or trading-path changes.
> 
> **Overview**
> **`list_combo_positions`** now accepts **`status`** as a single `ComboPositionStatus` or a **non-empty sequence** of statuses (lists/tuples). Multiple values are sent to the data API as a comma-separated query param and treated as **OR** filters in caller order.
> 
> Validation lives in **`_normalize_combo_status_filter`**: each entry must be a valid enum, empty sequences are rejected, and a single comma-joined string (e.g. `"RESOLVED_WIN,RESOLVED_LOSS"`) is **not** accepted—callers must pass a sequence. Sync/async **public** and **secure** clients share the widened type and updated docstrings.
> 
> Unit tests cover request shaping and edge cases; integration tests exercise single- and multi-status filters against live data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6112f5ccf1aac60b21f3ded3882639e29ff844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->