### PR TITLE
feat(perps): expose server time

### DIFF
--- a/src/polymarket/_internal/actions/perps/public.py
+++ b/src/polymarket/_internal/actions/perps/public.py
@@ -5,6 +5,8 @@ import time
 from datetime import datetime
 from typing import Any, cast
 
+from pydantic import field_validator
+
 from polymarket._internal.actions.perps.paging import (
     ONE_DAY_MS,
     as_json_dict,
@@ -18,6 +20,10 @@ from polymarket._internal.actions.perps.paging import (
 )
 from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import UnexpectedResponseError, UserInputError
+from polymarket.models.base import BaseModel
+from polymarket.models.perps._validators import (
+    _require_epoch_ms,  # pyright: ignore[reportPrivateUsage]
+)
 from polymarket.models.perps.market import (
     PerpsBook,
     PerpsCandle,
@@ -40,6 +46,15 @@ _CATEGORIES = ("equity", "commodity", "index", "crypto")
 _KLINE_INTERVALS = ("1s", "1m", "5m", "15m", "1h", "4h", "1d", "1w")
 
 
+class _PerpsServerTimeResponse(BaseModel):
+    time: datetime
+
+    @field_validator("time", mode="before")
+    @classmethod
+    def _parse_time(cls, value: object) -> object:
+        return _require_epoch_ms(value)
+
+
 def _validate_instrument_id(instrument_id: object, *, optional: bool = False) -> int | None:
     if instrument_id is None and optional:
         return None
@@ -48,6 +63,12 @@ def _validate_instrument_id(instrument_id: object, *, optional: bool = False) ->
     if instrument_id < 0:
         raise UserInputError("instrument_id must be non-negative")
     return instrument_id
+
+
+async def get_server_time(perps: AsyncTransport) -> datetime:
+    """Return the Perps server clock as an aware UTC datetime."""
+    response = _PerpsServerTimeResponse.parse_response(await perps.get_json("/v1/info/time"))
+    return response.time
 
 
 async def fetch_instruments(

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1427,6 +1427,14 @@ class AsyncPublicClient:
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
+    async def get_server_time(self) -> "datetime":
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Get the current Perps server time as an aware UTC datetime.
+        """
+        return await _perps_actions.get_server_time(self._ctx.perps)
+
     async def fetch_perps_ticker(self, *, instrument_id: int) -> PerpsTicker:
         """Experimental: This API may change in a breaking way in any release,
         including patch releases.

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -3,6 +3,7 @@
 import contextlib
 import logging
 from collections.abc import Sequence
+from datetime import datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, Self, assert_never, cast, overload
@@ -136,8 +137,6 @@ from polymarket.streams._specs import (
 )
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from polymarket._internal.streams.clob.market import ClobMarketStreamManager
     from polymarket._internal.streams.perps.market import PerpsMarketStreamManager
     from polymarket._internal.streams.rtds.manager import RtdsStreamManager
@@ -1427,7 +1426,7 @@ class AsyncPublicClient:
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
-    async def get_server_time(self) -> "datetime":
+    async def get_server_time(self) -> datetime:
         """Experimental: This API may change in a breaking way in any release,
         including patch releases.
 

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -3301,6 +3301,14 @@ class AsyncSecureClient:
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
+    async def get_server_time(self) -> "datetime":
+        """Experimental: This API may change in a breaking way in any release,
+        including patch releases.
+
+        Get the current Perps server time as an aware UTC datetime.
+        """
+        return await _perps_actions.get_server_time(self._ctx.perps)
+
     async def fetch_perps_ticker(self, *, instrument_id: int) -> PerpsTicker:
         """Experimental: This API may change in a breaking way in any release,
         including patch releases.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import (
@@ -281,7 +282,7 @@ from polymarket.transactions import (
 from polymarket.types import EvmAddress, HexString, TransactionHash
 
 if TYPE_CHECKING:
-    from datetime import datetime, timedelta
+    from datetime import timedelta
 
     from polymarket._internal.perps_session import PerpsSession
     from polymarket._internal.rfq import RfqQuoterSession
@@ -3301,7 +3302,7 @@ class AsyncSecureClient:
             self._ctx.perps, instrument_id=instrument_id, category=category
         )
 
-    async def get_server_time(self) -> "datetime":
+    async def get_server_time(self) -> datetime:
         """Experimental: This API may change in a breaking way in any release,
         including patch releases.
 

--- a/tests/integration/test_perps.py
+++ b/tests/integration/test_perps.py
@@ -116,6 +116,17 @@ async def test_public_perps_reads() -> None:
 
 
 @pytest.mark.integration
+async def test_get_server_time() -> None:
+    before = datetime.now(UTC) - timedelta(seconds=5)
+    async with AsyncPublicClient() as client:
+        server_time = await client.get_server_time()
+    after = datetime.now(UTC) + timedelta(seconds=5)
+
+    assert server_time.tzinfo is not None
+    assert before <= server_time <= after
+
+
+@pytest.mark.integration
 async def test_perps_book_subscription_receives_an_event() -> None:
     async with AsyncPublicClient() as client:
         instruments = await client.fetch_perps_instruments()

--- a/tests/unit/test_perps_public_actions.py
+++ b/tests/unit/test_perps_public_actions.py
@@ -13,7 +13,7 @@ import pytest
 
 from polymarket._internal.actions.perps import public as perps_public
 from polymarket.clients._transport import AsyncTransport
-from polymarket.errors import UserInputError
+from polymarket.errors import UnexpectedResponseError, UserInputError
 
 _BASE_URL = "https://perps.test"
 
@@ -31,6 +31,31 @@ def _query(request: httpx.Request) -> dict[str, str]:
 
 def _cursor(state: dict[str, Any]) -> str:
     return base64.b64encode(json.dumps(state, separators=(",", ":")).encode()).decode()
+
+
+@pytest.mark.parametrize("time", [1_786_697_208_022, True, "1786697208022", None])
+def test_get_server_time_parses_only_epoch_milliseconds(time: object) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"time": time})
+
+    async def run() -> None:
+        transport = _transport(handler)
+        try:
+            if isinstance(time, int) and not isinstance(time, bool):
+                server_time = await perps_public.get_server_time(transport)
+                assert server_time.tzinfo is not None
+                assert int(server_time.timestamp() * 1000) == time
+            else:
+                with pytest.raises(UnexpectedResponseError):
+                    await perps_public.get_server_time(transport)
+        finally:
+            await transport.close()
+
+    asyncio.run(run())
+    assert [request.url.path for request in requests] == ["/v1/info/time"]
 
 
 def test_list_candles_steps_forward_by_interval() -> None:

--- a/tests/unit/test_perps_public_actions.py
+++ b/tests/unit/test_perps_public_actions.py
@@ -4,14 +4,16 @@ import asyncio
 import base64
 import json
 from collections.abc import Callable
+from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, get_type_hints
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 
 from polymarket._internal.actions.perps import public as perps_public
+from polymarket.clients import AsyncPublicClient, AsyncSecureClient
 from polymarket.clients._transport import AsyncTransport
 from polymarket.errors import UnexpectedResponseError, UserInputError
 
@@ -56,6 +58,11 @@ def test_get_server_time_parses_only_epoch_milliseconds(time: object) -> None:
 
     asyncio.run(run())
     assert [request.url.path for request in requests] == ["/v1/info/time"]
+
+
+def test_get_server_time_public_return_types_are_runtime_resolvable() -> None:
+    assert get_type_hints(AsyncPublicClient.get_server_time)["return"] is datetime
+    assert get_type_hints(AsyncSecureClient.get_server_time)["return"] is datetime
 
 
 def test_list_candles_steps_forward_by_interval() -> None:


### PR DESCRIPTION
[DEV-467](https://linear.app/polymarket/issue/DEV-467/plan-integrate-server-time-from-v1infotime-into-perps-request): Exposes the Perps server clock.

Tests: lint/format, typecheck, build, unit PASS; public live PASS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive experimental read-only API with no auth or trading-path changes; main risk is callers depending on strict epoch-ms parsing behavior.
> 
> **Overview**
> Adds **`get_server_time()`** on **`AsyncPublicClient`** and **`AsyncSecureClient`**, backed by a new Perps public action that calls **`GET /v1/info/time`** and returns an **timezone-aware UTC `datetime`**.
> 
> The JSON **`time`** field is parsed through a small response model that accepts **epoch milliseconds only** (reusing **`_require_epoch_ms`**); invalid shapes raise **`UnexpectedResponseError`**. **`datetime`** imports were moved out of **`TYPE_CHECKING`** so the public return type is runtime-resolvable.
> 
> Coverage includes **mocked unit tests** for parsing/endpoint path and **a live integration test** that the clock is within a few seconds of local UTC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00423d99500faa1253ee252b93e5c17e95297413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->