### PR TITLE
fix(session-keys): default session key expiration

### DIFF
--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -51,7 +51,7 @@ _EVM_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _TRANSACTION_HASH_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 _SESSION_KEY_SUBMISSION_MAX_RETRIES = 2
-_DEFAULT_SESSION_KEY_LIFETIME_SECONDS = 4_315 * 60 * 60
+_SESSION_KEY_LIFETIME_SECONDS = 180 * 24 * 60 * 60
 
 _SecureContext = AsyncSecureClientContext | SyncSecureClientContext
 _ResponseT = TypeVar("_ResponseT")
@@ -186,7 +186,6 @@ async def authorize_session_key(
     *,
     address: str,
     scopes: Sequence[SessionKeyScope],
-    valid_until: datetime | None,
     idempotency_key: str | None,
 ) -> AuthorizeSessionKeyResult:
     _assert_owner_deposit_wallet(ctx)
@@ -194,7 +193,6 @@ async def authorize_session_key(
     request = _parse_authorize_session_key_request(
         address=address,
         scopes=scopes,
-        valid_until=valid_until,
         idempotency_key=idempotency_key,
     )
     call = authorize_session_signer_call(
@@ -232,7 +230,6 @@ def authorize_session_key_sync(
     *,
     address: str,
     scopes: Sequence[SessionKeyScope],
-    valid_until: datetime | None,
     idempotency_key: str | None,
 ) -> AuthorizeSessionKeyResult:
     _assert_owner_deposit_wallet(ctx)
@@ -240,7 +237,6 @@ def authorize_session_key_sync(
     request = _parse_authorize_session_key_request(
         address=address,
         scopes=scopes,
-        valid_until=valid_until,
         idempotency_key=idempotency_key,
     )
     call = authorize_session_signer_call(
@@ -347,17 +343,19 @@ def _parse_authorize_session_key_request(
     *,
     address: object,
     scopes: object,
-    valid_until: object,
     idempotency_key: object,
 ) -> _ParsedAuthorizeSessionKeyRequest:
     session_address = _parse_session_address(address)
     normalized_scopes = _parse_scopes(scopes)
-    normalized_expiry = _parse_valid_until(valid_until)
+    valid_until = datetime.fromtimestamp(
+        int(time.time()) + _SESSION_KEY_LIFETIME_SECONDS,
+        tz=UTC,
+    )
     return _ParsedAuthorizeSessionKeyRequest(
         address=session_address,
         scopes=normalized_scopes,
-        valid_until=normalized_expiry,
-        valid_until_epoch=int(normalized_expiry.timestamp()),
+        valid_until=valid_until,
+        valid_until_epoch=int(valid_until.timestamp()),
         idempotency_key=_parse_idempotency_key(idempotency_key),
     )
 
@@ -414,22 +412,6 @@ def _parse_scopes(scopes: object) -> tuple[SessionKeyScope, ...]:
     ):
         raise UserInputError("Session key scope ALL cannot be combined with another scope.")
     return tuple(normalized)
-
-
-def _parse_valid_until(valid_until: object) -> datetime:
-    if valid_until is None:
-        return datetime.fromtimestamp(
-            int(time.time()) + _DEFAULT_SESSION_KEY_LIFETIME_SECONDS,
-            tz=UTC,
-        )
-    if not isinstance(valid_until, datetime):
-        raise UserInputError("Session key expiry must be a timezone-aware datetime.")
-    if valid_until.tzinfo is None or valid_until.utcoffset() is None:
-        raise UserInputError("Session key expiry must be a timezone-aware datetime.")
-    normalized = valid_until.astimezone(UTC).replace(microsecond=0)
-    if int(normalized.timestamp()) <= int(time.time()):
-        raise UserInputError("Session key expiry must be in the future.")
-    return normalized
 
 
 def _parse_idempotency_key(idempotency_key: object) -> str:

--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -51,6 +51,7 @@ _EVM_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _TRANSACTION_HASH_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 _SESSION_KEY_SUBMISSION_MAX_RETRIES = 2
+_DEFAULT_SESSION_KEY_LIFETIME_SECONDS = 4_315 * 60 * 60
 
 _SecureContext = AsyncSecureClientContext | SyncSecureClientContext
 _ResponseT = TypeVar("_ResponseT")
@@ -185,7 +186,7 @@ async def authorize_session_key(
     *,
     address: str,
     scopes: Sequence[SessionKeyScope],
-    valid_until: datetime,
+    valid_until: datetime | None,
     idempotency_key: str | None,
 ) -> AuthorizeSessionKeyResult:
     _assert_owner_deposit_wallet(ctx)
@@ -231,7 +232,7 @@ def authorize_session_key_sync(
     *,
     address: str,
     scopes: Sequence[SessionKeyScope],
-    valid_until: datetime,
+    valid_until: datetime | None,
     idempotency_key: str | None,
 ) -> AuthorizeSessionKeyResult:
     _assert_owner_deposit_wallet(ctx)
@@ -416,6 +417,11 @@ def _parse_scopes(scopes: object) -> tuple[SessionKeyScope, ...]:
 
 
 def _parse_valid_until(valid_until: object) -> datetime:
+    if valid_until is None:
+        return datetime.fromtimestamp(
+            int(time.time()) + _DEFAULT_SESSION_KEY_LIFETIME_SECONDS,
+            tz=UTC,
+        )
     if not isinstance(valid_until, datetime):
         raise UserInputError("Session key expiry must be a timezone-aware datetime.")
     if valid_until.tzinfo is None or valid_until.utcoffset() is None:

--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -51,7 +51,7 @@ _EVM_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _TRANSACTION_HASH_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 _SESSION_KEY_SUBMISSION_MAX_RETRIES = 2
-_SESSION_KEY_LIFETIME_SECONDS = 180 * 24 * 60 * 60
+_SESSION_KEY_LIFETIME_SECONDS = 4_315 * 60 * 60
 
 _SecureContext = AsyncSecureClientContext | SyncSecureClientContext
 _ResponseT = TypeVar("_ResponseT")

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -581,7 +581,7 @@ class AsyncSecureClient:
         *,
         address: str,
         scopes: Sequence[SessionKeyScope] = (SessionKeyKnownScope.ALL,),
-        valid_until: datetime,
+        valid_until: datetime | None = None,
         idempotency_key: str | None = None,
     ) -> AuthorizeSessionKeyResult:
         """Authorize an externally managed signer for selected venues.
@@ -593,6 +593,8 @@ class AsyncSecureClient:
         Scope names are normalized to uppercase. Unknown names remain usable
         before this SDK enumerates them. When scopes are omitted,
         authorization defaults to ``ALL``.
+        When ``valid_until`` is omitted, the authorization expires 4,315 hours
+        from the current time.
 
         Resolves after the submitted transaction is confirmed and the session
         key appears in the active session-key list.

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from datetime import datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import (
@@ -581,7 +580,6 @@ class AsyncSecureClient:
         *,
         address: str,
         scopes: Sequence[SessionKeyScope] = (SessionKeyKnownScope.ALL,),
-        valid_until: datetime | None = None,
         idempotency_key: str | None = None,
     ) -> AuthorizeSessionKeyResult:
         """Authorize an externally managed signer for selected venues.
@@ -593,8 +591,7 @@ class AsyncSecureClient:
         Scope names are normalized to uppercase. Unknown names remain usable
         before this SDK enumerates them. When scopes are omitted,
         authorization defaults to ``ALL``.
-        When ``valid_until`` is omitted, the authorization expires 4,315 hours
-        from the current time.
+        Authorizations expire 180 days after they are created.
 
         Resolves after the submitted transaction is confirmed and the session
         key appears in the active session-key list.
@@ -613,7 +610,6 @@ class AsyncSecureClient:
             self._ctx,
             address=address,
             scopes=scopes,
-            valid_until=valid_until,
             idempotency_key=idempotency_key,
         )
 

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -3,7 +3,6 @@
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from datetime import datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import TYPE_CHECKING, Literal, Self, cast, overload
@@ -511,7 +510,6 @@ class SecureClient:
         *,
         address: str,
         scopes: Sequence[SessionKeyScope] = (SessionKeyKnownScope.ALL,),
-        valid_until: datetime | None = None,
         idempotency_key: str | None = None,
     ) -> AuthorizeSessionKeyResult:
         """Authorize an externally managed signer for selected venues.
@@ -523,8 +521,7 @@ class SecureClient:
         Scope names are normalized to uppercase. Unknown names remain usable
         before this SDK enumerates them. When scopes are omitted,
         authorization defaults to ``ALL``.
-        When ``valid_until`` is omitted, the authorization expires 4,315 hours
-        from the current time.
+        Authorizations expire 180 days after they are created.
 
         Resolves after the submitted transaction is confirmed and the session
         key appears in the active session-key list.
@@ -543,7 +540,6 @@ class SecureClient:
             self._ctx,
             address=address,
             scopes=scopes,
-            valid_until=valid_until,
             idempotency_key=idempotency_key,
         )
 

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -511,7 +511,7 @@ class SecureClient:
         *,
         address: str,
         scopes: Sequence[SessionKeyScope] = (SessionKeyKnownScope.ALL,),
-        valid_until: datetime,
+        valid_until: datetime | None = None,
         idempotency_key: str | None = None,
     ) -> AuthorizeSessionKeyResult:
         """Authorize an externally managed signer for selected venues.
@@ -523,6 +523,8 @@ class SecureClient:
         Scope names are normalized to uppercase. Unknown names remain usable
         before this SDK enumerates them. When scopes are omitted,
         authorization defaults to ``ALL``.
+        When ``valid_until`` is omitted, the authorization expires 4,315 hours
+        from the current time.
 
         Resolves after the submitted transaction is confirmed and the session
         key appears in the active session-key list.

--- a/src/polymarket/session_keys.py
+++ b/src/polymarket/session_keys.py
@@ -51,12 +51,6 @@ class AuthorizeSessionKeyRequest(TypedDict):
     scopes: NotRequired[Sequence[SessionKeyScope]]
     """Requested scopes. Defaults to ``ALL``, which must appear alone."""
 
-    valid_until: NotRequired[datetime | None]
-    """Timezone-aware future expiry, normalized to UTC by the SDK.
-
-    Defaults to 4,315 hours from the current time.
-    """
-
     idempotency_key: NotRequired[str | None]
     """Operation key reused by the SDK's built-in exact-payload retries."""
 

--- a/src/polymarket/session_keys.py
+++ b/src/polymarket/session_keys.py
@@ -51,8 +51,11 @@ class AuthorizeSessionKeyRequest(TypedDict):
     scopes: NotRequired[Sequence[SessionKeyScope]]
     """Requested scopes. Defaults to ``ALL``, which must appear alone."""
 
-    valid_until: datetime
-    """Timezone-aware future expiry, normalized to UTC by the SDK."""
+    valid_until: NotRequired[datetime | None]
+    """Timezone-aware future expiry, normalized to UTC by the SDK.
+
+    Defaults to 4,315 hours from the current time.
+    """
 
     idempotency_key: NotRequired[str | None]
     """Operation key reused by the SDK's built-in exact-payload retries."""

--- a/tests/integration/test_session_keys.py
+++ b/tests/integration/test_session_keys.py
@@ -46,21 +46,17 @@ async def test_session_key_authorizes_lists_trades_and_revokes(
     revocation_accepted = False
     try:
         authorization_attempted = True
-        earliest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+        earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
         authorization = await deposit_wallet_client.authorize_session_key(
             address=session_account.address,
         )
-        latest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+        latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
         assert authorization.transaction.transaction_id is not None
         assert re.fullmatch(r"0x[0-9a-fA-F]{64}", str(authorization.transaction.transaction_hash))
         assert authorization.session_key.address.lower() == session_account.address.lower()
         assert authorization.session_key.scopes == (SessionKeyKnownScope.ALL,)
-        assert (
-            earliest_default_expiry
-            <= authorization.session_key.valid_until
-            <= latest_default_expiry
-        )
+        assert earliest_expiry <= authorization.session_key.valid_until <= latest_expiry
 
         active_session_keys = await deposit_wallet_client.fetch_session_keys()
         assert authorization.session_key in active_session_keys

--- a/tests/integration/test_session_keys.py
+++ b/tests/integration/test_session_keys.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import re
-from datetime import UTC, datetime, timedelta
 
 import pytest
 from eth_account import Account
@@ -46,17 +45,14 @@ async def test_session_key_authorizes_lists_trades_and_revokes(
     revocation_accepted = False
     try:
         authorization_attempted = True
-        earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
         authorization = await deposit_wallet_client.authorize_session_key(
             address=session_account.address,
         )
-        latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
         assert authorization.transaction.transaction_id is not None
         assert re.fullmatch(r"0x[0-9a-fA-F]{64}", str(authorization.transaction.transaction_hash))
         assert authorization.session_key.address.lower() == session_account.address.lower()
         assert authorization.session_key.scopes == (SessionKeyKnownScope.ALL,)
-        assert earliest_expiry <= authorization.session_key.valid_until <= latest_expiry
 
         active_session_keys = await deposit_wallet_client.fetch_session_keys()
         assert authorization.session_key in active_session_keys

--- a/tests/integration/test_session_keys.py
+++ b/tests/integration/test_session_keys.py
@@ -35,8 +35,6 @@ async def test_session_key_authorizes_lists_trades_and_revokes(
     # scopes, places one post-only order, cancels it, and revokes the key.
     session_account = Account.create()
     session_private_key = "0x" + session_account.key.hex().removeprefix("0x")
-    requested_expiry = datetime.now(UTC) + timedelta(hours=2)
-    expected_expiry = requested_expiry.replace(microsecond=0)
 
     deposit_wallet_client = await AsyncSecureClient.create(
         private_key=deposit_wallet_private_key,
@@ -48,16 +46,21 @@ async def test_session_key_authorizes_lists_trades_and_revokes(
     revocation_accepted = False
     try:
         authorization_attempted = True
+        earliest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
         authorization = await deposit_wallet_client.authorize_session_key(
             address=session_account.address,
-            valid_until=requested_expiry,
         )
+        latest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
 
         assert authorization.transaction.transaction_id is not None
         assert re.fullmatch(r"0x[0-9a-fA-F]{64}", str(authorization.transaction.transaction_hash))
         assert authorization.session_key.address.lower() == session_account.address.lower()
         assert authorization.session_key.scopes == (SessionKeyKnownScope.ALL,)
-        assert authorization.session_key.valid_until == expected_expiry
+        assert (
+            earliest_default_expiry
+            <= authorization.session_key.valid_until
+            <= latest_default_expiry
+        )
 
         active_session_keys = await deposit_wallet_client.fetch_session_keys()
         assert authorization.session_key in active_session_keys

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -253,7 +253,7 @@ def _assert_authorization_result_and_request(
 
 def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> None:
     captured: list[httpx.Request] = []
-    requested_expiry = datetime.now(UTC) + timedelta(minutes=15, microseconds=123_456)
+    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
     async def run() -> tuple[AuthorizeSessionKeyResult, str]:
         client = await make_deposit_client()
@@ -272,7 +272,6 @@ def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> N
                     _NEWER_SCOPE,
                     SessionKeyKnownScope.CLOB,
                 ),
-                valid_until=requested_expiry,
                 idempotency_key=" authorization-1 ",
             )
             return result, wallet
@@ -280,6 +279,8 @@ def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> N
             await client.close()
 
     result, wallet = asyncio.run(run())
+    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
+    assert earliest_expiry <= result.session_key.valid_until <= latest_expiry
     _assert_authorization_result_and_request(
         result,
         captured,
@@ -299,7 +300,7 @@ def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> N
             _NEWER_SCOPE,
             SessionKeyKnownScope.CLOB,
         ),
-        requested_expiry=requested_expiry,
+        requested_expiry=result.session_key.valid_until,
         wallet=wallet,
     )
 
@@ -331,7 +332,6 @@ def test_authorize_session_key_async_retries_the_exact_signed_payload() -> None:
             await client.authorize_session_key(
                 address=_SESSION_ADDRESS,
                 scopes=("clob",),
-                valid_until=datetime.now(UTC) + timedelta(minutes=15),
                 idempotency_key="exact-authorization",
             )
         finally:
@@ -356,7 +356,7 @@ def test_authorize_session_key_async_retries_the_exact_signed_payload() -> None:
 )
 def test_authorize_session_key_sync_uses_default_scopes(authorization_status: str) -> None:
     captured: list[httpx.Request] = []
-    earliest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
     with make_sync_deposit_client() as client:
         wallet = str(client.wallet)
@@ -371,10 +371,10 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
             address=_SESSION_ADDRESS,
             idempotency_key=" authorization-1 ",
         )
-    latest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
     requested_expiry = result.session_key.valid_until
 
-    assert earliest_default_expiry <= requested_expiry <= latest_default_expiry
+    assert earliest_expiry <= requested_expiry <= latest_expiry
 
     _assert_authorization_result_and_request(
         result,
@@ -573,7 +573,6 @@ def test_authorize_session_key_retries_transient_registry_read_failure() -> None
         try:
             return await client.authorize_session_key(
                 address=_SESSION_ADDRESS,
-                valid_until=datetime.now(UTC) + timedelta(minutes=15),
             )
         finally:
             await client.close()
@@ -606,13 +605,11 @@ def test_authorize_session_key_rejects_address_without_0x_prefix() -> None:
         client.authorize_session_key(
             address=_SESSION_ADDRESS.removeprefix("0x"),
             scopes=(SessionKeyKnownScope.CLOB,),
-            valid_until=datetime.now(UTC) + timedelta(minutes=15),
         )
 
 
 def test_authorize_session_key_allows_wallet_address_to_reach_service() -> None:
     captured: list[httpx.Request] = []
-    requested_expiry = datetime.now(UTC) + timedelta(minutes=15)
 
     with make_sync_deposit_client() as client:
         wallet = str(client.wallet)
@@ -623,7 +620,6 @@ def test_authorize_session_key_allows_wallet_address_to_reach_service() -> None:
         result = client.authorize_session_key(
             address=wallet,
             scopes=(SessionKeyKnownScope.CLOB,),
-            valid_until=requested_expiry,
         )
 
     assert result.session_key.address.lower() == wallet.lower()
@@ -636,37 +632,25 @@ def test_authorize_session_key_allows_wallet_address_to_reach_service() -> None:
     assert session_signer_address.lower() == wallet.lower()
 
 
-def test_authorize_session_key_rejects_invalid_cross_field_combinations() -> None:
-    valid_expiry = datetime.now(UTC) + timedelta(minutes=15)
+def test_authorize_session_key_rejects_invalid_scope_combinations() -> None:
     client = make_sync_deposit_client()
     try:
         with pytest.raises(UserInputError, match="ALL cannot be combined"):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
                 scopes=(SessionKeyKnownScope.ALL, SessionKeyKnownScope.CLOB),
-                valid_until=valid_expiry,
             )
 
         with pytest.raises(UserInputError, match="non-empty strings"):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
                 scopes=("",),
-                valid_until=valid_expiry,
-            )
-
-        with pytest.raises(UserInputError, match="timezone-aware datetime"):
-            client.authorize_session_key(
-                address=_SESSION_ADDRESS,
-                scopes=(SessionKeyKnownScope.CLOB,),
-                valid_until=datetime.now(),
             )
     finally:
         client.close()
 
 
 def test_authorize_session_key_requires_builder_api_key() -> None:
-    valid_expiry = datetime.now(UTC) + timedelta(minutes=15)
-
     with make_sync_deposit_client() as client:
         client._ctx = dataclasses.replace(client._ctx, api_key=None)
         with pytest.raises(
@@ -675,12 +659,10 @@ def test_authorize_session_key_requires_builder_api_key() -> None:
         ):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
-                valid_until=valid_expiry,
             )
 
 
 def test_authorize_session_key_rejects_relayer_api_key() -> None:
-    valid_expiry = datetime.now(UTC) + timedelta(minutes=15)
     relayer_api_key = RelayerApiKey(
         key="relayer-key",
         address="0x0000000000000000000000000000000000000001",
@@ -694,7 +676,6 @@ def test_authorize_session_key_rejects_relayer_api_key() -> None:
         ):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
-                valid_until=valid_expiry,
             )
 
 
@@ -721,7 +702,6 @@ def test_authorize_session_key_rejects_terminal_status_before_polling(status: st
         ):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
-                valid_until=datetime.now(UTC) + timedelta(minutes=15),
             )
 
     paths = [urlparse(str(request.url)).path for request in captured]
@@ -757,7 +737,6 @@ def test_authorize_session_key_rejects_unknown_response_status() -> None:
         with pytest.raises(UnexpectedResponseError, match="did not match expected shape"):
             client.authorize_session_key(
                 address=_SESSION_ADDRESS,
-                valid_until=datetime.now(UTC) + timedelta(minutes=15),
             )
 
 

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -356,7 +356,7 @@ def test_authorize_session_key_async_retries_the_exact_signed_payload() -> None:
 )
 def test_authorize_session_key_sync_uses_default_scopes(authorization_status: str) -> None:
     captured: list[httpx.Request] = []
-    requested_expiry = datetime.now(UTC) + timedelta(minutes=15, microseconds=123_456)
+    earliest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
 
     with make_sync_deposit_client() as client:
         wallet = str(client.wallet)
@@ -369,9 +369,12 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
         _install_sync_secure_clob_handler(client, handler)
         result = client.authorize_session_key(
             address=_SESSION_ADDRESS,
-            valid_until=requested_expiry,
             idempotency_key=" authorization-1 ",
         )
+    latest_default_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+    requested_expiry = result.session_key.valid_until
+
+    assert earliest_default_expiry <= requested_expiry <= latest_default_expiry
 
     _assert_authorization_result_and_request(
         result,

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import cast
 from urllib.parse import urlparse
 
@@ -253,7 +253,6 @@ def _assert_authorization_result_and_request(
 
 def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> None:
     captured: list[httpx.Request] = []
-    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
     async def run() -> tuple[AuthorizeSessionKeyResult, str]:
         client = await make_deposit_client()
@@ -279,8 +278,6 @@ def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> N
             await client.close()
 
     result, wallet = asyncio.run(run())
-    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
-    assert earliest_expiry <= result.session_key.valid_until <= latest_expiry
     _assert_authorization_result_and_request(
         result,
         captured,
@@ -356,7 +353,6 @@ def test_authorize_session_key_async_retries_the_exact_signed_payload() -> None:
 )
 def test_authorize_session_key_sync_uses_default_scopes(authorization_status: str) -> None:
     captured: list[httpx.Request] = []
-    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
 
     with make_sync_deposit_client() as client:
         wallet = str(client.wallet)
@@ -371,10 +367,7 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
             address=_SESSION_ADDRESS,
             idempotency_key=" authorization-1 ",
         )
-    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(days=180)
     requested_expiry = result.session_key.valid_until
-
-    assert earliest_expiry <= requested_expiry <= latest_expiry
 
     _assert_authorization_result_and_request(
         result,

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import cast
 from urllib.parse import urlparse
 
@@ -253,6 +253,7 @@ def _assert_authorization_result_and_request(
 
 def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> None:
     captured: list[httpx.Request] = []
+    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
 
     async def run() -> tuple[AuthorizeSessionKeyResult, str]:
         client = await make_deposit_client()
@@ -278,6 +279,8 @@ def test_authorize_session_key_async_preserves_scopes_and_submits_request() -> N
             await client.close()
 
     result, wallet = asyncio.run(run())
+    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
+    assert earliest_expiry <= result.session_key.valid_until <= latest_expiry
     _assert_authorization_result_and_request(
         result,
         captured,
@@ -353,6 +356,7 @@ def test_authorize_session_key_async_retries_the_exact_signed_payload() -> None:
 )
 def test_authorize_session_key_sync_uses_default_scopes(authorization_status: str) -> None:
     captured: list[httpx.Request] = []
+    earliest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
 
     with make_sync_deposit_client() as client:
         wallet = str(client.wallet)
@@ -367,7 +371,10 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
             address=_SESSION_ADDRESS,
             idempotency_key=" authorization-1 ",
         )
+    latest_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=4_315)
     requested_expiry = result.session_key.valid_until
+
+    assert earliest_expiry <= requested_expiry <= latest_expiry
 
     _assert_authorization_result_and_request(
         result,


### PR DESCRIPTION
Makes valid_until optional and defaults it to now + 4,315 hours.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API change for session-key authorization; expiry is fixed server-side at submit time, which may surprise integrators who relied on custom lifetimes.
> 
> **Overview**
> **Session key authorization no longer accepts a caller-chosen expiry.** The `valid_until` argument is removed from `authorize_session_key` on sync/async secure clients, from `AuthorizeSessionKeyRequest`, and from the internal authorize flow.
> 
> The SDK now sets expiry at authorization time to **now + 4,315 hours (~180 days)** via `_SESSION_KEY_LIFETIME_SECONDS`, and documents that behavior on the client methods. User-facing validation for custom datetimes (`_parse_valid_until`) is deleted.
> 
> Tests and the integration flow are updated to call authorize without `valid_until` and to assert expiry falls within the computed 180-day window instead of matching a passed-in time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b4346447bc4b2b1532485f7dd9cd270363b3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->