### PR TITLE
fix(client): extend session-key relayer timeout

### DIFF
--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 from typing import TypeVar, cast
 from uuid import uuid4
 
+import httpx
 from eth_utils.address import to_checksum_address
 from pydantic import Field, StrictBool, field_validator
 
@@ -52,6 +53,13 @@ _ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 _TRANSACTION_HASH_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 _SESSION_KEY_SUBMISSION_MAX_RETRIES = 2
 _SESSION_KEY_LIFETIME_SECONDS = 4_315 * 60 * 60
+# Session-key mutations synchronously validate, simulate, persist, and broadcast.
+_SESSION_KEY_RELAYER_SUBMISSION_TIMEOUT = httpx.Timeout(
+    connect=5.0,
+    read=300.0,
+    write=10.0,
+    pool=2.0,
+)
 
 _SecureContext = AsyncSecureClientContext | SyncSecureClientContext
 _ResponseT = TypeVar("_ResponseT")
@@ -499,7 +507,12 @@ async def _post_session_key_operation(
     headers = {"Idempotency-Key": idempotency_key}
     for attempt in range(_SESSION_KEY_SUBMISSION_MAX_RETRIES + 1):
         try:
-            data = await ctx.relayer.post_json(path, json=payload, headers=headers)
+            data = await ctx.relayer.post_json(
+                path,
+                json=payload,
+                headers=headers,
+                timeout=_SESSION_KEY_RELAYER_SUBMISSION_TIMEOUT,
+            )
         except (RateLimitError, RequestRejectedError, TransportError) as error:
             if (
                 attempt == _SESSION_KEY_SUBMISSION_MAX_RETRIES
@@ -523,7 +536,12 @@ def _post_session_key_operation_sync(
     headers = {"Idempotency-Key": idempotency_key}
     for attempt in range(_SESSION_KEY_SUBMISSION_MAX_RETRIES + 1):
         try:
-            data = ctx.relayer.post_json(path, json=payload, headers=headers)
+            data = ctx.relayer.post_json(
+                path,
+                json=payload,
+                headers=headers,
+                timeout=_SESSION_KEY_RELAYER_SUBMISSION_TIMEOUT,
+            )
         except (RateLimitError, RequestRejectedError, TransportError) as error:
             if (
                 attempt == _SESSION_KEY_SUBMISSION_MAX_RETRIES


### PR DESCRIPTION
Extends the relayer read timeout to five minutes for sync and async session-key authorization and revocation submissions. Transaction and registry polling timeouts remain unchanged.

Tests: `uv run pytest tests/unit/test_session_key_authorization.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped timeout override for session-key relayer POSTs only; no auth or signing logic changes.
> 
> **Overview**
> Session-key **authorize** and **revoke** submissions can block on the relayer while it validates, simulates, persists, and broadcasts, so the default **10s** HTTP read timeout was too short.
> 
> This PR passes a dedicated `httpx.Timeout` (**300s** read) into `post_json` for both async and sync `_post_session_key_operation` helpers. Connect, write, and pool limits stay modest; **transaction and registry polling** still use existing relayer poll settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4726ffd5ebc3293786d920b95c63cff99f8c567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->