### PR TITLE
fix(client): stop revocation after registry removal

### DIFF
--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -274,7 +274,7 @@ async def revoke_session_key(
     *,
     address: str,
     idempotency_key: str | None,
-) -> TransactionOutcome:
+) -> GaslessTransactionHandle:
     _assert_owner_deposit_wallet(ctx)
     _require_gasless_api_key(ctx)
     request = _parse_revoke_session_key_request(
@@ -295,13 +295,15 @@ async def revoke_session_key(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
-    return await GaslessTransactionHandle(
+    transaction = GaslessTransactionHandle(
         transaction_id=response.transaction_id,
         transaction_hash=None,
         _relayer=ctx.relayer,
         _max_polls=ctx.environment_config.relayer_max_polls,
         _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
-    ).wait()
+    )
+    await _wait_for_revoked_session_key(ctx, address=request.address)
+    return transaction
 
 
 def revoke_session_key_sync(
@@ -309,7 +311,7 @@ def revoke_session_key_sync(
     *,
     address: str,
     idempotency_key: str | None,
-) -> TransactionOutcome:
+) -> SyncGaslessTransactionHandle:
     _assert_owner_deposit_wallet(ctx)
     _require_gasless_api_key(ctx)
     request = _parse_revoke_session_key_request(
@@ -330,13 +332,15 @@ def revoke_session_key_sync(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
-    return SyncGaslessTransactionHandle(
+    transaction = SyncGaslessTransactionHandle(
         transaction_id=response.transaction_id,
         transaction_hash=None,
         _relayer=ctx.relayer,
         _max_polls=ctx.environment_config.relayer_max_polls,
         _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
-    ).wait()
+    )
+    _wait_for_revoked_session_key_sync(ctx, address=request.address)
+    return transaction
 
 
 def _parse_authorize_session_key_request(
@@ -605,6 +609,68 @@ def _wait_for_authorized_session_key_sync(
         if attempt + 1 < ctx.environment_config.relayer_max_polls:
             time.sleep(ctx.environment_config.relayer_poll_frequency_ms / 1000)
     raise TimeoutError(f"Timed out waiting for session key {expected.address} to become active")
+
+
+async def _wait_for_revoked_session_key(
+    ctx: AsyncSecureClientContext,
+    *,
+    address: EvmAddress,
+) -> None:
+    for attempt in range(ctx.environment_config.relayer_max_polls):
+        session_keys = await _fetch_session_keys_for_revocation(ctx)
+        if session_keys is not None and all(
+            session_key.address.lower() != address.lower() for session_key in session_keys
+        ):
+            return
+        if attempt + 1 < ctx.environment_config.relayer_max_polls:
+            await asyncio.sleep(ctx.environment_config.relayer_poll_frequency_ms / 1000)
+    raise TimeoutError(f"Timed out waiting for session key {address} to be revoked")
+
+
+def _wait_for_revoked_session_key_sync(
+    ctx: SyncSecureClientContext,
+    *,
+    address: EvmAddress,
+) -> None:
+    for attempt in range(ctx.environment_config.relayer_max_polls):
+        session_keys = _fetch_session_keys_for_revocation_sync(ctx)
+        if session_keys is not None and all(
+            session_key.address.lower() != address.lower() for session_key in session_keys
+        ):
+            return
+        if attempt + 1 < ctx.environment_config.relayer_max_polls:
+            time.sleep(ctx.environment_config.relayer_poll_frequency_ms / 1000)
+    raise TimeoutError(f"Timed out waiting for session key {address} to be revoked")
+
+
+async def _fetch_session_keys_for_revocation(
+    ctx: AsyncSecureClientContext,
+) -> tuple[AuthorizedSessionKey, ...] | None:
+    try:
+        return await fetch_session_keys(ctx)
+    except (RateLimitError, TransportError):
+        return None
+    except RequestRejectedError as error:
+        if error.status == 404:
+            return ()
+        if 500 <= error.status < 600:
+            return None
+        raise
+
+
+def _fetch_session_keys_for_revocation_sync(
+    ctx: SyncSecureClientContext,
+) -> tuple[AuthorizedSessionKey, ...] | None:
+    try:
+        return fetch_session_keys_sync(ctx)
+    except (RateLimitError, TransportError):
+        return None
+    except RequestRejectedError as error:
+        if error.status == 404:
+            return ()
+        if 500 <= error.status < 600:
+            return None
+        raise
 
 
 async def _fetch_session_keys_for_readiness(

--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -642,12 +642,8 @@ async def _fetch_session_keys_for_revocation(
 ) -> tuple[AuthorizedSessionKey, ...] | None:
     try:
         return await fetch_session_keys(ctx)
-    except (RateLimitError, TransportError):
-        return None
-    except RequestRejectedError as error:
-        if error.status == 404:
-            return ()
-        if 500 <= error.status < 600:
+    except (RateLimitError, RequestRejectedError, TransportError) as error:
+        if _is_retryable_session_key_registry_read(error):
             return None
         raise
 
@@ -657,12 +653,8 @@ def _fetch_session_keys_for_revocation_sync(
 ) -> tuple[AuthorizedSessionKey, ...] | None:
     try:
         return fetch_session_keys_sync(ctx)
-    except (RateLimitError, TransportError):
-        return None
-    except RequestRejectedError as error:
-        if error.status == 404:
-            return ()
-        if 500 <= error.status < 600:
+    except (RateLimitError, RequestRejectedError, TransportError) as error:
+        if _is_retryable_session_key_registry_read(error):
             return None
         raise
 
@@ -672,12 +664,10 @@ async def _fetch_session_keys_for_readiness(
 ) -> tuple[AuthorizedSessionKey, ...]:
     try:
         return await fetch_session_keys(ctx)
-    except (RateLimitError, TransportError):
-        return ()
-    except RequestRejectedError as error:
-        if error.status != 404 and not 500 <= error.status < 600:
-            raise
-        return ()
+    except (RateLimitError, RequestRejectedError, TransportError) as error:
+        if _is_retryable_session_key_registry_read(error):
+            return ()
+        raise
 
 
 def _fetch_session_keys_for_readiness_sync(
@@ -685,12 +675,17 @@ def _fetch_session_keys_for_readiness_sync(
 ) -> tuple[AuthorizedSessionKey, ...]:
     try:
         return fetch_session_keys_sync(ctx)
-    except (RateLimitError, TransportError):
-        return ()
-    except RequestRejectedError as error:
-        if error.status != 404 and not 500 <= error.status < 600:
-            raise
-        return ()
+    except (RateLimitError, RequestRejectedError, TransportError) as error:
+        if _is_retryable_session_key_registry_read(error):
+            return ()
+        raise
+
+
+def _is_retryable_session_key_registry_read(error: BaseException) -> bool:
+    return isinstance(error, (RateLimitError, TransportError)) or (
+        isinstance(error, RequestRejectedError)
+        and (error.status == 404 or 500 <= error.status < 600)
+    )
 
 
 def _is_expected_session_key(

--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -274,7 +274,7 @@ async def revoke_session_key(
     *,
     address: str,
     idempotency_key: str | None,
-) -> GaslessTransactionHandle:
+) -> None:
     _assert_owner_deposit_wallet(ctx)
     _require_gasless_api_key(ctx)
     request = _parse_revoke_session_key_request(
@@ -295,15 +295,7 @@ async def revoke_session_key(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
-    transaction = GaslessTransactionHandle(
-        transaction_id=response.transaction_id,
-        transaction_hash=None,
-        _relayer=ctx.relayer,
-        _max_polls=ctx.environment_config.relayer_max_polls,
-        _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
-    )
     await _wait_for_revoked_session_key(ctx, address=request.address)
-    return transaction
 
 
 def revoke_session_key_sync(
@@ -311,7 +303,7 @@ def revoke_session_key_sync(
     *,
     address: str,
     idempotency_key: str | None,
-) -> SyncGaslessTransactionHandle:
+) -> None:
     _assert_owner_deposit_wallet(ctx)
     _require_gasless_api_key(ctx)
     request = _parse_revoke_session_key_request(
@@ -332,15 +324,7 @@ def revoke_session_key_sync(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
-    transaction = SyncGaslessTransactionHandle(
-        transaction_id=response.transaction_id,
-        transaction_hash=None,
-        _relayer=ctx.relayer,
-        _max_polls=ctx.environment_config.relayer_max_polls,
-        _poll_delay_s=ctx.environment_config.relayer_poll_frequency_ms / 1000,
-    )
     _wait_for_revoked_session_key_sync(ctx, address=request.address)
-    return transaction
 
 
 def _parse_authorize_session_key_request(

--- a/src/polymarket/_internal/actions/session_keys.py
+++ b/src/polymarket/_internal/actions/session_keys.py
@@ -295,6 +295,8 @@ async def revoke_session_key(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
+    # This eager return is intentional; the backend continues the remaining
+    # revocation work after the key leaves the active-key registry.
     await _wait_for_revoked_session_key(ctx, address=request.address)
 
 
@@ -324,6 +326,8 @@ def revoke_session_key_sync(
         parse=_RevokeSessionKeyResponse.parse_response,
     )
     _assert_revocation_accepted(response.status)
+    # This eager return is intentional; the backend continues the remaining
+    # revocation work after the key leaves the active-key registry.
     _wait_for_revoked_session_key_sync(ctx, address=request.address)
 
 
@@ -600,6 +604,9 @@ async def _wait_for_revoked_session_key(
     *,
     address: EvmAddress,
 ) -> None:
+    # This revocation readiness check deliberately reuses the relayer transaction
+    # polling limits instead of introducing revocation-specific configuration.
+    # The defaults allow about 200 seconds (100 polls every two seconds).
     for attempt in range(ctx.environment_config.relayer_max_polls):
         session_keys = await _fetch_session_keys_for_revocation(ctx)
         if session_keys is not None and all(
@@ -616,6 +623,9 @@ def _wait_for_revoked_session_key_sync(
     *,
     address: EvmAddress,
 ) -> None:
+    # This revocation readiness check deliberately reuses the relayer transaction
+    # polling limits instead of introducing revocation-specific configuration.
+    # The defaults allow about 200 seconds (100 polls every two seconds).
     for attempt in range(ctx.environment_config.relayer_max_polls):
         session_keys = _fetch_session_keys_for_revocation_sync(ctx)
         if session_keys is not None and all(

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -195,7 +195,7 @@ from polymarket.models.clob.cancel import CancelOrdersResponse
 from polymarket.models.clob.market_events import MarketEvent
 from polymarket.models.clob.order_response import AcceptedOrder, OrderResponse
 from polymarket.models.clob.orders import MarketOrderType, SignedOrder
-from polymarket.models.clob.relayer import RelayerTransactionType, TransactionOutcome
+from polymarket.models.clob.relayer import RelayerTransactionType
 from polymarket.models.clob.rewards import (
     CurrentReward,
     MarketReward,
@@ -631,21 +631,21 @@ class AsyncSecureClient:
         *,
         address: str,
         idempotency_key: str | None = None,
-    ) -> TransactionOutcome:
+    ) -> TransactionHandle:
         """Revoke a session key authorized for the Deposit Wallet.
 
-        Returns the confirmed transaction after order cleanup and on-chain
-        confirmation. Requires an ``api_key=`` that supports gasless transactions.
+        Returns once the key is absent from the active-key registry and unusable.
+        Call ``wait()`` on the returned transaction to await on-chain confirmation.
+        Requires an ``api_key=`` that supports gasless transactions.
 
         Raises:
             UserInputError: If the client or revocation input is invalid.
             RequestRejectedError: If the revocation request is rejected.
-            RateLimitError: If a revocation or transaction request remains rate-limited.
+            RateLimitError: If a revocation or registry request remains rate-limited.
             SigningError: If the owner signature cannot be produced.
             TransportError: If a network request fails.
-            UnexpectedResponseError: If a revocation or transaction response is malformed.
-            TimeoutError: If transaction confirmation exceeds the wait budget.
-            TransactionFailedError: If the revocation transaction fails.
+            UnexpectedResponseError: If a revocation or registry response is malformed.
+            TimeoutError: If registry removal exceeds the wait budget.
         """
         return await _session_key_actions.revoke_session_key(
             self._ctx,

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -643,6 +643,7 @@ class AsyncSecureClient:
             RateLimitError: If a revocation or registry request remains rate-limited.
             SigningError: If the owner signature cannot be produced.
             TransportError: If a network request fails.
+            TransactionFailedError: If the revocation transaction fails.
             UnexpectedResponseError: If a revocation or registry response is malformed.
             TimeoutError: If registry removal exceeds the wait budget.
         """

--- a/src/polymarket/clients/async_secure.py
+++ b/src/polymarket/clients/async_secure.py
@@ -631,11 +631,10 @@ class AsyncSecureClient:
         *,
         address: str,
         idempotency_key: str | None = None,
-    ) -> TransactionHandle:
+    ) -> None:
         """Revoke a session key authorized for the Deposit Wallet.
 
         Returns once the key is absent from the active-key registry and unusable.
-        Call ``wait()`` on the returned transaction to await on-chain confirmation.
         Requires an ``api_key=`` that supports gasless transactions.
 
         Raises:

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -176,7 +176,7 @@ from polymarket.models.clob import BuilderApiKeyInfo, BuilderTrade
 from polymarket.models.clob.cancel import CancelOrdersResponse
 from polymarket.models.clob.order_response import AcceptedOrder, OrderResponse
 from polymarket.models.clob.orders import MarketOrderType, SignedOrder
-from polymarket.models.clob.relayer import RelayerTransactionType, TransactionOutcome
+from polymarket.models.clob.relayer import RelayerTransactionType
 from polymarket.models.clob.rewards import (
     CurrentReward,
     MarketReward,
@@ -561,21 +561,21 @@ class SecureClient:
         *,
         address: str,
         idempotency_key: str | None = None,
-    ) -> TransactionOutcome:
+    ) -> SyncTransactionHandle:
         """Revoke a session key authorized for the Deposit Wallet.
 
-        Returns the confirmed transaction after order cleanup and on-chain
-        confirmation. Requires an ``api_key=`` that supports gasless transactions.
+        Returns once the key is absent from the active-key registry and unusable.
+        Call ``wait()`` on the returned transaction to await on-chain confirmation.
+        Requires an ``api_key=`` that supports gasless transactions.
 
         Raises:
             UserInputError: If the client or revocation input is invalid.
             RequestRejectedError: If the revocation request is rejected.
-            RateLimitError: If a revocation or transaction request remains rate-limited.
+            RateLimitError: If a revocation or registry request remains rate-limited.
             SigningError: If the owner signature cannot be produced.
             TransportError: If a network request fails.
-            UnexpectedResponseError: If a revocation or transaction response is malformed.
-            TimeoutError: If transaction confirmation exceeds the wait budget.
-            TransactionFailedError: If the revocation transaction fails.
+            UnexpectedResponseError: If a revocation or registry response is malformed.
+            TimeoutError: If registry removal exceeds the wait budget.
         """
         return _session_key_actions.revoke_session_key_sync(
             self._ctx,

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -573,6 +573,7 @@ class SecureClient:
             RateLimitError: If a revocation or registry request remains rate-limited.
             SigningError: If the owner signature cannot be produced.
             TransportError: If a network request fails.
+            TransactionFailedError: If the revocation transaction fails.
             UnexpectedResponseError: If a revocation or registry response is malformed.
             TimeoutError: If registry removal exceeds the wait budget.
         """

--- a/src/polymarket/clients/secure.py
+++ b/src/polymarket/clients/secure.py
@@ -561,11 +561,10 @@ class SecureClient:
         *,
         address: str,
         idempotency_key: str | None = None,
-    ) -> SyncTransactionHandle:
+    ) -> None:
         """Revoke a session key authorized for the Deposit Wallet.
 
         Returns once the key is absent from the active-key registry and unusable.
-        Call ``wait()`` on the returned transaction to await on-chain confirmation.
         Requires an ``api_key=`` that supports gasless transactions.
 
         Raises:

--- a/tests/integration/test_session_keys.py
+++ b/tests/integration/test_session_keys.py
@@ -98,15 +98,8 @@ async def test_session_key_authorizes_lists_trades_and_revokes(
             assert order_id in cancellation.canceled
             order_id = None
 
-            revocation_transaction = await deposit_wallet_client.revoke_session_key(
-                address=session_account.address
-            )
+            await deposit_wallet_client.revoke_session_key(address=session_account.address)
             revocation_accepted = True
-            assert revocation_transaction.transaction_id is not None
-            assert re.fullmatch(
-                r"0x[0-9a-fA-F]{64}",
-                str(revocation_transaction.transaction_hash),
-            )
 
             remaining_session_keys = await deposit_wallet_client.fetch_session_keys()
             assert all(

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -36,11 +36,11 @@ from polymarket import (
     SessionKeyKnownScope,
     SessionKeyScope,
     TransactionFailedError,
-    TransactionOutcome,
     UnexpectedResponseError,
     UserInputError,
 )
 from polymarket.clients._transport import AsyncTransport, SyncTransport
+from polymarket.transactions import GaslessTransactionHandle, SyncGaslessTransactionHandle
 
 _AUTHORIZATIONS_PATH = "/v1/session-signers/authorizations"
 _EXECUTE_PARAMS_PATH = "/v1/account/transactions/params"
@@ -166,11 +166,17 @@ def _management_handler(
         captured.append(request)
         path = urlparse(str(request.url)).path
         if path == _SESSION_KEYS_PATH:
+            revocation_submitted = any(
+                urlparse(str(captured_request.url)).path == _REVOCATIONS_PATH
+                for captured_request in captured
+            )
             return httpx.Response(
                 200,
                 json={
                     "wallet": wallet.lower(),
-                    "signers": [
+                    "signers": []
+                    if revocation_submitted
+                    else [
                         {
                             "address": _SESSION_ADDRESS.lower(),
                             "scopes": ["clob", f" {_NEWER_SCOPE.lower()} "],
@@ -388,7 +394,7 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
 
 def _assert_fetch_and_revocation(
     session_keys: tuple[AuthorizedSessionKey, ...],
-    transaction: TransactionOutcome,
+    transaction: GaslessTransactionHandle | SyncGaslessTransactionHandle,
     captured: list[httpx.Request],
     *,
     wallet: str,
@@ -399,7 +405,7 @@ def _assert_fetch_and_revocation(
     assert session_key.scopes == ("clob", f" {_NEWER_SCOPE.lower()} ")
     assert session_key.valid_until == datetime.fromtimestamp(_LISTED_EXPIRY, tz=UTC)
 
-    assert transaction.transaction_hash == _TRANSACTION_HASH
+    assert transaction.transaction_hash is None
     assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
 
     revocation_requests = [
@@ -422,7 +428,8 @@ def _assert_fetch_and_revocation(
     assert len(signature) == 2 + 65 * 2
 
     paths = [urlparse(str(request.url)).path for request in captured]
-    assert f"/v1/account/transactions/{_REVOCATION_TRANSACTION_ID}" in paths
+    assert _SESSION_KEYS_PATH in paths
+    assert f"/v1/account/transactions/{_REVOCATION_TRANSACTION_ID}" not in paths
 
 
 def test_fetch_and_revoke_session_key_async() -> None:
@@ -430,7 +437,7 @@ def test_fetch_and_revoke_session_key_async() -> None:
 
     async def run() -> tuple[
         tuple[AuthorizedSessionKey, ...],
-        TransactionOutcome,
+        GaslessTransactionHandle,
         str,
     ]:
         client = await make_deposit_client()
@@ -508,13 +515,14 @@ def test_revoke_session_key_sync_retries_the_exact_signed_payload() -> None:
         )
         client._ctx = dataclasses.replace(client._ctx, _resolved_environment_config=config)
         install_sync_relayer_handler(client, handler)
+        _install_sync_secure_clob_handler(client, handler)
         transaction = client.revoke_session_key(
             address=_SESSION_ADDRESS,
             idempotency_key="exact-revocation",
         )
 
     assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
-    assert transaction.transaction_hash == _TRANSACTION_HASH
+    assert transaction.transaction_hash is None
     revocation_requests = [
         request for request in captured if urlparse(str(request.url)).path == _REVOCATIONS_PATH
     ]
@@ -526,24 +534,26 @@ def test_revoke_session_key_sync_retries_the_exact_signed_payload() -> None:
     assert sum(urlparse(str(request.url)).path == _EXECUTE_PARAMS_PATH for request in captured) == 1
 
 
-def test_revoke_session_key_waits_for_confirmation_before_returning() -> None:
+def test_revoke_session_key_returns_after_registry_removal() -> None:
     captured: list[httpx.Request] = []
 
     with make_sync_deposit_client() as client:
         handler = _management_handler(captured, wallet=str(client.wallet))
         install_sync_relayer_handler(client, handler)
+        _install_sync_secure_clob_handler(client, handler)
         transaction = client.revoke_session_key(address=_SESSION_ADDRESS)
 
     assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
-    assert transaction.transaction_hash == _TRANSACTION_HASH
+    assert transaction.transaction_hash is None
     assert (
         sum(
             urlparse(str(request.url)).path
             == f"/v1/account/transactions/{_REVOCATION_TRANSACTION_ID}"
             for request in captured
         )
-        == 1
+        == 0
     )
+    assert sum(urlparse(str(request.url)).path == _SESSION_KEYS_PATH for request in captured) == 1
 
 
 def test_authorize_session_key_retries_transient_registry_read_failure() -> None:

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -40,7 +40,6 @@ from polymarket import (
     UserInputError,
 )
 from polymarket.clients._transport import AsyncTransport, SyncTransport
-from polymarket.transactions import GaslessTransactionHandle, SyncGaslessTransactionHandle
 
 _AUTHORIZATIONS_PATH = "/v1/session-signers/authorizations"
 _EXECUTE_PARAMS_PATH = "/v1/account/transactions/params"
@@ -394,7 +393,6 @@ def test_authorize_session_key_sync_uses_default_scopes(authorization_status: st
 
 def _assert_fetch_and_revocation(
     session_keys: tuple[AuthorizedSessionKey, ...],
-    transaction: GaslessTransactionHandle | SyncGaslessTransactionHandle,
     captured: list[httpx.Request],
     *,
     wallet: str,
@@ -404,9 +402,6 @@ def _assert_fetch_and_revocation(
     assert session_key.address.lower() == _SESSION_ADDRESS.lower()
     assert session_key.scopes == ("clob", f" {_NEWER_SCOPE.lower()} ")
     assert session_key.valid_until == datetime.fromtimestamp(_LISTED_EXPIRY, tz=UTC)
-
-    assert transaction.transaction_hash is None
-    assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
 
     revocation_requests = [
         request for request in captured if urlparse(str(request.url)).path == _REVOCATIONS_PATH
@@ -437,7 +432,7 @@ def test_fetch_and_revoke_session_key_async() -> None:
 
     async def run() -> tuple[
         tuple[AuthorizedSessionKey, ...],
-        GaslessTransactionHandle,
+        None,
         str,
     ]:
         client = await make_deposit_client()
@@ -447,18 +442,18 @@ def test_fetch_and_revoke_session_key_async() -> None:
         _install_secure_clob_handler(client, handler)
         try:
             session_keys = await client.fetch_session_keys()
-            transaction = await client.revoke_session_key(
+            result = await client.revoke_session_key(
                 address=_SESSION_ADDRESS,
                 idempotency_key=" revocation-key ",
             )
-            return session_keys, transaction, wallet
+            return session_keys, result, wallet
         finally:
             await client.close()
 
-    session_keys, transaction, wallet = asyncio.run(run())
+    session_keys, result, wallet = asyncio.run(run())
+    assert result is None
     _assert_fetch_and_revocation(
         session_keys,
-        transaction,
         captured,
         wallet=wallet,
     )
@@ -481,14 +476,14 @@ def test_fetch_and_revoke_session_key_sync(revocation_status: str) -> None:
         install_sync_relayer_handler(client, handler)
         _install_sync_secure_clob_handler(client, handler)
         session_keys = client.fetch_session_keys()
-        transaction = client.revoke_session_key(
+        result = client.revoke_session_key(
             address=_SESSION_ADDRESS,
             idempotency_key=" revocation-key ",
         )
 
+    assert result is None
     _assert_fetch_and_revocation(
         session_keys,
-        transaction,
         captured,
         wallet=wallet,
     )
@@ -516,13 +511,12 @@ def test_revoke_session_key_sync_retries_the_exact_signed_payload() -> None:
         client._ctx = dataclasses.replace(client._ctx, _resolved_environment_config=config)
         install_sync_relayer_handler(client, handler)
         _install_sync_secure_clob_handler(client, handler)
-        transaction = client.revoke_session_key(
+        result = client.revoke_session_key(
             address=_SESSION_ADDRESS,
             idempotency_key="exact-revocation",
         )
 
-    assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
-    assert transaction.transaction_hash is None
+    assert result is None
     revocation_requests = [
         request for request in captured if urlparse(str(request.url)).path == _REVOCATIONS_PATH
     ]
@@ -541,10 +535,9 @@ def test_revoke_session_key_returns_after_registry_removal() -> None:
         handler = _management_handler(captured, wallet=str(client.wallet))
         install_sync_relayer_handler(client, handler)
         _install_sync_secure_clob_handler(client, handler)
-        transaction = client.revoke_session_key(address=_SESSION_ADDRESS)
+        result = client.revoke_session_key(address=_SESSION_ADDRESS)
 
-    assert transaction.transaction_id == _REVOCATION_TRANSACTION_ID
-    assert transaction.transaction_hash is None
+    assert result is None
     assert (
         sum(
             urlparse(str(request.url)).path

--- a/tests/unit/test_session_key_authorization.py
+++ b/tests/unit/test_session_key_authorization.py
@@ -549,6 +549,41 @@ def test_revoke_session_key_returns_after_registry_removal() -> None:
     assert sum(urlparse(str(request.url)).path == _SESSION_KEYS_PATH for request in captured) == 1
 
 
+@pytest.mark.parametrize("status", (404, 503))
+def test_revoke_session_key_retries_transient_registry_read_failure(status: int) -> None:
+    captured: list[httpx.Request] = []
+
+    with make_sync_deposit_client() as client:
+        stable_handler = _management_handler(captured, wallet=str(client.wallet))
+        registry_unavailable = True
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal registry_unavailable
+            if urlparse(str(request.url)).path == _SESSION_KEYS_PATH and registry_unavailable:
+                registry_unavailable = False
+                captured.append(request)
+                return httpx.Response(
+                    status,
+                    json={"error": "registry unavailable"},
+                    request=request,
+                )
+            return stable_handler(request)
+
+        config = dataclasses.replace(
+            client._ctx.environment_config,
+            relayer_max_polls=3,
+            relayer_poll_frequency_ms=0,
+        )
+        client._ctx = dataclasses.replace(client._ctx, _resolved_environment_config=config)
+        install_sync_relayer_handler(client, handler)
+        _install_sync_secure_clob_handler(client, handler)
+
+        result = client.revoke_session_key(address=_SESSION_ADDRESS)
+
+    assert result is None
+    assert sum(urlparse(str(request.url)).path == _SESSION_KEYS_PATH for request in captured) == 2
+
+
 def test_authorize_session_key_retries_transient_registry_read_failure() -> None:
     captured: list[httpx.Request] = []
 


### PR DESCRIPTION
Return from session-key revocation once the key leaves the wallet registry, without waiting for on-chain confirmation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change: `revoke_session_key` no longer returns `TransactionOutcome`, so callers relying on transaction IDs/hashes must adapt. Semantics shift from on-chain confirmation to registry visibility, which could diverge if backend behavior changes.
> 
> **Overview**
> **Session-key revocation** no longer waits for relayer on-chain confirmation or returns a `TransactionOutcome`. After the revocation request is accepted, async/sync `revoke_session_key` poll the active session-signer registry until the address is gone, then return `None`.
> 
> Public `SecureClient` / `AsyncSecureClient` signatures and docstrings match this behavior (`TimeoutError` is tied to registry removal, not transaction polling). Registry reads during the wait reuse existing relayer poll limits and share a new `_is_retryable_session_key_registry_read` helper with authorization readiness polling (404/5xx/rate limits/transport errors retry; other rejections propagate).
> 
> Integration and unit tests drop transaction-hash assertions, expect no transaction-status polling, and cover transient registry read failures during revocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15f321d92d4f90aa75586194d2e57d91eabccc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->