### PR TITLE
fix(client): send order=volume and order=liquidity as their numeric fields on list_markets

### DIFF
--- a/src/polymarket/_internal/actions/gamma.py
+++ b/src/polymarket/_internal/actions/gamma.py
@@ -155,6 +155,26 @@ def _coerce_timestamp_filter(value: TimestampFilter | None) -> str | None:
     return value.isoformat()
 
 
+# The service keeps market ``volume`` and ``liquidity`` as text columns (a leftover
+# of the original ingestion writing ``toFixed(2)`` strings) next to numeric twins
+# holding the same value, and orders by the raw column, so ``order="volume"`` sorts
+# lexicographically. Callers mean the number: each token is sent as its numeric
+# twin. The service already does this itself for ``liquidity``, so that entry is
+# idempotent with upstream and only ``volume`` is load-bearing today. Every other
+# token is forwarded untouched; unknown names are still rejected by the service.
+_MARKET_ORDER_ALIASES: dict[str, str] = {
+    "volume": "volumeNum",
+    "liquidity": "liquidityNum",
+}
+
+
+def _normalize_market_order(order: str | None) -> str | None:
+    if order is None:
+        return None
+    tokens = [token.strip() for token in order.split(",")]
+    return ",".join(_MARKET_ORDER_ALIASES.get(token, token) for token in tokens)
+
+
 def _add_optional_seq(
     params: dict[str, QueryParamValue],
     key: str,
@@ -550,7 +570,7 @@ def list_markets_spec(
     _add_optional(params, "liquidity_num_min", liquidity_num_min)
     _add_optional(params, "locale", locale)
     _add_optional_seq(params, "market_maker_address", market_maker_addresses)
-    _add_optional(params, "order", order)
+    _add_optional(params, "order", _normalize_market_order(order))
     _add_optional_seq(params, "position_ids", position_ids)
     _add_optional_seq(params, "question_ids", question_ids)
     _add_optional(params, "related_tags", related_tags)

--- a/src/polymarket/clients/async_public.py
+++ b/src/polymarket/clients/async_public.py
@@ -1021,6 +1021,13 @@ class AsyncPublicClient:
         Markets that cannot be represented by the binary Market model are
         omitted from results.
 
+        ``order`` takes one or more comma-separated market field names, with
+        ``ascending`` setting the direction (for example ``"volume"``,
+        ``"liquidity"``, ``"volume24hr"``, ``"startDate"``, ``"endDate"``,
+        ``"createdAt"``, ``"slug"``). ``"volume"`` and ``"liquidity"`` sort by
+        their numeric values. A cursor obtained from an earlier release with
+        ``order="volume"`` or ``order="liquidity"`` cannot be resumed.
+
         Returns:
             An async paginator over matching markets.
 

--- a/src/polymarket/clients/public.py
+++ b/src/polymarket/clients/public.py
@@ -806,6 +806,13 @@ class PublicClient:
         Markets that cannot be represented by the binary Market model are
         omitted from results.
 
+        ``order`` takes one or more comma-separated market field names, with
+        ``ascending`` setting the direction (for example ``"volume"``,
+        ``"liquidity"``, ``"volume24hr"``, ``"startDate"``, ``"endDate"``,
+        ``"createdAt"``, ``"slug"``). ``"volume"`` and ``"liquidity"`` sort by
+        their numeric values. A cursor obtained from an earlier release with
+        ``order="volume"`` or ``order="liquidity"`` cannot be resumed.
+
         Returns:
             A paginator over matching markets.
 

--- a/tests/unit/test_gamma_paginated_specs.py
+++ b/tests/unit/test_gamma_paginated_specs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from polymarket._internal.actions import gamma as gamma_actions
+from polymarket._internal.pagination import fingerprint_query
 from polymarket._internal.request import (
     KeysetPaginatedSpec,
     OffsetPaginatedSpec,
@@ -83,6 +84,52 @@ def test_list_markets_spec_collects_array_params() -> None:
         "id": (1, 2),
         "position_ids": ("P1", "P2"),
     }
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        ("volume", "volumeNum"),
+        ("liquidity", "liquidityNum"),
+        ("volume,id", "volumeNum,id"),
+        ("createdAt, volume", "createdAt,volumeNum"),
+    ],
+)
+def test_list_markets_spec_sends_numeric_twins_for_text_sorted_fields(
+    order: str, expected: str
+) -> None:
+    spec = gamma_actions.list_markets_spec(order=order)
+
+    assert spec.base_params == {"order": expected}
+
+
+@pytest.mark.parametrize("order", ["volumeNum", "liquidityNum", "volume24hr", "startDate", "id"])
+def test_list_markets_spec_forwards_other_order_fields_unchanged(order: str) -> None:
+    spec = gamma_actions.list_markets_spec(order=order, ascending=False)
+
+    assert spec.base_params == {"ascending": False, "order": order}
+
+
+def test_list_markets_spec_order_alias_keeps_cursors_interchangeable() -> None:
+    # Pagination cursors carry a fingerprint of the query; a cursor issued while
+    # ordering by "volume" must resume when the caller spells it "volumeNum".
+    aliased = gamma_actions.list_markets_spec(order="volume", closed=False)
+    explicit = gamma_actions.list_markets_spec(order="volumeNum", closed=False)
+
+    assert fingerprint_query(aliased.base_params) == fingerprint_query(explicit.base_params)
+
+
+def test_list_markets_spec_order_alias_leaves_empty_tokens_alone() -> None:
+    spec = gamma_actions.list_markets_spec(order="volume,")
+
+    assert spec.base_params == {"order": "volumeNum,"}
+
+
+def test_list_events_spec_does_not_alias_order() -> None:
+    # Events store volume as a number upstream, so the alias is markets-only.
+    spec = gamma_actions.list_events_spec(order="volume")
+
+    assert spec.base_params == {"closed": False, "order": "volume"}
 
 
 def test_list_markets_parser_skips_non_binary_markets_and_keeps_cursor() -> None:


### PR DESCRIPTION
## Summary

`list_markets(order="volume")` returned markets sorted as text: every value on the first page started with a 9, topping out at `999.99`, while the true maximum in the same filter set was around `83,000,000`.

Gamma keeps market `volume` and `liquidity` as text columns, a leftover of the original ingestion writing `toFixed(2)` strings, and orders by the raw column. The numeric companions `volumeNum` and `liquidityNum` were added later specifically for numeric filtering and ordering, and the ETL writes the same value into both fields, so the only difference is the column type. There is no meaningful alphabetical volume sort, the SDK already treats `volumeNum` as the numeric field for its `volume_num_min` / `volume_num_max` filters, and the `Market` model already exposes `volume` as a `Decimal`. Gamma itself already maps `order=liquidity` to the numeric column on the keyset endpoint; it has not done the same for `volume` yet.

`list_markets` now sends `volume` as `volumeNum` and `liquidity` as `liquidityNum`, per comma-separated token in `order`, so `"volume,id"` goes out as `"volumeNum,id"`. Every other token, the direction (`ascending`), and multi-field ordering are forwarded unchanged. The mapping is markets-only; events and series store `volume` as a number and are untouched. Response fields keep their current names and types.

## Behaviour change

- `order="volume"` now returns numerically ordered markets. `order="liquidity"` is unchanged in practice since the service already orders it numerically; the mapping keeps the two spellings interchangeable.
- Pagination cursors carry a fingerprint of the query, and Gamma binds its own cursor to the effective sort fields. A cursor obtained from an earlier release with `order="volume"` or `order="liquidity"` will not resume after upgrading; the SDK raises its usual query-parameter mismatch error. Cursors created by this release are interchangeable between the two spellings.

## Docs

The `list_markets` docstring (sync and async) now describes `order`: comma-separated market field names with `ascending` setting the direction, examples, that `volume` and `liquidity` sort by their numeric values, and the cursor caveat.

## Tests

- Mapping per token: `volume`, `liquidity`, `volume,id`, `createdAt, volume` with whitespace, and a trailing empty token.
- Pass-through unchanged for `volumeNum`, `liquidityNum`, `volume24hr`, `startDate`, `id`, with `ascending` preserved.
- Cursor fingerprints for `order="volume"` and `order="volumeNum"` are identical.
- `list_events_spec(order="volume")` is not rewritten.

The TypeScript client accepts the same free-form `order` string and gets an equivalent change separately. Longer term the mapping belongs in Gamma; this stays harmless once that lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional breaking change for saved pagination cursors and different sort order for `order="volume"`; scope is limited to public market listing query params.
> 
> **Overview**
> **`list_markets`** now rewrites comma-separated **`order`** tokens so **`volume`** and **`liquidity`** are sent to Gamma as **`volumeNum`** and **`liquidityNum`**, fixing lexicographic sorting on the text columns while leaving other sort fields and **`ascending`** unchanged. The alias applies only in **`list_markets_spec`**; **`list_events`** and other list endpoints are untouched.
> 
> Sync and async **`list_markets`** docstrings document supported **`order`** values, numeric sorting for volume/liquidity, and that **pagination cursors** from older SDK versions with **`order="volume"`** or **`order="liquidity"`** cannot be resumed after upgrade (while **`volume`** vs **`volumeNum`** spellings share the same query fingerprint in this release).
> 
> Unit tests cover token mapping, pass-through, cursor fingerprint parity, and markets-only scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd2636a225846c66442a3908793b819cbfaa43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Fixes #288
